### PR TITLE
Update Harden-Windows-Security.ps1

### DIFF
--- a/Harden-Windows-Security.ps1
+++ b/Harden-Windows-Security.ps1
@@ -314,7 +314,7 @@ else {
             .\LGPO.exe /m "..\Security-Baselines-X\GPOX\DomainSysvol\GPO\Machine\registry.pol"
 
             # Apply the Security Baselines X security template into Computer (Machine) Configuration
-            .\lgpo.exe /s "..\Security-Baselines-X\GPOX\DomainSysvol\GPO\Machine\microsoft\windows nt\SecEdit\GptTmpl.inf"
+            .\Lgpo.exe /s "..\Security-Baselines-X\GPOX\DomainSysvol\GPO\Machine\microsoft\windows nt\SecEdit\GptTmpl.inf"
 
             # Change the current working directory back to where we were
             Pop-Location

--- a/Harden-Windows-Security.ps1
+++ b/Harden-Windows-Security.ps1
@@ -161,32 +161,30 @@ Write-Host $infomsg -ForegroundColor Green
 
 
 # check if user's OS is Windows Home edition
-if (((Get-WmiObject Win32_OperatingSystem).OperatingSystemSKU) -eq "101"){
+if (((Get-WmiObject Win32_OperatingSystem).OperatingSystemSKU) -eq "101") {
 
     Write-host "Windows Home edition detected, exiting..." -ForegroundColor Red
     break
-    }
+}
 
 
 #region Functions
-    # Questions function
-    function Select-Option
-    {
-        param(
-            [parameter(Mandatory = $true, Position = 0)][string]$Message,
-            [parameter(Mandatory = $true, Position = 1)][string[]]$Options
-        )
-        $Selected = $null
-        while ($null -eq $Selected)
-        {
-            Write-Host $Message -ForegroundColor DarkMagenta
-            for ($i = 0; $i -lt $Options.Length; $i++) { Write-Host "$($i+1): $($Options[$i])" }
-            $SelectedIndex = Read-Host "Select an option"
-            if ($SelectedIndex -gt 0 -and $SelectedIndex -le $Options.Length) { $Selected = $Options[$SelectedIndex - 1] }
-            else { Write-Host "Invalid Option." -ForegroundColor Yellow }
-        }
-        return $Selected
+# Questions function
+function Select-Option {
+    param(
+        [parameter(Mandatory = $true, Position = 0)][string]$Message,
+        [parameter(Mandatory = $true, Position = 1)][string[]]$Options
+    )
+    $Selected = $null
+    while ($null -eq $Selected) {
+        Write-Host $Message -ForegroundColor DarkMagenta
+        for ($i = 0; $i -lt $Options.Length; $i++) { Write-Host "$($i+1): $($Options[$i])" }
+        $SelectedIndex = Read-Host "Select an option"
+        if ($SelectedIndex -gt 0 -and $SelectedIndex -le $Options.Length) { $Selected = $Options[$SelectedIndex - 1] }
+        else { Write-Host "Invalid Option." -ForegroundColor Yellow }
     }
+    return $Selected
+}
 
 
 
@@ -204,8 +202,8 @@ function ModifyRegistry {
 
         If (-NOT (Test-Path $hash.RegPath)) { 
             New-Item -Path $hash.RegPath -Force | Out-Null
-              }
-              New-ItemProperty -Path $hash.RegPath -Name $hash.RegName -Value $hash.RegValue -PropertyType DWORD -Force
+        }
+        New-ItemProperty -Path $hash.RegPath -Name $hash.RegName -Value $hash.RegValue -PropertyType DWORD -Force
 
         [pscustomobject]@{
             Path  = $hash.RegPath
@@ -222,7 +220,7 @@ function ModifyRegistry {
                 if ($item.Value -is [hashtable]) {
                     if ($item.Value.ContainsKey('RegPath') -and $item.Value.ContainsKey('RegValue')) {
                         $hash = $item.Value
-                        if (-not $hash.ContainsKey('RegName')){
+                        if (-not $hash.ContainsKey('RegName')) {
                             $hash.RegName = $item.Key
                         }
                         processit -hash $hash
@@ -250,159 +248,158 @@ function ModifyRegistry {
 
 # https://devblogs.microsoft.com/scripting/use-function-to-determine-elevation-of-powershell-console/
 # Function to test if current session has administrator privileges
-Function Test-IsAdmin
-{
-$identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+Function Test-IsAdmin {
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
 
-$principal = New-Object Security.Principal.WindowsPrincipal $identity
+    $principal = New-Object Security.Principal.WindowsPrincipal $identity
 
-$principal.IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)
+    $principal.IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)
 }
 #endregion functions
 
 
-if(-NOT (Test-IsAdmin))
+if (-NOT (Test-IsAdmin))
 
-   { write-host "Skipping commands that require Administrator privileges" -ForegroundColor Magenta }
+{ write-host "Skipping commands that require Administrator privileges" -ForegroundColor Magenta }
 
 else {
 
  
-#region Security-Baselines   
-# =========================================================================================================================
-# ================================================Security Baselines=======================================================
-# =========================================================================================================================
+    #region Security-Baselines   
+    # =========================================================================================================================
+    # ================================================Security Baselines=======================================================
+    # =========================================================================================================================
 
-switch (Select-Option -Options "Yes", "No", "Exit" -Message "`nApply Microsoft Security Baseline + Hardening Script's Baseline?")
-{  "Yes"  {
+    switch (Select-Option -Options "Yes", "No", "Exit" -Message "`nApply Microsoft Security Baseline + Hardening Script's Baseline?") {
+        "Yes" {
 
 
- # download Microsoft Security Baselines directly from their servers
-Invoke-WebRequest -Uri "https://download.microsoft.com/download/8/5/C/85C25433-A1B0-4FFA-9429-7E023E7DA8D8/Windows%2011%20version%2022H2%20Security%20Baseline.zip" -OutFile "Windows1122H2SecurityBaseline.zip"
+            # download Microsoft Security Baselines directly from their servers
+            Invoke-WebRequest -Uri "https://download.microsoft.com/download/8/5/C/85C25433-A1B0-4FFA-9429-7E023E7DA8D8/Windows%2011%20version%2022H2%20Security%20Baseline.zip" -OutFile "Windows1122H2SecurityBaseline.zip"
 
-# unzip Microsoft Security Baselines file
-Expand-Archive -Path .\Windows1122H2SecurityBaseline.zip -DestinationPath .\
+            # unzip Microsoft Security Baselines file
+            Expand-Archive -Path .\Windows1122H2SecurityBaseline.zip -DestinationPath .\
 
-# Download LGPO program from Microsoft servers
-Invoke-WebRequest -Uri "https://download.microsoft.com/download/8/5/C/85C25433-A1B0-4FFA-9429-7E023E7DA8D8/LGPO.zip" -OutFile "LGPO.zip"
+            # Download LGPO program from Microsoft servers
+            Invoke-WebRequest -Uri "https://download.microsoft.com/download/8/5/C/85C25433-A1B0-4FFA-9429-7E023E7DA8D8/LGPO.zip" -OutFile "LGPO.zip"
 
-# unzip the LGPO file
-Expand-Archive -Path .\LGPO.zip -DestinationPath .\
+            # unzip the LGPO file
+            Expand-Archive -Path .\LGPO.zip -DestinationPath .\
 
-# Download the Group Policies of Windows Hardening script from GitHub
-Invoke-WebRequest -Uri 'https://github.com/HotCakeX/Harden-Windows-Security/raw/main/GroupPolicy/Security-Baselines-X.zip' -OutFile 'Security-Baselines-X.zip'
+            # Download the Group Policies of Windows Hardening script from GitHub
+            Invoke-WebRequest -Uri 'https://github.com/HotCakeX/Harden-Windows-Security/raw/main/GroupPolicy/Security-Baselines-X.zip' -OutFile 'Security-Baselines-X.zip'
 
-# unzip the Security-Baselines-X file which contains Windows Hardening script Group Policy Objects
-expand-Archive -Path .\Security-Baselines-X.zip
+            # unzip the Security-Baselines-X file which contains Windows Hardening script Group Policy Objects
+            expand-Archive -Path .\Security-Baselines-X.zip
 
-# Copy LGPO.exe from its folder to Microsoft Security Baseline folder in order to get it ready to be used by PowerShell script
-Copy-Item -Path ".\LGPO_30\LGPO.exe" -Destination ".\Windows-11-v22H2-Security-Baseline\Scripts\Tools"
+            # Copy LGPO.exe from its folder to Microsoft Security Baseline folder in order to get it ready to be used by PowerShell script
+            Copy-Item -Path ".\LGPO_30\LGPO.exe" -Destination ".\Windows-11-v22H2-Security-Baseline\Scripts\Tools"
 
-# Change directory to the Security Baselines folder
-Push-Location .\Windows-11-v22H2-Security-Baseline\Scripts
+            # Change directory to the Security Baselines folder
+            Push-Location .\Windows-11-v22H2-Security-Baseline\Scripts
 
-# Run the official PowerShell script included in the Microsoft Security Baseline file we downloaded from official servers
-.\Baseline-LocalInstall.ps1 -Win11NonDomainJoined
+            # Run the official PowerShell script included in the Microsoft Security Baseline file we downloaded from official servers
+            .\Baseline-LocalInstall.ps1 -Win11NonDomainJoined
   
-# Change current working directory back to where we were  
-Pop-Location
+            # Change current working directory back to where we were  
+            Pop-Location
 
-# Change current working directory to the LGPO's folder
-Push-Location .\LGPO_30
+            # Change current working directory to the LGPO's folder
+            Push-Location .\LGPO_30
 
-# Use LGPO.exe to apply the Windows Hardening script Group Policy Objects on top of Microsoft Security Baselines
-.\LGPO.exe /g '..\Security-Baselines-X\{300945C6-E397-4D12-A29F-18612FBD1058}'
+            # Use LGPO.exe to apply the Windows Hardening script Group Policy Objects on top of Microsoft Security Baselines
+            .\LGPO.exe /g '..\Security-Baselines-X\{300945C6-E397-4D12-A29F-18612FBD1058}'
 
-# Change the current working directory back to where we were
-Pop-Location
+            # Change the current working directory back to where we were
+            Pop-Location
 
-# Delete Microsoft Security Baselines zip file
-Remove-Item -Path .\Windows1122H2SecurityBaseline.zip -Force
+            # Delete Microsoft Security Baselines zip file
+            Remove-Item -Path .\Windows1122H2SecurityBaseline.zip -Force
 
-# Delete Microsoft Security Baselines folder where we extracted the zip file
-remove-item -Path .\Windows-11-v22H2-Security-Baseline -Recurse -Force
+            # Delete Microsoft Security Baselines folder where we extracted the zip file
+            remove-item -Path .\Windows-11-v22H2-Security-Baseline -Recurse -Force
 
-# Delete the LGPO zip file
-remove-item -Path .\LGPO_30 -Recurse -Force
+            # Delete the LGPO zip file
+            remove-item -Path .\LGPO_30 -Recurse -Force
 
-# Delete the LGPO folder where we extracted the zip file
-Remove-Item -Path .\LGPO.zip -Force
+            # Delete the LGPO folder where we extracted the zip file
+            Remove-Item -Path .\LGPO.zip -Force
 
-# Delete the Windows Hardening script Group Policy Objects zip file
-remove-item .\Security-Baselines-X -Recurse -Force
+            # Delete the Windows Hardening script Group Policy Objects zip file
+            remove-item .\Security-Baselines-X -Recurse -Force
 
-# Delete the Windows Hardening script Group Policy Objects folder we extracted the zip file
-remove-item .\Security-Baselines-X.zip -Force
+            # Delete the Windows Hardening script Group Policy Objects folder we extracted the zip file
+            remove-item .\Security-Baselines-X.zip -Force
 
-# Force update the applied Group Policies
-gpupdate /force
+            # Force update the applied Group Policies
+            gpupdate /force
 
 
 
  
-} "No" { break }
-"Exit" { exit }
-}
-# =========================================================================================================================
-# ============================================End of Security Baselines====================================================
-# =========================================================================================================================
-#endregion Security-Baselines
+        } "No" { break }
+        "Exit" { exit }
+    }
+    # =========================================================================================================================
+    # ============================================End of Security Baselines====================================================
+    # =========================================================================================================================
+    #endregion Security-Baselines
 
 
  
-#region Windows-Security-Defender
-# =========================================================================================================================
-# ==========================================Windows Security aka Defender==================================================
-# =========================================================================================================================
-switch (Select-Option -Options "Yes", "No", "Exit" -Message "Run Windows Security (Defender) category ?")
-{  "Yes"  {
+    #region Windows-Security-Defender
+    # =========================================================================================================================
+    # ==========================================Windows Security aka Defender==================================================
+    # =========================================================================================================================
+    switch (Select-Option -Options "Yes", "No", "Exit" -Message "Run Windows Security (Defender) category ?") {
+        "Yes" {
  
 
 
-# Optimizing Network Protection Performance of Windows Defender - this was off by default on Windows 11 insider build 25247
-Set-MpPreference -AllowSwitchToAsyncInspection $True
+            # Optimizing Network Protection Performance of Windows Defender - this was off by default on Windows 11 insider build 25247
+            Set-MpPreference -AllowSwitchToAsyncInspection $True
 
 
 
-switch (Select-Option -Options "Yes", "No", "Exit" -Message "Turn on Smart App Control ?")
-{  "Yes"  {
+            switch (Select-Option -Options "Yes", "No", "Exit" -Message "Turn on Smart App Control ?") {
+                "Yes" {
 
-# Turn on Smart App Control
-ModifyRegistry -RegPath 'HKLM:\SYSTEM\CurrentControlSet\Control\CI\Policy' -RegName 'VerifiedAndReputablePolicyState' -RegValue '1'
+                    # Turn on Smart App Control
+                    ModifyRegistry -RegPath 'HKLM:\SYSTEM\CurrentControlSet\Control\CI\Policy' -RegName 'VerifiedAndReputablePolicyState' -RegValue '1'
 
-} "No" { break }
-"Exit" { exit }
-}
-
-
+                } "No" { break }
+                "Exit" { exit }
+            }
 
 
 
-} "No" { break }
-"Exit" { exit }
-}
-
-# =========================================================================================================================
-# =========================================End of Windows Security aka Defender============================================
-# =========================================================================================================================
-#endregion Windows-Security-Defender
 
 
+        } "No" { break }
+        "Exit" { exit }
+    }
 
-#region Bitlocker-Settings
-# =========================================================================================================================
-# ==========================================Bitlocker Settings=============================================================
-# =========================================================================================================================
-switch (Select-Option -Options "Yes", "No", "Exit" -Message "Run Bitlocker category ?")
- {  "Yes"  {
+    # =========================================================================================================================
+    # =========================================End of Windows Security aka Defender============================================
+    # =========================================================================================================================
+    #endregion Windows-Security-Defender
 
 
-# This PowerShell script can be used to find out if the DMA Protection is ON \ OFF.
-# The Script will show this by emitting True \ False for On \ Off respectively.
 
-# bootDMAProtection check - checks for Kernel DMA Protection status in System information or msinfo32
-$bootDMAProtectionCheck =
-@"
+    #region Bitlocker-Settings
+    # =========================================================================================================================
+    # ==========================================Bitlocker Settings=============================================================
+    # =========================================================================================================================
+    switch (Select-Option -Options "Yes", "No", "Exit" -Message "Run Bitlocker category ?") {
+        "Yes" {
+
+
+            # This PowerShell script can be used to find out if the DMA Protection is ON \ OFF.
+            # The Script will show this by emitting True \ False for On \ Off respectively.
+
+            # bootDMAProtection check - checks for Kernel DMA Protection status in System information or msinfo32
+            $bootDMAProtectionCheck =
+            @"
   namespace SystemInfo
     {
       using System;
@@ -446,23 +443,21 @@ $bootDMAProtectionCheck =
     }
 "@
 
-Add-Type -TypeDefinition $bootDMAProtectionCheck
+            Add-Type -TypeDefinition $bootDMAProtectionCheck
 
-# returns true or false depending on whether Kernel DMA Protection is on or off
-$bootDMAProtection = ([SystemInfo.NativeMethods]::BootDmaCheck()) -ne 0
-
-
-# Enables or disables DMA protection from Bitlocker Countermeasures based on the status of Kernel DMA protection.
-if ($bootDMAProtection) {
-
-    ModifyRegistry -RegPath 'HKLM:\SOFTWARE\Policies\Microsoft\FVE' -RegName 'DisableExternalDMAUnderLock' -RegValue '1'
-}
-else {
-
-    ModifyRegistry -RegPath 'HKLM:\SOFTWARE\Policies\Microsoft\FVE' -RegName 'DisableExternalDMAUnderLock' -RegValue '0'
-}
+            # returns true or false depending on whether Kernel DMA Protection is on or off
+            $bootDMAProtection = ([SystemInfo.NativeMethods]::BootDmaCheck()) -ne 0
 
 
+            # Enables or disables DMA protection from Bitlocker Countermeasures based on the status of Kernel DMA protection.
+            if ($bootDMAProtection) {
+
+                ModifyRegistry -RegPath 'HKLM:\SOFTWARE\Policies\Microsoft\FVE' -RegName 'DisableExternalDMAUnderLock' -RegValue '1'
+            }
+            else {
+
+                ModifyRegistry -RegPath 'HKLM:\SOFTWARE\Policies\Microsoft\FVE' -RegName 'DisableExternalDMAUnderLock' -RegValue '0'
+            }
 
 
 
@@ -473,15 +468,17 @@ else {
 
 
 
-# set-up Bitlocker encryption for OS Drive with TPMandPIN and recovery password keyprotectors and Verify its implementation
-# https://learn.microsoft.com/en-us/powershell/module/bitlocker/remove-bitlockerkeyprotector?view=windowsserver2022-ps
-# Once it's done, it saves the recovery password in a text file in the encrypted drive
-# Make sure to keep it in a safe place, e.g. in OneDrive's Personal Vault which requires authentication to access.
+
+
+            # set-up Bitlocker encryption for OS Drive with TPMandPIN and recovery password keyprotectors and Verify its implementation
+            # https://learn.microsoft.com/en-us/powershell/module/bitlocker/remove-bitlockerkeyprotector?view=windowsserver2022-ps
+            # Once it's done, it saves the recovery password in a text file in the encrypted drive
+            # Make sure to keep it in a safe place, e.g. in OneDrive's Personal Vault which requires authentication to access.
 
 
 
 
-<#
+            <#
 https://stackoverflow.com/questions/48809012/compare-two-credentials-in-powershell
 
 
@@ -491,597 +488,596 @@ https://stackoverflow.com/questions/48809012/compare-two-credentials-in-powershe
 
 
 
-function Compare-SecureString {
-    param(
-      [Security.SecureString] $secureString1,
-      [Security.SecureString] $secureString2
-    )
-    try {
-      $bstr1 = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureString1)
-      $bstr2 = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureString2)
-      $length1 = [Runtime.InteropServices.Marshal]::ReadInt32($bstr1, -4)
-      $length2 = [Runtime.InteropServices.Marshal]::ReadInt32($bstr2, -4)
-      if ( $length1 -ne $length2 ) {
-        return $false
-      }
-      for ( $i = 0; $i -lt $length1; ++$i ) {
-        $b1 = [Runtime.InteropServices.Marshal]::ReadByte($bstr1, $i)
-        $b2 = [Runtime.InteropServices.Marshal]::ReadByte($bstr2, $i)
-        if ( $b1 -ne $b2 ) {
-          return $false
-        }
-      }
-      return $true
-    }
-    finally {
-      if ( $bstr1 -ne [IntPtr]::Zero ) {
-        [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr1)
-      }
-      if ( $bstr2 -ne [IntPtr]::Zero ) {
-        [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr2)
-      }
-    }
-  }
+            function Compare-SecureString {
+                param(
+                    [Security.SecureString] $secureString1,
+                    [Security.SecureString] $secureString2
+                )
+                try {
+                    $bstr1 = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureString1)
+                    $bstr2 = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureString2)
+                    $length1 = [Runtime.InteropServices.Marshal]::ReadInt32($bstr1, -4)
+                    $length2 = [Runtime.InteropServices.Marshal]::ReadInt32($bstr2, -4)
+                    if ( $length1 -ne $length2 ) {
+                        return $false
+                    }
+                    for ( $i = 0; $i -lt $length1; ++$i ) {
+                        $b1 = [Runtime.InteropServices.Marshal]::ReadByte($bstr1, $i)
+                        $b2 = [Runtime.InteropServices.Marshal]::ReadByte($bstr2, $i)
+                        if ( $b1 -ne $b2 ) {
+                            return $false
+                        }
+                    }
+                    return $true
+                }
+                finally {
+                    if ( $bstr1 -ne [IntPtr]::Zero ) {
+                        [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr1)
+                    }
+                    if ( $bstr2 -ne [IntPtr]::Zero ) {
+                        [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr2)
+                    }
+                }
+            }
 
 
 
   
- # check, make sure there is no CD/DVD drives in the system, because Bitlocker throws an error when there is
- $CDDVDCheck = (Get-WMIObject -Class Win32_CDROMDrive -Property *).MediaLoaded
- if ($CDDVDCheck){
-    Write-Warning "Remove any CD/DVD drives from the system and run the Bitlocker category after that"
-    break
-}
+            # check, make sure there is no CD/DVD drives in the system, because Bitlocker throws an error when there is
+            $CDDVDCheck = (Get-WMIObject -Class Win32_CDROMDrive -Property *).MediaLoaded
+            if ($CDDVDCheck) {
+                Write-Warning "Remove any CD/DVD drives from the system and run the Bitlocker category after that"
+                break
+            }
 
 
- # check, make sure Bitlocker isn't in the middle of decryption/encryption operation (on System Drive)
-if ((Get-BitLockerVolume -MountPoint $env:SystemDrive).EncryptionPercentage -ne "100" -and (Get-BitLockerVolume -MountPoint $env:SystemDrive).EncryptionPercentage -ne "0") {
+            # check, make sure Bitlocker isn't in the middle of decryption/encryption operation (on System Drive)
+            if ((Get-BitLockerVolume -MountPoint $env:SystemDrive).EncryptionPercentage -ne "100" -and (Get-BitLockerVolume -MountPoint $env:SystemDrive).EncryptionPercentage -ne "0") {
 
-    $kawai = (Get-BitLockerVolume -MountPoint $env:SystemDrive).EncryptionPercentage
-    Write-Host "Please wait for Bitlocker operation to finish encrypting or decrypting the disk" -ForegroundColor Magenta
-    Write-Host "drive $env:SystemDrive encryption is currently at $kawai" -ForegroundColor Magenta
-
-}
-
-else {
-
-
-
-
-    # check if Bitlocker is enabled for the system drive
-if ((Get-BitLockerVolume -MountPoint $env:SystemDrive).ProtectionStatus -eq "on")  { 
-                 
-               
-    $KeyProtectors = (Get-BitLockerVolume -MountPoint $env:SystemDrive).KeyProtector.keyprotectortype
-    # check if TPM, PIN and recovery password are being used with Bitlocker which are the safest settings
-    if ($KeyProtectors -contains 'Tpmpin' -and $KeyProtectors -contains 'recoveryPassword') {
-        
-        Write-Host "Bitlocker is fully and securely enabled for OS drive" -ForegroundColor Green
-    
-    }
-    else {       
-            # check if Bitlocker is using TPM and PIN but not recovery password as key protector
-            if ($KeyProtectors -contains 'Tpmpin' -and $KeyProtectors -notcontains 'recoveryPassword')
-             {
-
-                    Add-BitLockerKeyProtector -MountPoint $env:SystemDrive -RecoveryPasswordProtector *> "$env:SystemDrive\Drive $($env:SystemDrive.remove(1)) recovery password.txt"
-                    Write-Host "TPM and Startup Pin are available but the recovery password is missing, adding it now... `nthe recovery password will be saved in a Text file in $env:SystemDrive\Drive $($env:SystemDrive.remove(1)) recovery password.txt" -ForegroundColor yellow
-                    Write-Host "Make sure to keep it in a safe place, e.g. in OneDrive's Personal Vault which requires authentication to access." -ForegroundColor Blue
-                
-                
-                
-             }
-                
-                # check if Bitlocker is using recovery password but not TPM and PIN
-            if($KeyProtectors -notcontains 'Tpmpin' -and $KeyProtectors -contains 'recoveryPassword') {
-            
-                Write-Host "TPM and Start up PIN key protectors are missing but recovery password key protector is in place, `nadding TPM and Start up PIN key protectors now..." -ForegroundColor Magenta
-                
-
-
-                do  {
-
-                    $pin1 = $(write-host "Enter a Pin for Bitlocker startup (at least 6 digits)" -ForegroundColor Magenta; Read-Host -AsSecureString)
-                    $pin2 = $(write-host "Confirm your Bitlocker Startup Pin (at least 6 digits)" -ForegroundColor Magenta; Read-Host -AsSecureString)
-                    
-                  
-                    $theyMatch = Compare-SecureString $pin1 $pin2
-                     
-                  
-                    if ( $theyMatch -and $pin1.Length -gt 5 -and $pin2.Length -gt 5  ) {
-                  
-                    $pin = $pin1
-                  
-                     }
-                  
-                    else {Write-Host "the PINs you entered didn't match, try again" -ForegroundColor red}
-                  
-                  }
-                  
-                  until (
-                    $theyMatch -and $pin1.Length -gt 5 -and $pin2.Length -gt 5
-                  )
-
-
-
-                 
-                  try {
-
-                    Add-BitLockerKeyProtector -MountPoint $env:SystemDrive -TpmAndPinProtector -Pin $pin -ErrorAction Stop
-                    Write-Host "PINs matched, enabling TPM and startup PIN now" -ForegroundColor DarkMagenta
-                  }
-    
-                  catch {
-         
-                    Write-Host "These errors occured, run Bitlocker category again after meeting the requirements" -ForegroundColor Red
-                    $Error
-                    break
-                  }
+                $kawai = (Get-BitLockerVolume -MountPoint $env:SystemDrive).EncryptionPercentage
+                Write-Host "Please wait for Bitlocker operation to finish encrypting or decrypting the disk" -ForegroundColor Magenta
+                Write-Host "drive $env:SystemDrive encryption is currently at $kawai" -ForegroundColor Magenta
 
             }
+
+            else {
+
+
+
+
+                # check if Bitlocker is enabled for the system drive
+                if ((Get-BitLockerVolume -MountPoint $env:SystemDrive).ProtectionStatus -eq "on") { 
+                 
+               
+                    $KeyProtectors = (Get-BitLockerVolume -MountPoint $env:SystemDrive).KeyProtector.keyprotectortype
+                    # check if TPM, PIN and recovery password are being used with Bitlocker which are the safest settings
+                    if ($KeyProtectors -contains 'Tpmpin' -and $KeyProtectors -contains 'recoveryPassword') {
+        
+                        Write-Host "Bitlocker is fully and securely enabled for OS drive" -ForegroundColor Green
+    
+                    }
+                    else {       
+                        # check if Bitlocker is using TPM and PIN but not recovery password as key protector
+                        if ($KeyProtectors -contains 'Tpmpin' -and $KeyProtectors -notcontains 'recoveryPassword') {
+
+                            Add-BitLockerKeyProtector -MountPoint $env:SystemDrive -RecoveryPasswordProtector *> "$env:SystemDrive\Drive $($env:SystemDrive.remove(1)) recovery password.txt"
+                            Write-Host "TPM and Startup Pin are available but the recovery password is missing, adding it now... `nthe recovery password will be saved in a Text file in $env:SystemDrive\Drive $($env:SystemDrive.remove(1)) recovery password.txt" -ForegroundColor yellow
+                            Write-Host "Make sure to keep it in a safe place, e.g. in OneDrive's Personal Vault which requires authentication to access." -ForegroundColor Blue
+                
+                
+                
+                        }
+                
+                        # check if Bitlocker is using recovery password but not TPM and PIN
+                        if ($KeyProtectors -notcontains 'Tpmpin' -and $KeyProtectors -contains 'recoveryPassword') {
+            
+                            Write-Host "TPM and Start up PIN key protectors are missing but recovery password key protector is in place, `nadding TPM and Start up PIN key protectors now..." -ForegroundColor Magenta
+                
+
+
+                            do {
+
+                                $pin1 = $(write-host "Enter a Pin for Bitlocker startup (at least 6 digits)" -ForegroundColor Magenta; Read-Host -AsSecureString)
+                                $pin2 = $(write-host "Confirm your Bitlocker Startup Pin (at least 6 digits)" -ForegroundColor Magenta; Read-Host -AsSecureString)
+                    
+                  
+                                $theyMatch = Compare-SecureString $pin1 $pin2
+                     
+                  
+                                if ( $theyMatch -and $pin1.Length -gt 5 -and $pin2.Length -gt 5  ) {
+                  
+                                    $pin = $pin1
+                  
+                                }
+                  
+                                else { Write-Host "the PINs you entered didn't match, try again" -ForegroundColor red }
+                  
+                            }
+                  
+                            until (
+                                $theyMatch -and $pin1.Length -gt 5 -and $pin2.Length -gt 5
+                            )
+
+
+
+                 
+                            try {
+
+                                Add-BitLockerKeyProtector -MountPoint $env:SystemDrive -TpmAndPinProtector -Pin $pin -ErrorAction Stop
+                                Write-Host "PINs matched, enabling TPM and startup PIN now" -ForegroundColor DarkMagenta
+                            }
+    
+                            catch {
+         
+                                Write-Host "These errors occured, run Bitlocker category again after meeting the requirements" -ForegroundColor Red
+                                $Error
+                                break
+                            }
+
+                        }
      
-        }
+                    }
     
      
-}
+                }
 
    
-else {
-    Write-Host "Bitlocker is Not enabled for the System Drive Drive, activating now..." -ForegroundColor yellow
+                else {
+                    Write-Host "Bitlocker is Not enabled for the System Drive Drive, activating now..." -ForegroundColor yellow
     
-        do  {
+                    do {
 
-            $pin1 = $(write-host "Enter a Pin for Bitlocker startup (at least 6 digits)" -ForegroundColor Magenta; Read-Host -AsSecureString)
-            $pin2 = $(write-host "Confirm your Bitlocker Startup Pin (at least 6 digits)" -ForegroundColor Magenta; Read-Host -AsSecureString)
+                        $pin1 = $(write-host "Enter a Pin for Bitlocker startup (at least 6 digits)" -ForegroundColor Magenta; Read-Host -AsSecureString)
+                        $pin2 = $(write-host "Confirm your Bitlocker Startup Pin (at least 6 digits)" -ForegroundColor Magenta; Read-Host -AsSecureString)
 
       
-        $theyMatch = Compare-SecureString $pin1 $pin2
+                        $theyMatch = Compare-SecureString $pin1 $pin2
       
       
-         if ( $theyMatch -and $pin1.Length -gt 5 -and $pin2.Length -gt 5  ) {
+                        if ( $theyMatch -and $pin1.Length -gt 5 -and $pin2.Length -gt 5  ) {
       
-          $pin = $pin1
+                            $pin = $pin1
       
-         }
+                        }
       
-         else {Write-Host "the Pins you entered didn't match, try again" -ForegroundColor red}
+                        else { Write-Host "the Pins you entered didn't match, try again" -ForegroundColor red }
       
-         }
+                    }
       
-         until (
-            $theyMatch -and $pin1.Length -gt 5 -and $pin2.Length -gt 5
-          )
+                    until (
+                        $theyMatch -and $pin1.Length -gt 5 -and $pin2.Length -gt 5
+                    )
 
-         try {
+                    try {
 
-     enable-bitlocker -MountPoint $env:SystemDrive -EncryptionMethod XtsAes256 -pin $pin -TpmAndPinProtector -SkipHardwareTest -ErrorAction Stop
+                        enable-bitlocker -MountPoint $env:SystemDrive -EncryptionMethod XtsAes256 -pin $pin -TpmAndPinProtector -SkipHardwareTest -ErrorAction Stop
              
-         }
+                    }
 
-         catch {
+                    catch {
 
-          Write-Host "These errors occured, run Bitlocker category again after meeting the requirements" -ForegroundColor Red
-          $Error
-          break
-         }
+                        Write-Host "These errors occured, run Bitlocker category again after meeting the requirements" -ForegroundColor Red
+                        $Error
+                        break
+                    }
 
 
      
-            Add-BitLockerKeyProtector -MountPoint $env:SystemDrive -RecoveryPasswordProtector *> "$env:SystemDrive\Drive $($env:SystemDrive.remove(1)) recovery password.txt" 
-            Resume-BitLocker -MountPoint $env:SystemDrive
-            Write-Host "the recovery password will be saved in a Text file in $env:SystemDrive\Drive $($env:SystemDrive.remove(1)) recovery password.txt `nMake sure to keep it in a safe place, e.g. in OneDrive's Personal Vault which requires authentication to access." -ForegroundColor Blue
-            Write-Host "Bitlocker is now fully and securely enabled for OS drive" -ForegroundColor Green
+                    Add-BitLockerKeyProtector -MountPoint $env:SystemDrive -RecoveryPasswordProtector *> "$env:SystemDrive\Drive $($env:SystemDrive.remove(1)) recovery password.txt" 
+                    Resume-BitLocker -MountPoint $env:SystemDrive
+                    Write-Host "the recovery password will be saved in a Text file in $env:SystemDrive\Drive $($env:SystemDrive.remove(1)) recovery password.txt `nMake sure to keep it in a safe place, e.g. in OneDrive's Personal Vault which requires authentication to access." -ForegroundColor Blue
+                    Write-Host "Bitlocker is now fully and securely enabled for OS drive" -ForegroundColor Green
             
         
      
      
 
-}
+                }
 
 
-}
-
-
-
-
-# Enable Bitlocker for all the other drives
-
-# check if there is any other drive besides OS drive
-$nonOSVolumes = Get-BitLockerVolume | Where-Object {$_.volumeType -ne "OperatingSystem"}
-
-if ($nonOSVolumes){
-
-$nonOSVolumes | ForEach-Object {
-
-  $MountPoint  = $_.MountPoint
+            }
 
 
 
 
-  if ((Get-BitLockerVolume -MountPoint $MountPoint).EncryptionPercentage -ne "100" -and (Get-BitLockerVolume -MountPoint $MountPoint).EncryptionPercentage -ne "0") {
+            # Enable Bitlocker for all the other drives
 
-    $kawai = (Get-BitLockerVolume -MountPoint $MountPoint).EncryptionPercentage
-    Write-Host "Please wait for Bitlocker operation to finish encrypting or decrypting drive $MountPoint" -ForegroundColor Magenta
-    Write-Host "drive $MountPoint encryption is currently at $kawai" -ForegroundColor Magenta
+            # check if there is any other drive besides OS drive
+            $nonOSVolumes = Get-BitLockerVolume | Where-Object { $_.volumeType -ne "OperatingSystem" }
 
-    }   
+            if ($nonOSVolumes) {
 
-    else {
+                $nonOSVolumes | ForEach-Object {
 
-
-
+                    $MountPoint = $_.MountPoint
 
 
-  if ((Get-BitLockerVolume -MountPoint $MountPoint).ProtectionStatus -eq "on")  {          
+
+
+                    if ((Get-BitLockerVolume -MountPoint $MountPoint).EncryptionPercentage -ne "100" -and (Get-BitLockerVolume -MountPoint $MountPoint).EncryptionPercentage -ne "0") {
+
+                        $kawai = (Get-BitLockerVolume -MountPoint $MountPoint).EncryptionPercentage
+                        Write-Host "Please wait for Bitlocker operation to finish encrypting or decrypting drive $MountPoint" -ForegroundColor Magenta
+                        Write-Host "drive $MountPoint encryption is currently at $kawai" -ForegroundColor Magenta
+
+                    }   
+
+                    else {
+
+
+
+
+
+                        if ((Get-BitLockerVolume -MountPoint $MountPoint).ProtectionStatus -eq "on") {          
     
-       $KeyProtectors = (Get-BitLockerVolume -MountPoint $MountPoint).KeyProtector.keyprotectortype
+                            $KeyProtectors = (Get-BitLockerVolume -MountPoint $MountPoint).KeyProtector.keyprotectortype
     
-      if ($KeyProtectors -contains 'RecoveryPassword') {
+                            if ($KeyProtectors -contains 'RecoveryPassword') {
         
-        Write-Host "Bitlocker is fully and securely enabled for drive $MountPoint" -ForegroundColor Green
+                                Write-Host "Bitlocker is fully and securely enabled for drive $MountPoint" -ForegroundColor Green
     
-      }
+                            }
 
-      else {
+                            else {
 
-        Add-BitLockerKeyProtector -MountPoint $MountPoint -RecoveryPasswordProtector *> "$MountPoint\Drive $($MountPoint.Remove(1)) recovery password.txt";
-        Enable-BitLockerAutoUnlock -MountPoint $MountPoint
-        Write-Host "Bitlocker Recovery Password has been added for drive $MountPoint . it will be saved in a Text file in $($MountPoint)\Drive $($MountPoint.Remove(1)) recovery password.txt `nMake sure to keep it in a safe place, e.g. in OneDrive's Personal Vault which requires authentication to access." -ForegroundColor Blue
+                                Add-BitLockerKeyProtector -MountPoint $MountPoint -RecoveryPasswordProtector *> "$MountPoint\Drive $($MountPoint.Remove(1)) recovery password.txt";
+                                Enable-BitLockerAutoUnlock -MountPoint $MountPoint
+                                Write-Host "Bitlocker Recovery Password has been added for drive $MountPoint . it will be saved in a Text file in $($MountPoint)\Drive $($MountPoint.Remove(1)) recovery password.txt `nMake sure to keep it in a safe place, e.g. in OneDrive's Personal Vault which requires authentication to access." -ForegroundColor Blue
    
-        }
+                            }
 
 
-  }
+                        }
 
-  else {
+                        else {
 
-  Enable-BitLocker -MountPoint $MountPoint -RecoveryPasswordProtector *> "$MountPoint\Drive $($MountPoint.Remove(1)) recovery password.txt";
-  Enable-BitLockerAutoUnlock -MountPoint $MountPoint
-  Write-Host "Bitlocker has started encrypting drive $MountPoint . recovery password will be saved in a Text file in $($MountPoint)\Drive $($MountPoint.Remove(1)) recovery password.txt `nMake sure to keep it in a safe place, e.g. in OneDrive's Personal Vault which requires authentication to access." -ForegroundColor Blue
+                            Enable-BitLocker -MountPoint $MountPoint -RecoveryPasswordProtector *> "$MountPoint\Drive $($MountPoint.Remove(1)) recovery password.txt";
+                            Enable-BitLockerAutoUnlock -MountPoint $MountPoint
+                            Write-Host "Bitlocker has started encrypting drive $MountPoint . recovery password will be saved in a Text file in $($MountPoint)\Drive $($MountPoint.Remove(1)) recovery password.txt `nMake sure to keep it in a safe place, e.g. in OneDrive's Personal Vault which requires authentication to access." -ForegroundColor Blue
            
 
-  }
+                        }
 
 
-}
+                    }
 
-}
+                }
 
-} # end of if statement for detecting whether there is any non-OS drives
-
-
-
+            } # end of if statement for detecting whether there is any non-OS drives
 
 
 
 
-} "No" { break }
-"Exit" { exit }
-}
-# =========================================================================================================================
-# ==========================================End of Bitlocker Settings======================================================
-# =========================================================================================================================
-#endregion Bitlocker-Settings
 
 
 
-#region TLS-Security
-# =========================================================================================================================
-# ==============================================TLS Security===============================================================
-# =========================================================================================================================
-switch (Select-Option -Options "Yes", "No", "Exit" -Message "Run TLS Security category ?")
-{  "Yes"  {
-
-
-
-
-$TLS = [ordered]@{
-    # Disable TLS v1
-    Key1 = @{
-        RegName = 'DisabledByDefault'
-        RegPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Client'
-        RegValue = '1'
+        } "No" { break }
+        "Exit" { exit }
     }
-    Key2 = @{
-        RegName = 'Enabled'
-        RegPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Client'
-        RegValue = '0'
-    }
-    key3 = @{
-        RegName = 'DisabledByDefault'
-        RegPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Server'
-        RegValue = '1'
-    }
-    Key4 = @{
-        RegName = 'Enabled'
-        RegPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Server'
-        RegValue = '0'
-    }
-# Disable TLS v1.1
-    Key5 = @{
-        RegName = 'DisabledByDefault'
-        RegPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Client'
-        RegValue = '1'
-    }
-    Key6 = @{
-        RegName = 'Enabled'
-        RegPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Client'
-        RegValue = '0'
-    }
-    Key7 = @{
-        RegName = 'DisabledByDefault'
-        RegPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Server'
-        RegValue = '1'
-    }
-    Key8 = @{
-        RegName = 'Enabled'
-        RegPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Server'
-        RegValue = '0'
-    }
-}
-# Disable TLS v1 and v1.1
-ModifyRegistry -HashTable $TLS
+    # =========================================================================================================================
+    # ==========================================End of Bitlocker Settings======================================================
+    # =========================================================================================================================
+    #endregion Bitlocker-Settings
+
+
+
+    #region TLS-Security
+    # =========================================================================================================================
+    # ==============================================TLS Security===============================================================
+    # =========================================================================================================================
+    switch (Select-Option -Options "Yes", "No", "Exit" -Message "Run TLS Security category ?") {
+        "Yes" {
+
+
+
+
+            $TLS = [ordered]@{
+                # Disable TLS v1
+                Key1 = @{
+                    RegName  = 'DisabledByDefault'
+                    RegPath  = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Client'
+                    RegValue = '1'
+                }
+                Key2 = @{
+                    RegName  = 'Enabled'
+                    RegPath  = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Client'
+                    RegValue = '0'
+                }
+                key3 = @{
+                    RegName  = 'DisabledByDefault'
+                    RegPath  = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Server'
+                    RegValue = '1'
+                }
+                Key4 = @{
+                    RegName  = 'Enabled'
+                    RegPath  = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Server'
+                    RegValue = '0'
+                }
+                # Disable TLS v1.1
+                Key5 = @{
+                    RegName  = 'DisabledByDefault'
+                    RegPath  = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Client'
+                    RegValue = '1'
+                }
+                Key6 = @{
+                    RegName  = 'Enabled'
+                    RegPath  = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Client'
+                    RegValue = '0'
+                }
+                Key7 = @{
+                    RegName  = 'DisabledByDefault'
+                    RegPath  = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Server'
+                    RegValue = '1'
+                }
+                Key8 = @{
+                    RegName  = 'Enabled'
+                    RegPath  = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Server'
+                    RegValue = '0'
+                }
+            }
+            # Disable TLS v1 and v1.1
+            ModifyRegistry -HashTable $TLS
 
 
 
 
 
-# Enable TLS_CHACHA20_POLY1305_SHA256 Cipher Suite which is available but not enabled by default in Windows 11
-Enable-TlsCipherSuite -Name "TLS_CHACHA20_POLY1305_SHA256" -Position 0
+            # Enable TLS_CHACHA20_POLY1305_SHA256 Cipher Suite which is available but not enabled by default in Windows 11
+            Enable-TlsCipherSuite -Name "TLS_CHACHA20_POLY1305_SHA256" -Position 0
 
 
 
 
-# disabling weak cipher suites
+            # disabling weak cipher suites
 
 
-try {
-  # Disable NULL Cipher Suites - 1 
-  Disable-TlsCipherSuite TLS_RSA_WITH_NULL_SHA256
-  # Disable NULL Cipher Suites - 2
-  Disable-TlsCipherSuite TLS_RSA_WITH_NULL_SHA
-  # Disable NULL Cipher Suites - 3
-  Disable-TlsCipherSuite TLS_PSK_WITH_NULL_SHA384
-  # Disable NULL Cipher Suites - 4
-  Disable-TlsCipherSuite TLS_PSK_WITH_NULL_SHA256
+            try {
+                # Disable NULL Cipher Suites - 1 
+                Disable-TlsCipherSuite TLS_RSA_WITH_NULL_SHA256
+                # Disable NULL Cipher Suites - 2
+                Disable-TlsCipherSuite TLS_RSA_WITH_NULL_SHA
+                # Disable NULL Cipher Suites - 3
+                Disable-TlsCipherSuite TLS_PSK_WITH_NULL_SHA384
+                # Disable NULL Cipher Suites - 4
+                Disable-TlsCipherSuite TLS_PSK_WITH_NULL_SHA256
     
   
-  Disable-TlsCipherSuite -Name "TLS_RSA_WITH_AES_256_GCM_SHA384"
-  Disable-TlsCipherSuite -Name "TLS_RSA_WITH_AES_128_GCM_SHA256"
-  Disable-TlsCipherSuite -Name "TLS_RSA_WITH_AES_256_CBC_SHA256" 
-  Disable-TlsCipherSuite -Name "TLS_RSA_WITH_AES_128_CBC_SHA256"
-  Disable-TlsCipherSuite -Name "TLS_RSA_WITH_AES_256_CBC_SHA"
-  Disable-TlsCipherSuite -Name "TLS_RSA_WITH_AES_128_CBC_SHA"
-  Disable-TlsCipherSuite -Name "TLS_PSK_WITH_AES_256_GCM_SHA384" 
-  Disable-TlsCipherSuite -Name "TLS_PSK_WITH_AES_128_GCM_SHA256"
-  Disable-TlsCipherSuite -Name "TLS_PSK_WITH_AES_256_CBC_SHA384"
-  Disable-TlsCipherSuite -Name "TLS_PSK_WITH_AES_128_CBC_SHA256" 
-  }
-  catch {
-      Write-Host "All weak TLS Cipher Suites have been disabled" -ForegroundColor Magenta
-  }
+                Disable-TlsCipherSuite -Name "TLS_RSA_WITH_AES_256_GCM_SHA384"
+                Disable-TlsCipherSuite -Name "TLS_RSA_WITH_AES_128_GCM_SHA256"
+                Disable-TlsCipherSuite -Name "TLS_RSA_WITH_AES_256_CBC_SHA256" 
+                Disable-TlsCipherSuite -Name "TLS_RSA_WITH_AES_128_CBC_SHA256"
+                Disable-TlsCipherSuite -Name "TLS_RSA_WITH_AES_256_CBC_SHA"
+                Disable-TlsCipherSuite -Name "TLS_RSA_WITH_AES_128_CBC_SHA"
+                Disable-TlsCipherSuite -Name "TLS_PSK_WITH_AES_256_GCM_SHA384" 
+                Disable-TlsCipherSuite -Name "TLS_PSK_WITH_AES_128_GCM_SHA256"
+                Disable-TlsCipherSuite -Name "TLS_PSK_WITH_AES_256_CBC_SHA384"
+                Disable-TlsCipherSuite -Name "TLS_PSK_WITH_AES_128_CBC_SHA256" 
+            }
+            catch {
+                Write-Host "All weak TLS Cipher Suites have been disabled" -ForegroundColor Magenta
+            }
 
 
 
-# Enabling Diffie–Hellman based key exchange algorithms
+            # Enabling Diffie–Hellman based key exchange algorithms
 
-# TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
-# must be already available by default according to Microsoft Docs but it isn't, on Windows 11 insider dev build 25272
-# https://learn.microsoft.com/en-us/windows/win32/secauthn/tls-cipher-suites-in-windows-11
-Enable-TlsCipherSuite -Name "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256"
-
-
-
-# TLS_DHE_RSA_WITH_AES_128_CBC_SHA
-# Not enabled by default on Windows 11 according to the Microsoft Docs above
-Enable-TlsCipherSuite -Name "TLS_DHE_RSA_WITH_AES_128_CBC_SHA"
-
-
-# TLS_DHE_RSA_WITH_AES_256_CBC_SHA
-# Not enabled by default on Windows 11 according to the Microsoft Docs above
-Enable-TlsCipherSuite -Name "TLS_DHE_RSA_WITH_AES_256_CBC_SHA"
+            # TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
+            # must be already available by default according to Microsoft Docs but it isn't, on Windows 11 insider dev build 25272
+            # https://learn.microsoft.com/en-us/windows/win32/secauthn/tls-cipher-suites-in-windows-11
+            Enable-TlsCipherSuite -Name "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256"
 
 
 
+            # TLS_DHE_RSA_WITH_AES_128_CBC_SHA
+            # Not enabled by default on Windows 11 according to the Microsoft Docs above
+            Enable-TlsCipherSuite -Name "TLS_DHE_RSA_WITH_AES_128_CBC_SHA"
 
 
-# Disabling weak and unsecure ciphers
+            # TLS_DHE_RSA_WITH_AES_256_CBC_SHA
+            # Not enabled by default on Windows 11 according to the Microsoft Docs above
+            Enable-TlsCipherSuite -Name "TLS_DHE_RSA_WITH_AES_256_CBC_SHA"
 
 
-@( # creating these registry keys that have forward slashes in them
-'SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\DES 56/56', # DES 56-bit 
-'SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC2 40/128', # RC2 40-bit
-'SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC2 56/128', # RC2 56-bit
-'SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC2 128/128', # RC2 128-bit
-'SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC4 40/128', # RC4 40-bit
-'SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC4 56/128', # RC4 56-bit
-'SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC4 64/128', # RC4 64-bit
-'SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC4 128/128', # RC4 128-bit
-'SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\Triple DES 168' # 3DES 168-bit (Triple DES 168)
-) | ForEach-Object {
+
+
+
+            # Disabling weak and unsecure ciphers
+
+
+            @( # creating these registry keys that have forward slashes in them
+                'SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\DES 56/56', # DES 56-bit 
+                'SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC2 40/128', # RC2 40-bit
+                'SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC2 56/128', # RC2 56-bit
+                'SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC2 128/128', # RC2 128-bit
+                'SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC4 40/128', # RC4 40-bit
+                'SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC4 56/128', # RC4 56-bit
+                'SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC4 64/128', # RC4 64-bit
+                'SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC4 128/128', # RC4 128-bit
+                'SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\Triple DES 168' # 3DES 168-bit (Triple DES 168)
+            ) | ForEach-Object {
 ([Microsoft.Win32.RegistryKey]::OpenRemoteBaseKey([Microsoft.Win32.RegistryHive]::LocalMachine, $env:COMPUTERNAME)).CreateSubKey($_)
-}
+            }
 
 
-$WeakCiphers = [ordered]@{
-   key1 = @{ #NULL
-        RegName = 'Enabled'
-        RegPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\NULL\'
-        RegValue = '0'
-    }
-    key2 = @{ # DES 56-bit 
-        RegName = 'Enabled'
-        RegPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\DES 56/56'
-        RegValue = '0'
-    }
-    key3 = @{ # RC2 40-bit
-        RegName = 'Enabled'
-        RegPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC2 40/128'
-        RegValue = '0'
-    }
-    key4 = @{ # RC2 56-bit
-        RegName = 'Enabled'
-        RegPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC2 56/128'
-        RegValue = '0'
-    }
-    key5 = @{ # RC2 128-bit
-        RegName = 'Enabled'
-        RegPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC2 128/128'
-        RegValue = '0'
-    }
-    key6 = @{ # RC4 40-bit
-        RegName = 'Enabled'
-        RegPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC4 40/128'
-        RegValue = '0'
-    }
-    key7 = @{ # RC4 56-bit
-        RegName = 'Enabled'
-        RegPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC4 56/128'
-        RegValue = '0'
-    }
-    key8 = @{ # RC4 64-bit
-        RegName = 'Enabled'
-        RegPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC4 64/128'
-        RegValue = '0'
-    }
-    key9 = @{ # RC4 128-bit
-        RegName = 'Enabled'
-        RegPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC4 128/128'
-        RegValue = '0'
-    }
-    key10 = @{ # 3DES 168-bit (Triple DES 168)
-        RegName = 'Enabled'
-        RegPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\Triple DES 168'
-        RegValue = '0'
-    }
-    key11 = @{ # Disable MD5 Hashing Algorithm
-        RegName = 'Enabled'
-        RegPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Hashes\MD5'
-        RegValue = '0'
-    }
+            $WeakCiphers = [ordered]@{
+                key1  = @{ #NULL
+                    RegName  = 'Enabled'
+                    RegPath  = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\NULL\'
+                    RegValue = '0'
+                }
+                key2  = @{ # DES 56-bit 
+                    RegName  = 'Enabled'
+                    RegPath  = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\DES 56/56'
+                    RegValue = '0'
+                }
+                key3  = @{ # RC2 40-bit
+                    RegName  = 'Enabled'
+                    RegPath  = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC2 40/128'
+                    RegValue = '0'
+                }
+                key4  = @{ # RC2 56-bit
+                    RegName  = 'Enabled'
+                    RegPath  = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC2 56/128'
+                    RegValue = '0'
+                }
+                key5  = @{ # RC2 128-bit
+                    RegName  = 'Enabled'
+                    RegPath  = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC2 128/128'
+                    RegValue = '0'
+                }
+                key6  = @{ # RC4 40-bit
+                    RegName  = 'Enabled'
+                    RegPath  = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC4 40/128'
+                    RegValue = '0'
+                }
+                key7  = @{ # RC4 56-bit
+                    RegName  = 'Enabled'
+                    RegPath  = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC4 56/128'
+                    RegValue = '0'
+                }
+                key8  = @{ # RC4 64-bit
+                    RegName  = 'Enabled'
+                    RegPath  = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC4 64/128'
+                    RegValue = '0'
+                }
+                key9  = @{ # RC4 128-bit
+                    RegName  = 'Enabled'
+                    RegPath  = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC4 128/128'
+                    RegValue = '0'
+                }
+                key10 = @{ # 3DES 168-bit (Triple DES 168)
+                    RegName  = 'Enabled'
+                    RegPath  = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\Triple DES 168'
+                    RegValue = '0'
+                }
+                key11 = @{ # Disable MD5 Hashing Algorithm
+                    RegName  = 'Enabled'
+                    RegPath  = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Hashes\MD5'
+                    RegValue = '0'
+                }
     
-}
+            }
 
-# Disabling Weak Ciphers and MD5 Hashing Algorithm
-ModifyRegistry -HashTable $WeakCiphers
-
-
-} "No" { break }
-"Exit" { exit }
-}
-# =========================================================================================================================
-# ==========================================End of TLS Security============================================================
-# =========================================================================================================================
-#endregion TLS-Security
+            # Disabling Weak Ciphers and MD5 Hashing Algorithm
+            ModifyRegistry -HashTable $WeakCiphers
 
 
-
-
-
-#region Windows-Firewall
-# =========================================================================================================================
-# ====================================================Windows Firewall=====================================================
-# =========================================================================================================================
-switch (Select-Option -Options "Yes", "No", "Exit" -Message "Run Windows Firewall category ?")
-{  "Yes"  {
-
-
-# Disables Multicast DNS (mDNS) UDP-in Firewall Rules for all 3 Firewall profiles - disables only 3 rules
-get-NetFirewallRule |
-Where-Object {$_.RuleGroup -eq "@%SystemRoot%\system32\firewallapi.dll,-37302" -and $_.Direction -eq "inbound" } |
-ForEach-Object {Disable-NetFirewallRule -DisplayName $_.DisplayName}
-
-
-
-} "No" { break }
-"Exit" { exit }
-}
-# =========================================================================================================================
-# =================================================End of Windows Firewall=================================================
-# =========================================================================================================================
-#endregion Windows-Firewall
-
-
-
-
-#region Optional-Windows-Features
-# =========================================================================================================================
-# =================================================Optional Windows Features===============================================
-# =========================================================================================================================
-switch (Select-Option -Options "Yes", "No", "Exit" -Message "Run Optional Windows Features category ?")
-{  "Yes"  {
-
-
-# since PowerShell Core (only if installed from Microsoft Store) has problem with these commands, making sure the built-in PowerShell handles them
-# There are Github issues for it already: https://github.com/PowerShell/PowerShell/issues/13866
-
-
-# Disable PowerShell v2 (needs 2 commands)
-PowerShell.exe "if((get-WindowsOptionalFeature -Online -FeatureName MicrosoftWindowsPowerShellV2).state -eq 'enabled'){disable-WindowsOptionalFeature -Online -FeatureName MicrosoftWindowsPowerShellV2 -norestart}else{Write-Host 'MicrosoftWindowsPowerShellV2 is already disabled' -ForegroundColor Darkgreen}"
-PowerShell.exe "if((get-WindowsOptionalFeature -Online -FeatureName MicrosoftWindowsPowerShellV2Root).state -eq 'enabled'){disable-WindowsOptionalFeature -Online -FeatureName MicrosoftWindowsPowerShellV2Root -norestart}else{Write-Host 'MicrosoftWindowsPowerShellV2Root is already disabled' -ForegroundColor Darkgreen}"
-
-# Disable Work Folders client
-PowerShell.exe "if((get-WindowsOptionalFeature -Online -FeatureName WorkFolders-Client).state -eq 'enabled'){disable-WindowsOptionalFeature -Online -FeatureName WorkFolders-Client -norestart}else{Write-Host 'WorkFolders-Client is already disabled' -ForegroundColor Darkgreen}"
-
-# Disable Internet Printing Client
-PowerShell.exe "if((get-WindowsOptionalFeature -Online -FeatureName Printing-Foundation-Features).state -eq 'enabled'){disable-WindowsOptionalFeature -Online -FeatureName Printing-Foundation-Features -norestart}else{Write-Host 'Printing-Foundation-Features is already disabled' -ForegroundColor Darkgreen}"
-
-# Disable Windows Media Player (legacy)
-PowerShell.exe "if((get-WindowsOptionalFeature -Online -FeatureName WindowsMediaPlayer).state -eq 'enabled'){disable-WindowsOptionalFeature -Online -FeatureName WindowsMediaPlayer -norestart}else{Write-Host 'WindowsMediaPlayer is already disabled' -ForegroundColor Darkgreen}"
-
-# Enable Windows Defender Application Guard
-PowerShell.exe "if((get-WindowsOptionalFeature -Online -FeatureName Windows-Defender-ApplicationGuard).state -eq 'disabled'){enable-WindowsOptionalFeature -Online -FeatureName Windows-Defender-ApplicationGuard -norestart}else{Write-Host 'Windows-Defender-ApplicationGuard is already enabled' -ForegroundColor Darkgreen}"
-
-# Enable Windows Sandbox
-PowerShell.exe "if((get-WindowsOptionalFeature -Online -FeatureName Containers-DisposableClientVM).state -eq 'disabled'){enable-WindowsOptionalFeature -Online -FeatureName Containers-DisposableClientVM -All -norestart}else{Write-Host 'Containers-DisposableClientVM (Windows Sandbox) is already enabled' -ForegroundColor Darkgreen}"
-
-# Enable Hyper-V
-PowerShell.exe "if((get-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V).state -eq 'disabled'){enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All -norestart}else{Write-Host 'Microsoft-Hyper-V is already enabled' -ForegroundColor Darkgreen}"
-
-# Enable Virtual Machine Platform
-PowerShell.exe "if((get-WindowsOptionalFeature -Online -FeatureName VirtualMachinePlatform).state -eq 'disabled'){enable-WindowsOptionalFeature -Online -FeatureName VirtualMachinePlatform -norestart}else{Write-Host 'VirtualMachinePlatform is already enabled' -ForegroundColor Darkgreen}"
-
-
-
-} "No" { break }
-"Exit" { exit }
-}
-# =========================================================================================================================
-# ==============================================End of Optional Windows Features===========================================
-# =========================================================================================================================
-#endregion Optional-Windows-Features
+        } "No" { break }
+        "Exit" { exit }
+    }
+    # =========================================================================================================================
+    # ==========================================End of TLS Security============================================================
+    # =========================================================================================================================
+    #endregion TLS-Security
 
 
 
 
 
-
-#region Windows-Networking
-# =========================================================================================================================
-# ====================================================Windows Networking===================================================
-# =========================================================================================================================
-switch (Select-Option -Options "Yes", "No", "Exit" -Message "Run Windows Networking category ?")
-{  "Yes"  {
-
+    #region Windows-Firewall
+    # =========================================================================================================================
+    # ====================================================Windows Firewall=====================================================
+    # =========================================================================================================================
+    switch (Select-Option -Options "Yes", "No", "Exit" -Message "Run Windows Firewall category ?") {
+        "Yes" {
 
 
-# disable LMHOSTS lookup protocol on all network adapters
-ModifyRegistry -RegPath 'HKLM:\SYSTEM\CurrentControlSet\Services\NetBT\Parameters' -RegName 'EnableLMHOSTS' -RegValue '0'
-
-# Set the Network Location of all connections to Public
-Get-NetConnectionProfile | Set-NetConnectionProfile -NetworkCategory Public
+            # Disables Multicast DNS (mDNS) UDP-in Firewall Rules for all 3 Firewall profiles - disables only 3 rules
+            get-NetFirewallRule |
+            Where-Object { $_.RuleGroup -eq "@%SystemRoot%\system32\firewallapi.dll,-37302" -and $_.Direction -eq "inbound" } |
+            ForEach-Object { Disable-NetFirewallRule -DisplayName $_.DisplayName }
 
 
 
-# Disable IP Source Routing
-# https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/dd349797(v=ws.10)#disableipsourcerouting
-ModifyRegistry -RegPath 'HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters' -RegName 'DisableIPSourceRouting' -RegValue '2'
+        } "No" { break }
+        "Exit" { exit }
+    }
+    # =========================================================================================================================
+    # =================================================End of Windows Firewall=================================================
+    # =========================================================================================================================
+    #endregion Windows-Firewall
+
+
+
+
+    #region Optional-Windows-Features
+    # =========================================================================================================================
+    # =================================================Optional Windows Features===============================================
+    # =========================================================================================================================
+    switch (Select-Option -Options "Yes", "No", "Exit" -Message "Run Optional Windows Features category ?") {
+        "Yes" {
+
+
+            # since PowerShell Core (only if installed from Microsoft Store) has problem with these commands, making sure the built-in PowerShell handles them
+            # There are Github issues for it already: https://github.com/PowerShell/PowerShell/issues/13866
+
+
+            # Disable PowerShell v2 (needs 2 commands)
+            PowerShell.exe "if((get-WindowsOptionalFeature -Online -FeatureName MicrosoftWindowsPowerShellV2).state -eq 'enabled'){disable-WindowsOptionalFeature -Online -FeatureName MicrosoftWindowsPowerShellV2 -norestart}else{Write-Host 'MicrosoftWindowsPowerShellV2 is already disabled' -ForegroundColor Darkgreen}"
+            PowerShell.exe "if((get-WindowsOptionalFeature -Online -FeatureName MicrosoftWindowsPowerShellV2Root).state -eq 'enabled'){disable-WindowsOptionalFeature -Online -FeatureName MicrosoftWindowsPowerShellV2Root -norestart}else{Write-Host 'MicrosoftWindowsPowerShellV2Root is already disabled' -ForegroundColor Darkgreen}"
+
+            # Disable Work Folders client
+            PowerShell.exe "if((get-WindowsOptionalFeature -Online -FeatureName WorkFolders-Client).state -eq 'enabled'){disable-WindowsOptionalFeature -Online -FeatureName WorkFolders-Client -norestart}else{Write-Host 'WorkFolders-Client is already disabled' -ForegroundColor Darkgreen}"
+
+            # Disable Internet Printing Client
+            PowerShell.exe "if((get-WindowsOptionalFeature -Online -FeatureName Printing-Foundation-Features).state -eq 'enabled'){disable-WindowsOptionalFeature -Online -FeatureName Printing-Foundation-Features -norestart}else{Write-Host 'Printing-Foundation-Features is already disabled' -ForegroundColor Darkgreen}"
+
+            # Disable Windows Media Player (legacy)
+            PowerShell.exe "if((get-WindowsOptionalFeature -Online -FeatureName WindowsMediaPlayer).state -eq 'enabled'){disable-WindowsOptionalFeature -Online -FeatureName WindowsMediaPlayer -norestart}else{Write-Host 'WindowsMediaPlayer is already disabled' -ForegroundColor Darkgreen}"
+
+            # Enable Windows Defender Application Guard
+            PowerShell.exe "if((get-WindowsOptionalFeature -Online -FeatureName Windows-Defender-ApplicationGuard).state -eq 'disabled'){enable-WindowsOptionalFeature -Online -FeatureName Windows-Defender-ApplicationGuard -norestart}else{Write-Host 'Windows-Defender-ApplicationGuard is already enabled' -ForegroundColor Darkgreen}"
+
+            # Enable Windows Sandbox
+            PowerShell.exe "if((get-WindowsOptionalFeature -Online -FeatureName Containers-DisposableClientVM).state -eq 'disabled'){enable-WindowsOptionalFeature -Online -FeatureName Containers-DisposableClientVM -All -norestart}else{Write-Host 'Containers-DisposableClientVM (Windows Sandbox) is already enabled' -ForegroundColor Darkgreen}"
+
+            # Enable Hyper-V
+            PowerShell.exe "if((get-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V).state -eq 'disabled'){enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All -norestart}else{Write-Host 'Microsoft-Hyper-V is already enabled' -ForegroundColor Darkgreen}"
+
+            # Enable Virtual Machine Platform
+            PowerShell.exe "if((get-WindowsOptionalFeature -Online -FeatureName VirtualMachinePlatform).state -eq 'disabled'){enable-WindowsOptionalFeature -Online -FeatureName VirtualMachinePlatform -norestart}else{Write-Host 'VirtualMachinePlatform is already enabled' -ForegroundColor Darkgreen}"
+
+
+
+        } "No" { break }
+        "Exit" { exit }
+    }
+    # =========================================================================================================================
+    # ==============================================End of Optional Windows Features===========================================
+    # =========================================================================================================================
+    #endregion Optional-Windows-Features
 
 
 
 
 
-<#
+
+    #region Windows-Networking
+    # =========================================================================================================================
+    # ====================================================Windows Networking===================================================
+    # =========================================================================================================================
+    switch (Select-Option -Options "Yes", "No", "Exit" -Message "Run Windows Networking category ?") {
+        "Yes" {
+
+
+
+            # disable LMHOSTS lookup protocol on all network adapters
+            ModifyRegistry -RegPath 'HKLM:\SYSTEM\CurrentControlSet\Services\NetBT\Parameters' -RegName 'EnableLMHOSTS' -RegValue '0'
+
+            # Set the Network Location of all connections to Public
+            Get-NetConnectionProfile | Set-NetConnectionProfile -NetworkCategory Public
+
+
+
+            # Disable IP Source Routing
+            # https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/dd349797(v=ws.10)#disableipsourcerouting
+            ModifyRegistry -RegPath 'HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters' -RegName 'DisableIPSourceRouting' -RegValue '2'
+
+
+
+
+
+            <#
 Configure the policy value for Computer Configuration >> Administrative Templates >> MSS (Legacy) >> "MSS: (NoNameReleaseOnDemand) Allow the computer to ignore NetBIOS name release requests except from WINS servers" to "Enabled".
 
 This policy setting requires the installation of the MSS-Legacy custom templates.
@@ -1090,258 +1086,258 @@ This policy setting requires the installation of the MSS-Legacy custom templates
 they are available in Microsoft Security Baselines
 #>
 
-# Allow the computer to ignore NetBIOS name release requests
-ModifyRegistry -RegPath 'HKLM:\SYSTEM\CurrentControlSet\Services\Netbt\Parameters' -RegName 'NoNameReleaseOnDemand' -RegValue '1'
+            # Allow the computer to ignore NetBIOS name release requests
+            ModifyRegistry -RegPath 'HKLM:\SYSTEM\CurrentControlSet\Services\Netbt\Parameters' -RegName 'NoNameReleaseOnDemand' -RegValue '1'
 
 
 
 
-} "No" { break }
-"Exit" { exit }
-}
-# =========================================================================================================================
-# =================================================End of Windows Networking===============================================
-# =========================================================================================================================
-#endregion Windows-Networking
-
-
-
-
-#region Miscellaneous-Configurations
-# =========================================================================================================================
-# ==============================================Miscellaneous Configurations===============================================
-# =========================================================================================================================
-switch (Select-Option -Options "Yes", "No", "Exit" -Message "Run Miscellaneous Configurations category ?")
-{  "Yes"  {
-
-
-
-# Set Hibnernate mode to full
-powercfg /h /type full
-
-# Enable Mandatory ASLR
-set-processmitigation -System -Enable ForceRelocateImages
-
-# You can add Mandatory ASLR override for a Trusted app using the command below or in the Program Settings section of Exploit Protection in Windows Defender app. 
-# Set-ProcessMitigation -Name "C:\TrustedApp.exe" -Disable ForceRelocateImages
-
-# Turn on Enhanced mode search for Windows indexer
-ModifyRegistry -RegPath 'HKLM:\SOFTWARE\Microsoft\Windows Search' -RegName 'EnableFindMyFiles' -RegValue '1'
-
-# Enable SMB Encryption - using force to confirm the action
-Set-SmbServerConfiguration -EncryptData $true -force
-
-# Set Microsoft Edge to update over Metered connections
-ModifyRegistry -RegPath 'HKLM:\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\ClientStateMedium\{56EB18F8-B008-4CBD-B6D2-8C97FE7E9062}' -RegName 'allowautoupdatesmetered' -RegValue '1'
-
-# Enable notify me when a restart is required to finish updating
-ModifyRegistry -RegPath 'HKLM:\SOFTWARE\Microsoft\WindowsUpdate\UX\Settings' -RegName 'RestartNotificationsAllowed2' -RegValue '1'
-
-# Allow all Windows users to use Hyper-V and Windows Sandbox by adding all Windows users to the "Hyper-V Administrators" security group
-Get-LocalUser | Where-Object{$_.enabled -EQ "True"} | Select-Object "Name" |
-ForEach-Object {Add-LocalGroupMember -Group "Hyper-V Administrators" -Member $_.Name -ErrorAction SilentlyContinue}
-
-# Change Windows time sync interval from every 7 days to every 4 days (= every 345600 seconds)
-ModifyRegistry -RegPath 'HKLM:\SYSTEM\ControlSet001\Services\W32Time\TimeProviders\NtpClient' -RegName 'SpecialPollInterval' -RegValue '345600'
-
-
-
-
-} "No" { break }
-"Exit" { exit }
-}
-# =========================================================================================================================
-# ============================================End of Miscellaneous Configurations==========================================
-# =========================================================================================================================
-#endregion Miscellaneous-Configurations
-
-
-
-
-#region Certificate-Checking-Commands
-# =========================================================================================================================
-# ====================================================Certificate Checking Commands========================================
-# =========================================================================================================================
-switch (Select-Option -Options "Yes", "No", "Exit" -Message "Run Certificate Checking category ?")
-{  "Yes"  {
-
-
-
-      # List valid certificates not rooted to the Microsoft Certificate Trust List in the User store
-      switch (Select-Option -Options "Yes", "No", "Exit" -Message "List valid certificates not rooted to the Microsoft Certificate Trust List in the User store ?")
-      {  "Yes"  {
-
-
-        try {      
-        \\live.sysinternals.com\tools\sigcheck64.exe -tuv -accepteula -nobanner
-        }
-        catch {
-
-            Invoke-WebRequest -Uri "https://live.sysinternals.com/sigcheck64.exe" -OutFile "sigcheck64.exe"
-            .\sigcheck64.exe -tuv -accepteula -nobanner
-            Remove-Item .\sigcheck64.exe
-        }
-
-
-
-
-    } "No" { break }
-    "Exit" { exit }
+        } "No" { break }
+        "Exit" { exit }
     }
+    # =========================================================================================================================
+    # =================================================End of Windows Networking===============================================
+    # =========================================================================================================================
+    #endregion Windows-Networking
+
+
+
+
+    #region Miscellaneous-Configurations
+    # =========================================================================================================================
+    # ==============================================Miscellaneous Configurations===============================================
+    # =========================================================================================================================
+    switch (Select-Option -Options "Yes", "No", "Exit" -Message "Run Miscellaneous Configurations category ?") {
+        "Yes" {
+
+
+
+            # Set Hibnernate mode to full
+            powercfg /h /type full
+
+            # Enable Mandatory ASLR
+            set-processmitigation -System -Enable ForceRelocateImages
+
+            # You can add Mandatory ASLR override for a Trusted app using the command below or in the Program Settings section of Exploit Protection in Windows Defender app. 
+            # Set-ProcessMitigation -Name "C:\TrustedApp.exe" -Disable ForceRelocateImages
+
+            # Turn on Enhanced mode search for Windows indexer
+            ModifyRegistry -RegPath 'HKLM:\SOFTWARE\Microsoft\Windows Search' -RegName 'EnableFindMyFiles' -RegValue '1'
+
+            # Enable SMB Encryption - using force to confirm the action
+            Set-SmbServerConfiguration -EncryptData $true -force
+
+            # Set Microsoft Edge to update over Metered connections
+            ModifyRegistry -RegPath 'HKLM:\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\ClientStateMedium\{56EB18F8-B008-4CBD-B6D2-8C97FE7E9062}' -RegName 'allowautoupdatesmetered' -RegValue '1'
+
+            # Enable notify me when a restart is required to finish updating
+            ModifyRegistry -RegPath 'HKLM:\SOFTWARE\Microsoft\WindowsUpdate\UX\Settings' -RegName 'RestartNotificationsAllowed2' -RegValue '1'
+
+            # Allow all Windows users to use Hyper-V and Windows Sandbox by adding all Windows users to the "Hyper-V Administrators" security group
+            Get-LocalUser | Where-Object { $_.enabled -EQ "True" } | Select-Object "Name" |
+            ForEach-Object { Add-LocalGroupMember -Group "Hyper-V Administrators" -Member $_.Name -ErrorAction SilentlyContinue }
+
+            # Change Windows time sync interval from every 7 days to every 4 days (= every 345600 seconds)
+            ModifyRegistry -RegPath 'HKLM:\SYSTEM\ControlSet001\Services\W32Time\TimeProviders\NtpClient' -RegName 'SpecialPollInterval' -RegValue '345600'
+
+
+
+
+        } "No" { break }
+        "Exit" { exit }
+    }
+    # =========================================================================================================================
+    # ============================================End of Miscellaneous Configurations==========================================
+    # =========================================================================================================================
+    #endregion Miscellaneous-Configurations
+
+
+
+
+    #region Certificate-Checking-Commands
+    # =========================================================================================================================
+    # ====================================================Certificate Checking Commands========================================
+    # =========================================================================================================================
+    switch (Select-Option -Options "Yes", "No", "Exit" -Message "Run Certificate Checking category ?") {
+        "Yes" {
+
+
+
+            # List valid certificates not rooted to the Microsoft Certificate Trust List in the User store
+            switch (Select-Option -Options "Yes", "No", "Exit" -Message "List valid certificates not rooted to the Microsoft Certificate Trust List in the User store ?") {
+                "Yes" {
+
+
+                    try {      
+                        \\live.sysinternals.com\tools\sigcheck64.exe -tuv -accepteula -nobanner
+                    }
+                    catch {
+
+                        Invoke-WebRequest -Uri "https://live.sysinternals.com/sigcheck64.exe" -OutFile "sigcheck64.exe"
+                        .\sigcheck64.exe -tuv -accepteula -nobanner
+                        Remove-Item .\sigcheck64.exe
+                    }
+
+
+
+
+                } "No" { break }
+                "Exit" { exit }
+            }
 
 
 
       
 
-      # List valid certificates not rooted to the Microsoft Certificate Trust List in the Machine store
-      switch (Select-Option -Options "Yes", "No", "Exit" -Message "List valid certificates not rooted to the Microsoft Certificate Trust List in the Machine store ?")
-      {  "Yes"  {
+            # List valid certificates not rooted to the Microsoft Certificate Trust List in the Machine store
+            switch (Select-Option -Options "Yes", "No", "Exit" -Message "List valid certificates not rooted to the Microsoft Certificate Trust List in the Machine store ?") {
+                "Yes" {
 
 
-        try {
+                    try {
         
-        \\live.sysinternals.com\tools\sigcheck64.exe -tv -accepteula -nobanner
-        }
+                        \\live.sysinternals.com\tools\sigcheck64.exe -tv -accepteula -nobanner
+                    }
 
-        catch {
-            Invoke-WebRequest -Uri "https://live.sysinternals.com/sigcheck64.exe" -OutFile "sigcheck64.exe"
-            .\sigcheck64.exe -tv -accepteula -nobanner
-            Remove-Item .\sigcheck64.exe
-        }
+                    catch {
+                        Invoke-WebRequest -Uri "https://live.sysinternals.com/sigcheck64.exe" -OutFile "sigcheck64.exe"
+                        .\sigcheck64.exe -tv -accepteula -nobanner
+                        Remove-Item .\sigcheck64.exe
+                    }
 
 
 
-    } "No" { break }
-    "Exit" { exit }
+                } "No" { break }
+                "Exit" { exit }
+            }
+
+
+
+
+
+
+        } "No" { break }
+        "Exit" { exit }
     }
+    # =========================================================================================================================
+    # ====================================================End of Certificate Checking Commands=================================
+    # =========================================================================================================================
+    #endregion Certificate-Checking-Commands
 
 
 
 
-
-
-} "No" { break }
-"Exit" { exit }
-}
-# =========================================================================================================================
-# ====================================================End of Certificate Checking Commands=================================
-# =========================================================================================================================
-#endregion Certificate-Checking-Commands
+    #region Country-IP-Blocking
+    # =========================================================================================================================
+    # ====================================================Country IP Blocking==================================================
+    # =========================================================================================================================
+    switch (Select-Option -Options "Yes", "No", "Exit" -Message "Run Country IP Blocking category ?") {
+        "Yes" {
 
 
 
+            # -RemoteAddress in New-NetFirewallRule accepts array according to Microsoft Docs, 
+            # so we use "[string[]]$IPList = $IPList -split '\r?\n' -ne ''" to convert the IP lists, which is a single multiline string, into an array
 
-#region Country-IP-Blocking
-# =========================================================================================================================
-# ====================================================Country IP Blocking==================================================
-# =========================================================================================================================
-switch (Select-Option -Options "Yes", "No", "Exit" -Message "Run Country IP Blocking category ?")
-{  "Yes"  {
+            function BlockCountryIP {
+                param ($IPList , $CountryName)
 
+                # checks if the rule is present and if it is, deletes them to get new up-to-date IP ranges from the sources
+                if (Get-NetFirewallRule -DisplayName "$CountryName IP range blocking" 2> $null) 
+                { Remove-NetFirewallRule -DisplayName "$CountryName IP range blocking" }
 
+                # converts the list which is in string into array
+                [string[]]$IPList = $IPList -split '\r?\n' -ne ''
 
-# -RemoteAddress in New-NetFirewallRule accepts array according to Microsoft Docs, 
-# so we use "[string[]]$IPList = $IPList -split '\r?\n' -ne ''" to convert the IP lists, which is a single multiline string, into an array
-
-function BlockCountryIP {
-    param ($IPList , $CountryName)
-
-    # checks if the rule is present and if it is, deletes them to get new up-to-date IP ranges from the sources
-    if (Get-NetFirewallRule -DisplayName "$CountryName IP range blocking" 2> $null) 
-    {Remove-NetFirewallRule -DisplayName "$CountryName IP range blocking" }
-
-    # converts the list which is in string into array
-    [string[]]$IPList = $IPList -split '\r?\n' -ne ''
-
-    # makes sure the list isn't empty
-    if ($IPList.count -eq 0) { Write-Host "The IP list was empty, skipping $CountryName" -ForegroundColor Yellow ; break }
+                # makes sure the list isn't empty
+                if ($IPList.count -eq 0) { Write-Host "The IP list was empty, skipping $CountryName" -ForegroundColor Yellow ; break }
 
       
-    New-NetFirewallRule -DisplayName "$CountryName IP range blocking" -Direction Inbound -Action Block -LocalAddress Any -RemoteAddress $IPList -Description "$CountryName IP range blocking" -Profile Any -InterfaceType Any -Group "Hardening-Script-CountryIP-Blocking" -EdgeTraversalPolicy Block
-    New-NetFirewallRule -DisplayName "$CountryName IP range blocking" -Direction Outbound -Action Block -LocalAddress Any -RemoteAddress $IPList -Description "$CountryName IP range blocking" -Profile Any -InterfaceType Any -Group "Hardening-Script-CountryIP-Blocking" -EdgeTraversalPolicy Block
+                New-NetFirewallRule -DisplayName "$CountryName IP range blocking" -Direction Inbound -Action Block -LocalAddress Any -RemoteAddress $IPList -Description "$CountryName IP range blocking" -Profile Any -InterfaceType Any -Group "Hardening-Script-CountryIP-Blocking" -EdgeTraversalPolicy Block
+                New-NetFirewallRule -DisplayName "$CountryName IP range blocking" -Direction Outbound -Action Block -LocalAddress Any -RemoteAddress $IPList -Description "$CountryName IP range blocking" -Profile Any -InterfaceType Any -Group "Hardening-Script-CountryIP-Blocking" -EdgeTraversalPolicy Block
         
-}
+            }
 
 
 
 
-# Iran
-switch (Select-Option -Options "Yes", "No", "Exit" -Message "Block the entire range of IPv4 and IPv6 belonging to Iran?")
-{  "Yes"  {
+            # Iran
+            switch (Select-Option -Options "Yes", "No", "Exit" -Message "Block the entire range of IPv4 and IPv6 belonging to Iran?") {
+                "Yes" {
     
-    $IranIPv4 = Invoke-RestMethod -Uri "https://www.ipdeny.com/ipblocks/data/aggregated/ir-aggregated.zone"
-    $IranIPv6 = Invoke-RestMethod -Uri "https://www.ipdeny.com/ipv6/ipaddresses/blocks/ir.zone"
-    $IranIPRange = $IranIPv4 + $IranIPv6
-    BlockCountryIP -IPList $IranIPRange -CountryName "Iran"
+                    $IranIPv4 = Invoke-RestMethod -Uri "https://www.ipdeny.com/ipblocks/data/aggregated/ir-aggregated.zone"
+                    $IranIPv6 = Invoke-RestMethod -Uri "https://www.ipdeny.com/ipv6/ipaddresses/blocks/ir.zone"
+                    $IranIPRange = $IranIPv4 + $IranIPv6
+                    BlockCountryIP -IPList $IranIPRange -CountryName "Iran"
 
-} "No" { break }
-"Exit" { exit }
-}
-
-
-
-
-# Cuba
-switch (Select-Option -Options "Yes", "No", "Exit" -Message "Block the entire range of IPv4 and IPv6 belonging to Cuba?")
-{  "Yes"  {
-
-    $CubaIPv4 = Invoke-RestMethod -Uri "https://www.ipdeny.com/ipblocks/data/aggregated/cu-aggregated.zone"
-    $CubaIPv6 = Invoke-RestMethod -Uri "https://www.ipdeny.com/ipv6/ipaddresses/blocks/cu.zone"
-    $CubaIPRange = $CubaIPv4 + $CubaIPv6
-    BlockCountryIP -IPList $CubaIPRange -CountryName "Cuba"
-
-} "No" { break }
-"Exit" { exit }
-}
+                } "No" { break }
+                "Exit" { exit }
+            }
 
 
 
 
-# North Korea
-switch (Select-Option -Options "Yes", "No", "Exit" -Message "Block the entire range of IPv4 and IPv6 belonging to North Korea?")
-{  "Yes"  {
+            # Cuba
+            switch (Select-Option -Options "Yes", "No", "Exit" -Message "Block the entire range of IPv4 and IPv6 belonging to Cuba?") {
+                "Yes" {
+
+                    $CubaIPv4 = Invoke-RestMethod -Uri "https://www.ipdeny.com/ipblocks/data/aggregated/cu-aggregated.zone"
+                    $CubaIPv6 = Invoke-RestMethod -Uri "https://www.ipdeny.com/ipv6/ipaddresses/blocks/cu.zone"
+                    $CubaIPRange = $CubaIPv4 + $CubaIPv6
+                    BlockCountryIP -IPList $CubaIPRange -CountryName "Cuba"
+
+                } "No" { break }
+                "Exit" { exit }
+            }
+
+
+
+
+            # North Korea
+            switch (Select-Option -Options "Yes", "No", "Exit" -Message "Block the entire range of IPv4 and IPv6 belonging to North Korea?") {
+                "Yes" {
     
-    $NorthKoreaIPv4 = Invoke-RestMethod -Uri "https://www.ipdeny.com/ipblocks/data/aggregated/kp-aggregated.zone"
-    $NorthKoreaIPv6 = Invoke-RestMethod -Uri "https://www.ipdeny.com/ipv6/ipaddresses/blocks/kn.zone"
-    $NorthKoreaIPRange = $NorthKoreaIPv4 + $NorthKoreaIPv6
-    BlockCountryIP -IPList $NorthKoreaIPRange -CountryName "North Korea"
+                    $NorthKoreaIPv4 = Invoke-RestMethod -Uri "https://www.ipdeny.com/ipblocks/data/aggregated/kp-aggregated.zone"
+                    $NorthKoreaIPv6 = Invoke-RestMethod -Uri "https://www.ipdeny.com/ipv6/ipaddresses/blocks/kn.zone"
+                    $NorthKoreaIPRange = $NorthKoreaIPv4 + $NorthKoreaIPv6
+                    BlockCountryIP -IPList $NorthKoreaIPRange -CountryName "North Korea"
 
-} "No" { break }
-"Exit" { exit }
-}
+                } "No" { break }
+                "Exit" { exit }
+            }
 
 
 
-# Syria
-switch (Select-Option -Options "Yes", "No", "Exit" -Message "Block the entire range of IPv4 and IPv6 belonging to Syria?")
-{  "Yes"  {
+            # Syria
+            switch (Select-Option -Options "Yes", "No", "Exit" -Message "Block the entire range of IPv4 and IPv6 belonging to Syria?") {
+                "Yes" {
     
-    $SyriaIPv4 = Invoke-RestMethod -Uri "https://www.ipdeny.com/ipblocks/data/aggregated/sy-aggregated.zone"
-    $SyriaIPv6 = Invoke-RestMethod -Uri "https://www.ipdeny.com/ipv6/ipaddresses/blocks/sy.zone"
-    $SyriaIPRange = $SyriaIPv4 + $SyriaIPv6
-    BlockCountryIP -IPList $SyriaIPRange -CountryName "Syria"
+                    $SyriaIPv4 = Invoke-RestMethod -Uri "https://www.ipdeny.com/ipblocks/data/aggregated/sy-aggregated.zone"
+                    $SyriaIPv6 = Invoke-RestMethod -Uri "https://www.ipdeny.com/ipv6/ipaddresses/blocks/sy.zone"
+                    $SyriaIPRange = $SyriaIPv4 + $SyriaIPv6
+                    BlockCountryIP -IPList $SyriaIPRange -CountryName "Syria"
 
-} "No" { break }
-"Exit" { exit }
-}
+                } "No" { break }
+                "Exit" { exit }
+            }
 
 
 
-# how to query the number of IPs in each rule
-# (Get-NetFirewallRule -DisplayName "Cuba IP range blocking" | Get-NetFirewallAddressFilter).RemoteAddress.count
+            # how to query the number of IPs in each rule
+            # (Get-NetFirewallRule -DisplayName "Cuba IP range blocking" | Get-NetFirewallAddressFilter).RemoteAddress.count
 
 
 
 
         
 
-} "No" { break }
-"Exit" { exit }
-}
-# =========================================================================================================================
-# ====================================================End of Country IP Blocking===========================================
-# =========================================================================================================================
-#endregion Country-IP-Blocking
+        } "No" { break }
+        "Exit" { exit }
+    }
+    # =========================================================================================================================
+    # ====================================================End of Country IP Blocking===========================================
+    # =========================================================================================================================
+    #endregion Country-IP-Blocking
 
 
 
@@ -1354,143 +1350,143 @@ switch (Select-Option -Options "Yes", "No", "Exit" -Message "Block the entire ra
 # =========================================================================================================================
 # ====================================================Non-Admin Commands===================================================
 # =========================================================================================================================
-switch (Select-Option -Options "Yes", "No", "Exit" -Message "Run Non-Admin category ?")
-{  "Yes"  {
+switch (Select-Option -Options "Yes", "No", "Exit" -Message "Run Non-Admin category ?") {
+    "Yes" {
 
 
-# Show known file extensions in File explorer
-ModifyRegistry -RegPath 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -RegName 'HideFileExt' -RegValue '0'
+        # Show known file extensions in File explorer
+        ModifyRegistry -RegPath 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -RegName 'HideFileExt' -RegValue '0'
 
-# Show hidden files, folders and drives (toggles the control panel folder options item)
-ModifyRegistry -RegPath 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -RegName 'Hidden' -RegValue '1'
+        # Show hidden files, folders and drives (toggles the control panel folder options item)
+        ModifyRegistry -RegPath 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -RegName 'Hidden' -RegValue '1'
 
-# Disable websites accessing local language list
-ModifyRegistry -RegPath 'HKCU:\Control Panel\International\User Profile' -RegName 'HttpAcceptLanguageOptOut' -RegValue '1'
+        # Disable websites accessing local language list
+        ModifyRegistry -RegPath 'HKCU:\Control Panel\International\User Profile' -RegName 'HttpAcceptLanguageOptOut' -RegValue '1'
 
-# turn off safe search in Windows search. from Windows settings > privacy and security > search permissions > safe search
-ModifyRegistry -RegPath 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\SearchSettings' -RegName 'SafeSearchMode' -RegValue '0'
+        # turn off safe search in Windows search. from Windows settings > privacy and security > search permissions > safe search
+        ModifyRegistry -RegPath 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\SearchSettings' -RegName 'SafeSearchMode' -RegValue '0'
 
-# prevent showing notifications in Lock screen - this is the same as toggling the button in Windows settings > system > notifications > show notifications in the lock screen
-ModifyRegistry -RegPath 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Notifications\Settings' -RegName 'NOC_GLOBAL_SETTING_ALLOW_TOASTS_ABOVE_LOCK' -RegValue '0'
+        # prevent showing notifications in Lock screen - this is the same as toggling the button in Windows settings > system > notifications > show notifications in the lock screen
+        ModifyRegistry -RegPath 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Notifications\Settings' -RegName 'NOC_GLOBAL_SETTING_ALLOW_TOASTS_ABOVE_LOCK' -RegValue '0'
 
-# prevent showing notifications in Lock screen, 2nd reg key - this is the same as toggling the button in Windows settings > system > notifications > show notifications in the lock screen
-ModifyRegistry -RegPath 'HKCU:\Software\Microsoft\Windows\CurrentVersion\PushNotifications' -RegName 'LockScreenToastEnabled' -RegValue '0'
+        # prevent showing notifications in Lock screen, 2nd reg key - this is the same as toggling the button in Windows settings > system > notifications > show notifications in the lock screen
+        ModifyRegistry -RegPath 'HKCU:\Software\Microsoft\Windows\CurrentVersion\PushNotifications' -RegName 'LockScreenToastEnabled' -RegValue '0'
 
-# Enable Clipboard History for the current user
-ModifyRegistry -RegPath 'HKCU:\Software\Microsoft\Clipboard' -RegName 'EnableClipboardHistory' -RegValue '1'
+        # Enable Clipboard History for the current user
+        ModifyRegistry -RegPath 'HKCU:\Software\Microsoft\Clipboard' -RegName 'EnableClipboardHistory' -RegValue '1'
 
-# 2 commands to enable sync of Clipboard history in Windows between devices
-ModifyRegistry -RegPath 'HKCU:\Software\Microsoft\Clipboard' -RegName 'CloudClipboardAutomaticUpload' -RegValue '1'
+        # 2 commands to enable sync of Clipboard history in Windows between devices
+        ModifyRegistry -RegPath 'HKCU:\Software\Microsoft\Clipboard' -RegName 'CloudClipboardAutomaticUpload' -RegValue '1'
 
-# last one, to enable Clipboard sync
-ModifyRegistry -RegPath 'HKCU:\Software\Microsoft\Clipboard' -RegName 'EnableCloudClipboard' -RegValue '1'
-
-
+        # last one, to enable Clipboard sync
+        ModifyRegistry -RegPath 'HKCU:\Software\Microsoft\Clipboard' -RegName 'EnableCloudClipboard' -RegValue '1'
 
 
-# creates Custom Views for Event Viewer in "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\"
-# Event Viewer custom views are saved in "C:\ProgramData\Microsoft\Event Viewer\Views". files in there can be backed up and restored on new Windows installations.
 
-# attack surface reduction rules events
-$path_0 = "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\View_0.xml"
-if (-NOT (Test-Path $path_0)) {
-New-Item -Path $path_0 -ItemType File -Force
 
-$View_0 =
-@"
+        # creates Custom Views for Event Viewer in "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\"
+        # Event Viewer custom views are saved in "C:\ProgramData\Microsoft\Event Viewer\Views". files in there can be backed up and restored on new Windows installations.
+
+        # attack surface reduction rules events
+        $path_0 = "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\View_0.xml"
+        if (-NOT (Test-Path $path_0)) {
+            New-Item -Path $path_0 -ItemType File -Force
+
+            $View_0 =
+            @"
 <ViewerConfig><QueryConfig><QueryParams><UserQuery /></QueryParams><QueryNode><Name LanguageNeutralValue="attack surface reduction rule events">attack surface reduction rule events</Name><QueryList><Query Id="0" Path="Microsoft-Windows-Windows Defender/Operational"><Select Path="Microsoft-Windows-Windows Defender/Operational">*[System[(EventID=1121 or EventID=1122 or EventID=5007)]]</Select><Select Path="Microsoft-Windows-Windows Defender/WHC">*[System[(EventID=1121 or EventID=1122 or EventID=5007)]]</Select></Query></QueryList></QueryNode></QueryConfig><ResultsConfig><Columns><Column Name="Level" Type="System.String" Path="Event/System/Level" Visible="">111</Column><Column Name="Keywords" Type="System.String" Path="Event/System/Keywords">70</Column><Column Name="Date and Time" Type="System.DateTime" Path="Event/System/TimeCreated/@SystemTime" Visible="">190</Column><Column Name="Source" Type="System.String" Path="Event/System/Provider/@Name" Visible="">215</Column><Column Name="Event ID" Type="System.UInt32" Path="Event/System/EventID" Visible="">124</Column><Column Name="Task Category" Type="System.String" Path="Event/System/Task" Visible="">74</Column><Column Name="User" Type="System.String" Path="Event/System/Security/@UserID">50</Column><Column Name="Operational Code" Type="System.String" Path="Event/System/Opcode">110</Column><Column Name="Log" Type="System.String" Path="Event/System/Channel">80</Column><Column Name="Computer" Type="System.String" Path="Event/System/Computer">170</Column><Column Name="Process ID" Type="System.UInt32" Path="Event/System/Execution/@ProcessID">70</Column><Column Name="Thread ID" Type="System.UInt32" Path="Event/System/Execution/@ThreadID">70</Column><Column Name="Processor ID" Type="System.UInt32" Path="Event/System/Execution/@ProcessorID">90</Column><Column Name="Session ID" Type="System.UInt32" Path="Event/System/Execution/@SessionID">70</Column><Column Name="Kernel Time" Type="System.UInt32" Path="Event/System/Execution/@KernelTime">80</Column><Column Name="User Time" Type="System.UInt32" Path="Event/System/Execution/@UserTime">70</Column><Column Name="Processor Time" Type="System.UInt32" Path="Event/System/Execution/@ProcessorTime">100</Column><Column Name="Correlation Id" Type="System.Guid" Path="Event/System/Correlation/@ActivityID">85</Column><Column Name="Relative Correlation Id" Type="System.Guid" Path="Event/System/Correlation/@RelatedActivityID">140</Column><Column Name="Event Source Name" Type="System.String" Path="Event/System/Provider/@EventSourceName">140</Column></Columns></ResultsConfig></ViewerConfig>
 "@
-Add-Content -Path "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\View_0.xml" -Value $View_0
-}
+            Add-Content -Path "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\View_0.xml" -Value $View_0
+        }
 
-# controlled folder access events
-$path_1 = "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\View_1.xml"
-if (-NOT (Test-Path $path_1)) {
-New-Item -Path $path_1 -ItemType File
+        # controlled folder access events
+        $path_1 = "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\View_1.xml"
+        if (-NOT (Test-Path $path_1)) {
+            New-Item -Path $path_1 -ItemType File
 
-$View_1 =
-@"
+            $View_1 =
+            @"
 <ViewerConfig><QueryConfig><QueryParams><UserQuery /></QueryParams><QueryNode><Name LanguageNeutralValue="controlled folder access events">controlled folder access events</Name><QueryList><Query Id="0" Path="Microsoft-Windows-Windows Defender/Operational"><Select Path="Microsoft-Windows-Windows Defender/Operational">*[System[(EventID=1123 or EventID=1124 or EventID=5007)]]</Select><Select Path="Microsoft-Windows-Windows Defender/WHC">*[System[(EventID=1123 or EventID=1124 or EventID=5007)]]</Select></Query></QueryList></QueryNode></QueryConfig></ViewerConfig>
 "@
-Add-Content -Path "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\View_1.xml" -Value $View_1
-}
-# exploit protection events
-$path_2 = "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\View_2.xml"
-if (-NOT (Test-Path $path_2)) {
-New-Item -Path $path_2 -ItemType File
+            Add-Content -Path "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\View_1.xml" -Value $View_1
+        }
+        # exploit protection events
+        $path_2 = "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\View_2.xml"
+        if (-NOT (Test-Path $path_2)) {
+            New-Item -Path $path_2 -ItemType File
 
-$View_2 =
-@"
+            $View_2 =
+            @"
 <ViewerConfig><QueryConfig><QueryParams><UserQuery /></QueryParams><QueryNode><Name LanguageNeutralValue="exploit protection events">exploit protection events</Name><SortConfig Asc="0"><Column Name="Date and Time" Type="System.DateTime" Path="Event/System/TimeCreated/@SystemTime" Visible="">275</Column></SortConfig><QueryList><Query Id="0" Path="Microsoft-Windows-Security-Mitigations/KernelMode"><Select Path="Microsoft-Windows-Security-Mitigations/KernelMode">*[System[Provider[@Name='Microsoft-Windows-Security-Mitigations' or @Name='Microsoft-Windows-WER-Diag' or @Name='Microsoft-Windows-Win32k' or @Name='Win32k'] and ( (EventID &gt;= 1 and EventID &lt;= 24)  or EventID=5 or EventID=260)]]</Select><Select Path="Microsoft-Windows-Win32k/Concurrency">*[System[Provider[@Name='Microsoft-Windows-Security-Mitigations' or @Name='Microsoft-Windows-WER-Diag' or @Name='Microsoft-Windows-Win32k' or @Name='Win32k'] and ( (EventID &gt;= 1 and EventID &lt;= 24)  or EventID=5 or EventID=260)]]</Select><Select Path="Microsoft-Windows-Win32k/Contention">*[System[Provider[@Name='Microsoft-Windows-Security-Mitigations' or @Name='Microsoft-Windows-WER-Diag' or @Name='Microsoft-Windows-Win32k' or @Name='Win32k'] and ( (EventID &gt;= 1 and EventID &lt;= 24)  or EventID=5 or EventID=260)]]</Select><Select Path="Microsoft-Windows-Win32k/Messages">*[System[Provider[@Name='Microsoft-Windows-Security-Mitigations' or @Name='Microsoft-Windows-WER-Diag' or @Name='Microsoft-Windows-Win32k' or @Name='Win32k'] and ( (EventID &gt;= 1 and EventID &lt;= 24)  or EventID=5 or EventID=260)]]</Select><Select Path="Microsoft-Windows-Win32k/Operational">*[System[Provider[@Name='Microsoft-Windows-Security-Mitigations' or @Name='Microsoft-Windows-WER-Diag' or @Name='Microsoft-Windows-Win32k' or @Name='Win32k'] and ( (EventID &gt;= 1 and EventID &lt;= 24)  or EventID=5 or EventID=260)]]</Select><Select Path="Microsoft-Windows-Win32k/Power">*[System[Provider[@Name='Microsoft-Windows-Security-Mitigations' or @Name='Microsoft-Windows-WER-Diag' or @Name='Microsoft-Windows-Win32k' or @Name='Win32k'] and ( (EventID &gt;= 1 and EventID &lt;= 24)  or EventID=5 or EventID=260)]]</Select><Select Path="Microsoft-Windows-Win32k/Render">*[System[Provider[@Name='Microsoft-Windows-Security-Mitigations' or @Name='Microsoft-Windows-WER-Diag' or @Name='Microsoft-Windows-Win32k' or @Name='Win32k'] and ( (EventID &gt;= 1 and EventID &lt;= 24)  or EventID=5 or EventID=260)]]</Select><Select Path="Microsoft-Windows-Win32k/Tracing">*[System[Provider[@Name='Microsoft-Windows-Security-Mitigations' or @Name='Microsoft-Windows-WER-Diag' or @Name='Microsoft-Windows-Win32k' or @Name='Win32k'] and ( (EventID &gt;= 1 and EventID &lt;= 24)  or EventID=5 or EventID=260)]]</Select><Select Path="Microsoft-Windows-Win32k/UIPI">*[System[Provider[@Name='Microsoft-Windows-Security-Mitigations' or @Name='Microsoft-Windows-WER-Diag' or @Name='Microsoft-Windows-Win32k' or @Name='Win32k'] and ( (EventID &gt;= 1 and EventID &lt;= 24)  or EventID=5 or EventID=260)]]</Select><Select Path="System">*[System[Provider[@Name='Microsoft-Windows-Security-Mitigations' or @Name='Microsoft-Windows-WER-Diag' or @Name='Microsoft-Windows-Win32k' or @Name='Win32k'] and ( (EventID &gt;= 1 and EventID &lt;= 24)  or EventID=5 or EventID=260)]]</Select><Select Path="Microsoft-Windows-Security-Mitigations/UserMode">*[System[Provider[@Name='Microsoft-Windows-Security-Mitigations' or @Name='Microsoft-Windows-WER-Diag' or @Name='Microsoft-Windows-Win32k' or @Name='Win32k'] and ( (EventID &gt;= 1 and EventID &lt;= 24)  or EventID=5 or EventID=260)]]</Select></Query></QueryList></QueryNode></QueryConfig><ResultsConfig><Columns><Column Name="Level" Type="System.String" Path="Event/System/Level" Visible="">225</Column><Column Name="Keywords" Type="System.String" Path="Event/System/Keywords">70</Column><Column Name="Date and Time" Type="System.DateTime" Path="Event/System/TimeCreated/@SystemTime" Visible="">275</Column><Column Name="Source" Type="System.String" Path="Event/System/Provider/@Name" Visible="">242</Column><Column Name="Event ID" Type="System.UInt32" Path="Event/System/EventID" Visible="">185</Column><Column Name="Task Category" Type="System.String" Path="Event/System/Task" Visible="">188</Column><Column Name="User" Type="System.String" Path="Event/System/Security/@UserID">50</Column><Column Name="Operational Code" Type="System.String" Path="Event/System/Opcode">110</Column><Column Name="Log" Type="System.String" Path="Event/System/Channel">80</Column><Column Name="Computer" Type="System.String" Path="Event/System/Computer">170</Column><Column Name="Process ID" Type="System.UInt32" Path="Event/System/Execution/@ProcessID">70</Column><Column Name="Thread ID" Type="System.UInt32" Path="Event/System/Execution/@ThreadID">70</Column><Column Name="Processor ID" Type="System.UInt32" Path="Event/System/Execution/@ProcessorID">90</Column><Column Name="Session ID" Type="System.UInt32" Path="Event/System/Execution/@SessionID">70</Column><Column Name="Kernel Time" Type="System.UInt32" Path="Event/System/Execution/@KernelTime">80</Column><Column Name="User Time" Type="System.UInt32" Path="Event/System/Execution/@UserTime">70</Column><Column Name="Processor Time" Type="System.UInt32" Path="Event/System/Execution/@ProcessorTime">100</Column><Column Name="Correlation Id" Type="System.Guid" Path="Event/System/Correlation/@ActivityID">85</Column><Column Name="Relative Correlation Id" Type="System.Guid" Path="Event/System/Correlation/@RelatedActivityID">140</Column><Column Name="Event Source Name" Type="System.String" Path="Event/System/Provider/@EventSourceName">140</Column></Columns></ResultsConfig></ViewerConfig>
 "@
-Add-Content -Path "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\View_2.xml" -Value $View_2
-}
-# network protection events
-$path_3 = "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\View_3.xml"
-if (-NOT (Test-Path $path_3)) {
-New-Item -Path $path_3 -ItemType File
+            Add-Content -Path "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\View_2.xml" -Value $View_2
+        }
+        # network protection events
+        $path_3 = "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\View_3.xml"
+        if (-NOT (Test-Path $path_3)) {
+            New-Item -Path $path_3 -ItemType File
 
-$View_3 =
-@"
+            $View_3 =
+            @"
 <ViewerConfig><QueryConfig><QueryParams><UserQuery /></QueryParams><QueryNode><Name LanguageNeutralValue="network protection events">network protection events</Name><QueryList><Query Id="0" Path="Microsoft-Windows-Windows Defender/Operational"><Select Path="Microsoft-Windows-Windows Defender/Operational">*[System[(EventID=1125 or EventID=1126 or EventID=5007)]]</Select><Select Path="Microsoft-Windows-Windows Defender/WHC">*[System[(EventID=1125 or EventID=1126 or EventID=5007)]]</Select></Query></QueryList></QueryNode></QueryConfig><ResultsConfig><Columns><Column Name="Level" Type="System.String" Path="Event/System/Level" Visible="">225</Column><Column Name="Keywords" Type="System.String" Path="Event/System/Keywords">70</Column><Column Name="Date and Time" Type="System.DateTime" Path="Event/System/TimeCreated/@SystemTime" Visible="">275</Column><Column Name="Source" Type="System.String" Path="Event/System/Provider/@Name" Visible="">242</Column><Column Name="Event ID" Type="System.UInt32" Path="Event/System/EventID" Visible="">185</Column><Column Name="Task Category" Type="System.String" Path="Event/System/Task" Visible="">188</Column><Column Name="User" Type="System.String" Path="Event/System/Security/@UserID">50</Column><Column Name="Operational Code" Type="System.String" Path="Event/System/Opcode">110</Column><Column Name="Log" Type="System.String" Path="Event/System/Channel">80</Column><Column Name="Computer" Type="System.String" Path="Event/System/Computer">170</Column><Column Name="Process ID" Type="System.UInt32" Path="Event/System/Execution/@ProcessID">70</Column><Column Name="Thread ID" Type="System.UInt32" Path="Event/System/Execution/@ThreadID">70</Column><Column Name="Processor ID" Type="System.UInt32" Path="Event/System/Execution/@ProcessorID">90</Column><Column Name="Session ID" Type="System.UInt32" Path="Event/System/Execution/@SessionID">70</Column><Column Name="Kernel Time" Type="System.UInt32" Path="Event/System/Execution/@KernelTime">80</Column><Column Name="User Time" Type="System.UInt32" Path="Event/System/Execution/@UserTime">70</Column><Column Name="Processor Time" Type="System.UInt32" Path="Event/System/Execution/@ProcessorTime">100</Column><Column Name="Correlation Id" Type="System.Guid" Path="Event/System/Correlation/@ActivityID">85</Column><Column Name="Relative Correlation Id" Type="System.Guid" Path="Event/System/Correlation/@RelatedActivityID">140</Column><Column Name="Event Source Name" Type="System.String" Path="Event/System/Provider/@EventSourceName">140</Column></Columns></ResultsConfig></ViewerConfig>
 "@
-Add-Content -Path "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\View_3.xml" -Value $View_3
-}
-# MSI and Scripts for WDAC Auditing events
-$path_4 = "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\View_4.xml"
-if (-NOT (Test-Path $path_4)) {
-New-Item -Path $path_4 -ItemType File
+            Add-Content -Path "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\View_3.xml" -Value $View_3
+        }
+        # MSI and Scripts for WDAC Auditing events
+        $path_4 = "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\View_4.xml"
+        if (-NOT (Test-Path $path_4)) {
+            New-Item -Path $path_4 -ItemType File
 
-$View_4 =
-@"
+            $View_4 =
+            @"
 <ViewerConfig><QueryConfig><QueryParams><Simple><Channel>Microsoft-Windows-AppLocker/MSI and Script</Channel><RelativeTimeInfo>0</RelativeTimeInfo><BySource>False</BySource></Simple></QueryParams><QueryNode><Name LanguageNeutralValue="MSI and Scripts for WDAC Auditing">MSI and Scripts for WDAC Auditing</Name><QueryList><Query Id="0" Path="Microsoft-Windows-AppLocker/MSI and Script"><Select Path="Microsoft-Windows-AppLocker/MSI and Script">*</Select></Query></QueryList></QueryNode></QueryConfig><ResultsConfig><Columns><Column Name="Level" Type="System.String" Path="Event/System/Level" Visible="">225</Column><Column Name="Keywords" Type="System.String" Path="Event/System/Keywords">70</Column><Column Name="Date and Time" Type="System.DateTime" Path="Event/System/TimeCreated/@SystemTime" Visible="">275</Column><Column Name="Source" Type="System.String" Path="Event/System/Provider/@Name" Visible="">185</Column><Column Name="Event ID" Type="System.UInt32" Path="Event/System/EventID" Visible="">185</Column><Column Name="Task Category" Type="System.String" Path="Event/System/Task" Visible="">188</Column><Column Name="User" Type="System.String" Path="Event/System/Security/@UserID">50</Column><Column Name="Operational Code" Type="System.String" Path="Event/System/Opcode">110</Column><Column Name="Log" Type="System.String" Path="Event/System/Channel">80</Column><Column Name="Computer" Type="System.String" Path="Event/System/Computer">170</Column><Column Name="Process ID" Type="System.UInt32" Path="Event/System/Execution/@ProcessID">70</Column><Column Name="Thread ID" Type="System.UInt32" Path="Event/System/Execution/@ThreadID">70</Column><Column Name="Processor ID" Type="System.UInt32" Path="Event/System/Execution/@ProcessorID">90</Column><Column Name="Session ID" Type="System.UInt32" Path="Event/System/Execution/@SessionID">70</Column><Column Name="Kernel Time" Type="System.UInt32" Path="Event/System/Execution/@KernelTime">80</Column><Column Name="User Time" Type="System.UInt32" Path="Event/System/Execution/@UserTime">70</Column><Column Name="Processor Time" Type="System.UInt32" Path="Event/System/Execution/@ProcessorTime">100</Column><Column Name="Correlation Id" Type="System.Guid" Path="Event/System/Correlation/@ActivityID">85</Column><Column Name="Relative Correlation Id" Type="System.Guid" Path="Event/System/Correlation/@RelatedActivityID">140</Column><Column Name="Event Source Name" Type="System.String" Path="Event/System/Provider/@EventSourceName">140</Column></Columns></ResultsConfig></ViewerConfig>
 "@
-Add-Content -Path "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\View_4.xml" -Value $View_4
-}
-# Sudden Shut down events
-$path_5 = "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\View_5.xml"
-if (-NOT (Test-Path $path_5)) {
-New-Item -Path $path_5 -ItemType File
+            Add-Content -Path "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\View_4.xml" -Value $View_4
+        }
+        # Sudden Shut down events
+        $path_5 = "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\View_5.xml"
+        if (-NOT (Test-Path $path_5)) {
+            New-Item -Path $path_5 -ItemType File
 
-$View_5 =
-@"
+            $View_5 =
+            @"
 <ViewerConfig><QueryConfig><QueryParams><Simple><Channel>System</Channel><EventId>41,6008</EventId><RelativeTimeInfo>0</RelativeTimeInfo><BySource>False</BySource></Simple></QueryParams><QueryNode><Name LanguageNeutralValue="Sudden Shut down events">Sudden Shut down events</Name><Description>41= Unexpected Power loss or crash | 6008 = dirty shut down</Description><QueryList><Query Id="0" Path="System"><Select Path="System">*[System[(EventID=41 or EventID=6008)]]</Select></Query></QueryList></QueryNode></QueryConfig><ResultsConfig><Columns><Column Name="Level" Type="System.String" Path="Event/System/Level" Visible="">227</Column><Column Name="Keywords" Type="System.String" Path="Event/System/Keywords">70</Column><Column Name="Date and Time" Type="System.DateTime" Path="Event/System/TimeCreated/@SystemTime" Visible="">277</Column><Column Name="Source" Type="System.String" Path="Event/System/Provider/@Name" Visible="">187</Column><Column Name="Event ID" Type="System.UInt32" Path="Event/System/EventID" Visible="">187</Column><Column Name="Task Category" Type="System.String" Path="Event/System/Task" Visible="">188</Column><Column Name="User" Type="System.String" Path="Event/System/Security/@UserID">50</Column><Column Name="Operational Code" Type="System.String" Path="Event/System/Opcode">110</Column><Column Name="Log" Type="System.String" Path="Event/System/Channel">80</Column><Column Name="Computer" Type="System.String" Path="Event/System/Computer">170</Column><Column Name="Process ID" Type="System.UInt32" Path="Event/System/Execution/@ProcessID">70</Column><Column Name="Thread ID" Type="System.UInt32" Path="Event/System/Execution/@ThreadID">70</Column><Column Name="Processor ID" Type="System.UInt32" Path="Event/System/Execution/@ProcessorID">90</Column><Column Name="Session ID" Type="System.UInt32" Path="Event/System/Execution/@SessionID">70</Column><Column Name="Kernel Time" Type="System.UInt32" Path="Event/System/Execution/@KernelTime">80</Column><Column Name="User Time" Type="System.UInt32" Path="Event/System/Execution/@UserTime">70</Column><Column Name="Processor Time" Type="System.UInt32" Path="Event/System/Execution/@ProcessorTime">100</Column><Column Name="Correlation Id" Type="System.Guid" Path="Event/System/Correlation/@ActivityID">85</Column><Column Name="Relative Correlation Id" Type="System.Guid" Path="Event/System/Correlation/@RelatedActivityID">140</Column><Column Name="Event Source Name" Type="System.String" Path="Event/System/Provider/@EventSourceName">140</Column></Columns></ResultsConfig></ViewerConfig>
 "@
-Add-Content -Path "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\View_5.xml" -Value $View_5
-}
-# Code Integrity Operational events
-$path_6 = "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\View_6.xml"
-if (-NOT (Test-Path $path_6)) {
-New-Item -Path $path_6 -ItemType File
+            Add-Content -Path "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\View_5.xml" -Value $View_5
+        }
+        # Code Integrity Operational events
+        $path_6 = "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\View_6.xml"
+        if (-NOT (Test-Path $path_6)) {
+            New-Item -Path $path_6 -ItemType File
 
-$View_6 =
-@"
+            $View_6 =
+            @"
 <ViewerConfig><QueryConfig><QueryParams><Simple><Channel>Microsoft-Windows-CodeIntegrity/Operational</Channel><RelativeTimeInfo>0</RelativeTimeInfo><BySource>False</BySource></Simple></QueryParams><QueryNode><Name LanguageNeutralValue="Code Integrity Operational">Code Integrity Operational</Name><QueryList><Query Id="0" Path="Microsoft-Windows-CodeIntegrity/Operational"><Select Path="Microsoft-Windows-CodeIntegrity/Operational">*</Select></Query></QueryList></QueryNode></QueryConfig><ResultsConfig><Columns><Column Name="Level" Type="System.String" Path="Event/System/Level" Visible="">227</Column><Column Name="Keywords" Type="System.String" Path="Event/System/Keywords">70</Column><Column Name="Date and Time" Type="System.DateTime" Path="Event/System/TimeCreated/@SystemTime" Visible="">277</Column><Column Name="Source" Type="System.String" Path="Event/System/Provider/@Name" Visible="">187</Column><Column Name="Event ID" Type="System.UInt32" Path="Event/System/EventID" Visible="">187</Column><Column Name="Task Category" Type="System.String" Path="Event/System/Task" Visible="">188</Column><Column Name="User" Type="System.String" Path="Event/System/Security/@UserID">50</Column><Column Name="Operational Code" Type="System.String" Path="Event/System/Opcode">110</Column><Column Name="Log" Type="System.String" Path="Event/System/Channel">80</Column><Column Name="Computer" Type="System.String" Path="Event/System/Computer">170</Column><Column Name="Process ID" Type="System.UInt32" Path="Event/System/Execution/@ProcessID">70</Column><Column Name="Thread ID" Type="System.UInt32" Path="Event/System/Execution/@ThreadID">70</Column><Column Name="Processor ID" Type="System.UInt32" Path="Event/System/Execution/@ProcessorID">90</Column><Column Name="Session ID" Type="System.UInt32" Path="Event/System/Execution/@SessionID">70</Column><Column Name="Kernel Time" Type="System.UInt32" Path="Event/System/Execution/@KernelTime">80</Column><Column Name="User Time" Type="System.UInt32" Path="Event/System/Execution/@UserTime">70</Column><Column Name="Processor Time" Type="System.UInt32" Path="Event/System/Execution/@ProcessorTime">100</Column><Column Name="Correlation Id" Type="System.Guid" Path="Event/System/Correlation/@ActivityID">85</Column><Column Name="Relative Correlation Id" Type="System.Guid" Path="Event/System/Correlation/@RelatedActivityID">140</Column><Column Name="Event Source Name" Type="System.String" Path="Event/System/Provider/@EventSourceName">140</Column></Columns></ResultsConfig></ViewerConfig>
 "@
-Add-Content -Path "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\View_6.xml" -Value $View_6
-}
+            Add-Content -Path "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\View_6.xml" -Value $View_6
+        }
 
 
 
-# turn on "Show text suggestions when typing on the physical keyboard" for the current user, toggles the option in Windows settings
-ModifyRegistry -RegPath 'HKCU:\Software\Microsoft\Input\Settings' -RegName 'EnableHwkbTextPrediction' -RegValue '1'
+        # turn on "Show text suggestions when typing on the physical keyboard" for the current user, toggles the option in Windows settings
+        ModifyRegistry -RegPath 'HKCU:\Software\Microsoft\Input\Settings' -RegName 'EnableHwkbTextPrediction' -RegValue '1'
 
-# turn on "Multilingual text suggestions" for the current user, toggles the option in Windows settings
-ModifyRegistry -RegPath 'HKCU:\Software\Microsoft\Input\Settings' -RegName 'MultilingualEnabled' -RegValue '1'
+        # turn on "Multilingual text suggestions" for the current user, toggles the option in Windows settings
+        ModifyRegistry -RegPath 'HKCU:\Software\Microsoft\Input\Settings' -RegName 'MultilingualEnabled' -RegValue '1'
 
-# turn off sticky key shortcut of pressing shift key 5 time fast - value is type string, can't use ModifyRegistry Function
-$RegistryPath = 'HKCU:\Control Panel\Accessibility\StickyKeys'  
-$Name         = 'Flags'  
-$Value        = '506' 
-If (-NOT (Test-Path $RegistryPath)) {   New-Item -Path $RegistryPath -Force | Out-Null } 
-New-ItemProperty -Path $RegistryPath -Name $Name -Value $Value -PropertyType string -Force
-
-
+        # turn off sticky key shortcut of pressing shift key 5 time fast - value is type string, can't use ModifyRegistry Function
+        $RegistryPath = 'HKCU:\Control Panel\Accessibility\StickyKeys'  
+        $Name = 'Flags'  
+        $Value = '506' 
+        If (-NOT (Test-Path $RegistryPath)) { New-Item -Path $RegistryPath -Force | Out-Null } 
+        New-ItemProperty -Path $RegistryPath -Name $Name -Value $Value -PropertyType string -Force
 
 
 
-} "No" { break }
-"Exit" { exit }
+
+
+    } "No" { break }
+    "Exit" { exit }
 }
 # =========================================================================================================================
 # ====================================================End of Non-Admin Commands============================================

--- a/Harden-Windows-Security.ps1
+++ b/Harden-Windows-Security.ps1
@@ -219,16 +219,6 @@ remove-item .\Security-Baselines-X.zip -Force
  
  
   
- <#
-    .Synopsis
-        Tests if the user is an administrator
-    .Description
-        Returns true if a user is an administrator, false if the user is not an administrator   
-    .Example
-        Test-IsAdmin
-  https://devblogs.microsoft.com/scripting/use-function-to-determine-elevation-of-powershell-console/
-    #>
-
 
 
 
@@ -286,7 +276,16 @@ remove-item .\Security-Baselines-X.zip -Force
  
 
 
-
+ <#
+    .Synopsis
+        Tests if the user is an administrator
+    .Description
+        Returns true if a user is an administrator, false if the user is not an administrator   
+    .Example
+        Test-IsAdmin
+  https://devblogs.microsoft.com/scripting/use-function-to-determine-elevation-of-powershell-console/
+    #>
+    
 
  # Function to test if current session has administrator privileges
 Function Test-IsAdmin
@@ -498,8 +497,16 @@ function Compare-SecureString {
 
 
 
+  
+ # check, make sure there is no CD/DVD drives in the system, because Bitlocker throws an error when there is
+ $CDDVDCheck = (Get-WMIObject -Class Win32_CDROMDrive -Property *).MediaLoaded
+ if ($CDDVDCheck){
+    Write-Warning "Remove any CD/DVD drives from the system and run the Bitlocker category after that"
+    break
+}
 
- # first make sure Bitlocker isn't in the middle of any decryption/encryption operation
+
+ # check, make sure Bitlocker isn't in the middle of decryption/encryption operation (on System Drive)
 if ((Get-BitLockerVolume -MountPoint $env:SystemDrive).EncryptionPercentage -ne "100" -and (Get-BitLockerVolume -MountPoint $env:SystemDrive).EncryptionPercentage -ne "0") {
 
     $kawai = (Get-BitLockerVolume -MountPoint $env:SystemDrive).EncryptionPercentage
@@ -645,7 +652,6 @@ else {
 
 
 }
-
 
 
 

--- a/Harden-Windows-Security.ps1
+++ b/Harden-Windows-Security.ps1
@@ -87,20 +87,24 @@ Version 2023.1.26: completely optimized the script, changed it to be multilingua
 
 💠 Features of this Hardening script:
 
-  ✅ Running this script makes your PC compliant with Secured-core PC specifications (providing that you use a modern hardware that supports the latest Windows security features).
-  ✅ Always up-to-date and works with the latest build of Windows (Currently Windows 11 - compatible and rigorously tested on stable and Insider Dev builds)
+  ✅ Always up-to-date and works with latest build of Windows (Currently Windows 11 - compatible and rigorously tested on stable and Insider Dev builds)
   ✅ Doesn't break anything
   ✅ Doesn't remove or disable Windows functionalities against Microsoft's recommendation
-  ✅ The Readme page on GitHub is used as the reference for all of the commands used in the script. the order in which they appear there is the same as the one in the script file.
+  ✅ The Readme page on GitHub is used as the reference for all of the security measures applied by this script and Group Policies. the order in which they appear there is the same as the one in the script file.
   ✅ When a hardening command is no longer necessary because it's applied by default by Microsoft on new builds of Windows, it will also be removed from this script in order to prevent any problems and because it won't be necessary anymore.
   ✅ The script can be run infinite number of times, it's made in a way that it won't make any duplicate changes at all.
-  
+  ✅ The script asks for confirmation, in the PowerShell console, before running each hardening category, so you can selectively run (or don't run) each of them.
+  ✅ Running this script makes your PC compliant with Secured-core PC specifications (providing that you use a modern hardware that supports the latest Windows security features). 
+  ✅ Running this script makes your system compliant with the official Microsoft Security Baselines
+
 
 🛑 Warning: Windows by default is secure and safe, this script does not imply nor claim otherwise. just like anything, you have to use it wisely and don't compromise yourself with reckless behavior and bad user configuration; Nothing is foolproof. this script only uses the tools and features that have already been implemented by Microsoft in Windows OS to fine-tune it towards the highest security and locked-down state, using well-documented, supported, often recommended and official methods. continue reading for comprehensive info.
 
 💠 Hardening Categories from top to bottom: (🔺Detailed info about each of them at my Github🔻)
 
 ⏹ Commands that require Administrator Privileges
+  ✅Microsoft Security Baselines
+  ✅Security Baselines X
   ✅ Windows Security aka Defender
   ✅ Attack surface reduction rules
   ✅ Bitlocker Settings
@@ -122,7 +126,7 @@ Version 2023.1.26: completely optimized the script, changed it to be multilingua
 
 💎 Note: The script asks for confirmation, in the PowerShell console, before running each hardening category, so you can selectively run (or don't run) each of them.
 
-💎 Note: There are 4 items tagged with #TopSecurity that can break functionalities or cause difficulties so this script does NOT enable them by default. press Control + F and search for #TopSecurity in GitHub readme to find those commands and how to enable them if you want.
+💎 Note: There are 4 items tagged with #TopSecurity that can break functionalities or cause difficulties so this script does NOT enable them by default. press Control + F and search for #TopSecurity in the GitHub Readme page to find those security measures and how to enable them if you want.
 
 🏴 if you have any questions, requests, suggestions etc. about this script, please open a new discussion in Github:
 
@@ -139,7 +143,6 @@ Version 2023.1.26: completely optimized the script, changed it to be multilingua
 
 #>
 
- 
  
 
 $infomsg = "`r`n" +
@@ -165,8 +168,7 @@ if (((Get-WmiObject Win32_OperatingSystem).OperatingSystemSKU) -eq "101"){
     }
 
 
-
-
+#region Functions
     # Questions function
     function Select-Option
     {
@@ -256,9 +258,7 @@ $principal = New-Object Security.Principal.WindowsPrincipal $identity
 
 $principal.IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)
 }
-
-
-
+#endregion functions
 
 
 if(-NOT (Test-IsAdmin))
@@ -266,13 +266,15 @@ if(-NOT (Test-IsAdmin))
    { write-host "Skipping commands that require Administrator privileges" -ForegroundColor Magenta }
 
 else {
-    
 
+ 
+#region Security-Baselines   
 # =========================================================================================================================
 # ================================================Security Baselines=======================================================
 # =========================================================================================================================
- switch (Select-Option -Options "Yes", "No", "Exit" -Message "`nApply Microsoft Security Baseline + Hardening Script's Baseline?")
- {  "Yes"  {
+
+switch (Select-Option -Options "Yes", "No", "Exit" -Message "`nApply Microsoft Security Baseline + Hardening Script's Baseline?")
+{  "Yes"  {
 
 
  # download Microsoft Security Baselines directly from their servers
@@ -340,17 +342,15 @@ gpupdate /force
  
 } "No" { break }
 "Exit" { exit }
-} 
+}
 # =========================================================================================================================
 # ============================================End of Security Baselines====================================================
 # =========================================================================================================================
-
-  
-
+#endregion Security-Baselines
 
 
  
-
+#region Windows-Security-Defender
 # =========================================================================================================================
 # ==========================================Windows Security aka Defender==================================================
 # =========================================================================================================================
@@ -385,11 +385,11 @@ ModifyRegistry -RegPath 'HKLM:\SYSTEM\CurrentControlSet\Control\CI\Policy' -RegN
 # =========================================================================================================================
 # =========================================End of Windows Security aka Defender============================================
 # =========================================================================================================================
+#endregion Windows-Security-Defender
 
 
 
-
-
+#region Bitlocker-Settings
 # =========================================================================================================================
 # ==========================================Bitlocker Settings=============================================================
 # =========================================================================================================================
@@ -761,11 +761,11 @@ $nonOSVolumes | ForEach-Object {
 # =========================================================================================================================
 # ==========================================End of Bitlocker Settings======================================================
 # =========================================================================================================================
+#endregion Bitlocker-Settings
 
 
 
-
-
+#region TLS-Security
 # =========================================================================================================================
 # ==============================================TLS Security===============================================================
 # =========================================================================================================================
@@ -972,13 +972,13 @@ ModifyRegistry -HashTable $WeakCiphers
 # =========================================================================================================================
 # ==========================================End of TLS Security============================================================
 # =========================================================================================================================
+#endregion TLS-Security
 
 
 
 
 
-
-
+#region Windows-Firewall
 # =========================================================================================================================
 # ====================================================Windows Firewall=====================================================
 # =========================================================================================================================
@@ -987,10 +987,9 @@ switch (Select-Option -Options "Yes", "No", "Exit" -Message "Run Windows Firewal
 
 
 # Disables Multicast DNS (mDNS) UDP-in Firewall Rules for all 3 Firewall profiles - disables only 3 rules
-get-NetFirewallRule
-    | Where-Object {$_.RuleGroup -eq "@%SystemRoot%\system32\firewallapi.dll,-37302" -and $_.Direction -eq "inbound" }
-        | ForEach-Object {
-            Disable-NetFirewallRule -DisplayName $_.DisplayName}
+get-NetFirewallRule |
+Where-Object {$_.RuleGroup -eq "@%SystemRoot%\system32\firewallapi.dll,-37302" -and $_.Direction -eq "inbound" } |
+ForEach-Object {Disable-NetFirewallRule -DisplayName $_.DisplayName}
 
 
 
@@ -1000,12 +999,12 @@ get-NetFirewallRule
 # =========================================================================================================================
 # =================================================End of Windows Firewall=================================================
 # =========================================================================================================================
+#endregion Windows-Firewall
 
 
 
 
-
-
+#region Optional-Windows-Features
 # =========================================================================================================================
 # =================================================Optional Windows Features===============================================
 # =========================================================================================================================
@@ -1050,14 +1049,14 @@ PowerShell.exe "if((get-WindowsOptionalFeature -Online -FeatureName VirtualMachi
 # =========================================================================================================================
 # ==============================================End of Optional Windows Features===========================================
 # =========================================================================================================================
+#endregion Optional-Windows-Features
 
 
 
 
 
 
-
-
+#region Windows-Networking
 # =========================================================================================================================
 # ====================================================Windows Networking===================================================
 # =========================================================================================================================
@@ -1103,12 +1102,12 @@ ModifyRegistry -RegPath 'HKLM:\SYSTEM\CurrentControlSet\Services\Netbt\Parameter
 # =========================================================================================================================
 # =================================================End of Windows Networking===============================================
 # =========================================================================================================================
+#endregion Windows-Networking
 
 
 
 
-
-
+#region Miscellaneous-Configurations
 # =========================================================================================================================
 # ==============================================Miscellaneous Configurations===============================================
 # =========================================================================================================================
@@ -1145,6 +1144,12 @@ ForEach-Object {Add-LocalGroupMember -Group "Hyper-V Administrators" -Member $_.
 # Change Windows time sync interval from every 7 days to every 4 days (= every 345600 seconds)
 ModifyRegistry -RegPath 'HKLM:\SYSTEM\ControlSet001\Services\W32Time\TimeProviders\NtpClient' -RegName 'SpecialPollInterval' -RegValue '345600'
 
+# Change Computer Name from the random Desktop-.... to "Mainframe"
+if (-NOT ($env:computername -eq "Mainframe"))
+{Rename-Computer -NewName "Mainframe"}
+
+
+
 
 
 
@@ -1154,12 +1159,12 @@ ModifyRegistry -RegPath 'HKLM:\SYSTEM\ControlSet001\Services\W32Time\TimeProvide
 # =========================================================================================================================
 # ============================================End of Miscellaneous Configurations==========================================
 # =========================================================================================================================
+#endregion Miscellaneous-Configurations
 
 
 
 
-
-
+#region Certificate-Checking-Commands
 # =========================================================================================================================
 # ====================================================Certificate Checking Commands========================================
 # =========================================================================================================================
@@ -1227,12 +1232,12 @@ switch (Select-Option -Options "Yes", "No", "Exit" -Message "Run Certificate Che
 # =========================================================================================================================
 # ====================================================End of Certificate Checking Commands=================================
 # =========================================================================================================================
+#endregion Certificate-Checking-Commands
 
 
 
 
-
-
+#region Country-IP-Blocking
 # =========================================================================================================================
 # ====================================================Country IP Blocking==================================================
 # =========================================================================================================================
@@ -1342,7 +1347,7 @@ switch (Select-Option -Options "Yes", "No", "Exit" -Message "Block the entire ra
 # =========================================================================================================================
 # ====================================================End of Country IP Blocking===========================================
 # =========================================================================================================================
-
+#endregion Country-IP-Blocking
 
 
 
@@ -1351,7 +1356,7 @@ switch (Select-Option -Options "Yes", "No", "Exit" -Message "Block the entire ra
 } # End of Admin test function
 
 
-
+#region Non-Admin-Commands
 # =========================================================================================================================
 # ====================================================Non-Admin Commands===================================================
 # =========================================================================================================================
@@ -1473,7 +1478,6 @@ Add-Content -Path "C:\ProgramData\Microsoft\Event Viewer\Views\Hardening Script\
 
 
 
-
 # turn on "Show text suggestions when typing on the physical keyboard" for the current user, toggles the option in Windows settings
 ModifyRegistry -RegPath 'HKCU:\Software\Microsoft\Input\Settings' -RegName 'EnableHwkbTextPrediction' -RegValue '1'
 
@@ -1490,12 +1494,14 @@ New-ItemProperty -Path $RegistryPath -Name $Name -Value $Value -PropertyType str
 
 
 
+
 } "No" { break }
 "Exit" { exit }
 }
 # =========================================================================================================================
 # ====================================================End of Non-Admin Commands============================================
 # =========================================================================================================================
+#endregion Non-Admin-Commands
 
 Write-Host "T" -ForegroundColor Green -NoNewline;
 Write-Host "H" -ForegroundColor Yellow -NoNewline;

--- a/Harden-Windows-Security.ps1
+++ b/Harden-Windows-Security.ps1
@@ -1144,12 +1144,6 @@ ForEach-Object {Add-LocalGroupMember -Group "Hyper-V Administrators" -Member $_.
 # Change Windows time sync interval from every 7 days to every 4 days (= every 345600 seconds)
 ModifyRegistry -RegPath 'HKLM:\SYSTEM\ControlSet001\Services\W32Time\TimeProviders\NtpClient' -RegName 'SpecialPollInterval' -RegValue '345600'
 
-# Change Computer Name from the random Desktop-.... to "Mainframe"
-if (-NOT ($env:computername -eq "Mainframe"))
-{Rename-Computer -NewName "Mainframe"}
-
-
-
 
 
 

--- a/Harden-Windows-Security.ps1
+++ b/Harden-Windows-Security.ps1
@@ -308,7 +308,7 @@ else {
             Push-Location .\LGPO_30
 
             # Use LGPO.exe to apply the Windows Hardening script Group Policy Objects on top of Microsoft Security Baselines
-            .\LGPO.exe /g '..\Security-Baselines-X\{300945C6-E397-4D12-A29F-18612FBD1058}'
+            .\LGPO.exe /g '..\Security-Baselines-X\GPOX'
 
             # Change the current working directory back to where we were
             Pop-Location
@@ -331,9 +331,11 @@ else {
             # Delete the Windows Hardening script Group Policy Objects folder we extracted the zip file
             remove-item .\Security-Baselines-X.zip -Force
 
+            # wait 3 seconds
+            Start-Sleep -Seconds 3
+            
             # Force update the applied Group Policies
             gpupdate /force
-
 
 
  

--- a/Harden-Windows-Security.ps1
+++ b/Harden-Windows-Security.ps1
@@ -141,41 +141,6 @@ Version 2023.1.25: The script now applies the official Microsoft Security Baseli
  
  
 
-<#
-
-# Source https://github.com/HotCakeX/Harden-Windows-Security
- 
-Hardening Categories from top to bottom:
-
-  Commands that require Administrator Privileges
-  -Windows Security aka Defender
-  -Attack surface reduction rules
-  -Bitlocker Settings
-  -TLS Security
-  -Lock Screen
-  -UAC (User Account Control)
-  -Device Guard
-  -Windows Firewall
-  -Optional Windows Features
-  -Windows Networking
-  -Miscellaneous Configurations
-  -Certificate Checking Commands
-  -Country IP Blocking
- Commands that don't require Administrator Privileges
-  -Non-Admin Commands that only affect the current user and do not make machine-wide changes.
-
-
-
-Applying the latest Microsoft Security Baseline + Hardening script Group Policies
-
-The rest of the commands that couldn't be applied as Group Policies are applied using registry and PowerShell
-
-
-
-#>
-
-
-
 write-host "`n`n  Make Sure you've completely read what's written in the GitHub repository, before running this script `n" -ForegroundColor yellow
 
 Write-Host "Link to the GitHub Repository: " -ForegroundColor Green "https://github.com/HotCakeX/Harden-Windows-Security `n`n"

--- a/Harden-Windows-Security.ps1
+++ b/Harden-Windows-Security.ps1
@@ -331,12 +331,6 @@ else {
             # Delete the Windows Hardening script Group Policy Objects folder we extracted the zip file
             remove-item .\Security-Baselines-X.zip -Force
 
-            # wait 3 seconds
-            Start-Sleep -Seconds 3
-            
-            # Force update the applied Group Policies
-            gpupdate /force
-
 
  
         } "No" { break }
@@ -1495,9 +1489,8 @@ switch (Select-Option -Options "Yes", "No", "Exit" -Message "Run Non-Admin categ
 # =========================================================================================================================
 #endregion Non-Admin-Commands
 
-Write-Host "T" -ForegroundColor Green -NoNewline;
-Write-Host "H" -ForegroundColor Yellow -NoNewline;
-Write-Host "E " -ForegroundColor Blue -NoNewline;
-Write-Host "E" -ForegroundColor Red -NoNewline;
-Write-Host "N" -ForegroundColor Magenta -NoNewline;
-Write-Host "D" -ForegroundColor Cyan ;
+$infomsg = "`r`n" +
+"################################################################################################`r`n" +
+"###  Please Restart your device to completely apply the security measures and Group Policies ###`r`n" +
+"################################################################################################`r`n"
+Write-Host $infomsg -ForegroundColor Cyan

--- a/Harden-Windows-Security.ps1
+++ b/Harden-Windows-Security.ps1
@@ -308,7 +308,13 @@ else {
             Push-Location .\LGPO_30
 
             # Use LGPO.exe to apply the Windows Hardening script Group Policy Objects on top of Microsoft Security Baselines
-            .\LGPO.exe /g '..\Security-Baselines-X\GPOX'
+            #.\LGPO.exe /g '..\Security-Baselines-X\GPOX'
+
+            # Import settings from Security Baselines X Registry Policy file into Computer (Machine) Configuration.
+            .\LGPO.exe /m "..\Security-Baselines-X\GPOX\DomainSysvol\GPO\Machine\registry.pol"
+
+            # Apply the Security Baselines X security template into Computer (Machine) Configuration
+            .\lgpo.exe /s "..\Security-Baselines-X\GPOX\DomainSysvol\GPO\Machine\microsoft\windows nt\SecEdit\GptTmpl.inf"
 
             # Change the current working directory back to where we were
             Pop-Location


### PR DESCRIPTION
The script now applies the official Microsoft Security Baselines and on top of that applies as many of the script settings as possible using Group Policy, the rest of the settings that aren't possible to be applied using Group Policy continue to be applied using registry and PowerShell Cmdlets.


Also: enforce encryption type on removable and fixed drive types to full disk encryption instead of only used disk encryption
