### PR TITLE
WDACConfig update 0.2.2

### DIFF
--- a/WDACConfig/ArgumentCompleters.ps1
+++ b/WDACConfig/ArgumentCompleters.ps1
@@ -1,3 +1,4 @@
+<#
 # argument tab auto-completion for CertPath param to show only .cer files in current directory and 2 sub-directories recursively
 [scriptblock]$ArgumentCompleterCertPath = {
     # Note the use of -Depth 1
@@ -8,6 +9,7 @@
         $null # Dummy response that prevents fallback to the default file-name completion.
     }   
 }
+#>
 
 # argument tab auto-completion for Policy Paths to show only .xml files and only suggest files that haven't been already selected by user 
 # https://stackoverflow.com/questions/76141864/how-to-make-a-powershell-argument-completer-that-only-suggests-files-not-already/76142865

--- a/WDACConfig/ArgumentCompleters.ps1
+++ b/WDACConfig/ArgumentCompleters.ps1
@@ -1,8 +1,3 @@
-# argument tab auto-completion for SignToolPath param to show only .exe files in the current directory
-[scriptblock]$ArgumentCompleterSignToolPath = {
-    Get-ChildItem | Where-Object { $_.extension -like '*.exe' } | ForEach-Object { return "`"$_`"" }
-}
-
 # argument tab auto-completion for CertPath param to show only .cer files in current directory and 2 sub-directories recursively
 [scriptblock]$ArgumentCompleterCertPath = {
     # Note the use of -Depth 1

--- a/WDACConfig/Confirm-WDACConfig.psm1
+++ b/WDACConfig/Confirm-WDACConfig.psm1
@@ -1,6 +1,6 @@
 #Requires -RunAsAdministrator
 function Confirm-WDACConfig {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'List Active Policies')]
     Param(
         [Alias('L')]
         [Parameter(Mandatory = $false, ParameterSetName = 'List Active Policies')][Switch]$ListActivePolicies,
@@ -34,7 +34,14 @@ function Confirm-WDACConfig {
             $SupplementalPolicies = (CiTool -lp -json | ConvertFrom-Json).Policies | Where-Object { $_.IsSystemPolicy -ne 'True' } | Where-Object { $_.PolicyID -ne $_.BasePolicyID }           
             &$WriteLavender "`nThere are currently $(($SupplementalPolicies.count)) Non-system Supplemental policies deployed`n"
             $SupplementalPolicies
-        }        
+        } 
+        
+        # If no parameters were passed run all of them
+        if ($PSBoundParameters.Count -eq 0) {
+            $ListActivePolicies = $true
+            $VerifyWDACStatus = $true
+            $CheckSmartAppControlStatus = $true
+        }
     }
 
     process {
@@ -60,7 +67,7 @@ function Confirm-WDACConfig {
             elseif ((Get-MpComputerStatus).SmartAppControlState -eq 'Off') {
                 &$WritePink "`nSmart App Control is turned off."
             }
-        }    
+        }            
     }
     
     <#

--- a/WDACConfig/Deploy-SignedWDACConfig.psm1
+++ b/WDACConfig/Deploy-SignedWDACConfig.psm1
@@ -25,7 +25,7 @@ function Deploy-SignedWDACConfig {
         [parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
         [System.String]$SignToolPath,
 
-        [Parameter(Mandatory = $false)][Switch]$SignOnly,
+        [Parameter(Mandatory = $false)][Switch]$Deploy,
         
         [Parameter(Mandatory = $false)][Switch]$SkipVersionCheck
     )
@@ -135,7 +135,7 @@ function Deploy-SignedWDACConfig {
             Remove-Item ".\$PolicyID.cip" -Force            
             Rename-Item "$PolicyID.cip.p7" -NewName "$PolicyID.cip" -Force
 
-            if (!$SignOnly) {
+            if ($Deploy) {
 
                 CiTool --update-policy ".\$PolicyID.cip" -json | Out-Null
                 Write-Host "`npolicy with the following details has been Signed and Deployed in Enforced Mode:" -ForegroundColor Green        
@@ -149,7 +149,7 @@ function Deploy-SignedWDACConfig {
                     $userInput = $(Write-Host 'Add the Signed policy xml file path just created to the User Configurations? Please enter 1 to Confirm or 2 to Skip.' -ForegroundColor Cyan ; Read-Host) 
                     if ($userInput -eq 1) {
                         Set-CommonWDACConfig -SignedPolicyPath $PolicyPath
-                        &$WriteViolet "Added $PolicyPath to the User Configuration file."             
+                        &$WriteHotPink "Added $PolicyPath to the User Configuration file."             
                     }
                     elseif ($userInput -eq 2) {                    
                         &$WritePink 'Skipping...'                  
@@ -196,8 +196,8 @@ Certificate common name
 .PARAMETER SignToolPath
 Path to the SignTool.exe - optional parameter
 
-.PARAMETER SignOnly
-Indicates that the cmdlet only signs the WDAC policy and will not deploy it to the system. Useful for when you want to deploy it elsewhere.
+.PARAMETER Deploy
+Indicates that the cmdlet will deploy the signed policy on the current system
 
 .PARAMETER SkipVersionCheck
 Can be used with any parameter to bypass the online version check - only to be used in rare cases
@@ -211,5 +211,5 @@ Can be used with any parameter to bypass the online version check - only to be u
 Set-PSReadLineKeyHandler -Key Tab -Function MenuComplete
 Register-ArgumentCompleter -CommandName 'Deploy-SignedWDACConfig' -ParameterName 'CertCN' -ScriptBlock $ArgumentCompleterCertificateCN
 Register-ArgumentCompleter -CommandName 'Deploy-SignedWDACConfig' -ParameterName 'PolicyPaths' -ScriptBlock $ArgumentCompleterPolicyPaths
-Register-ArgumentCompleter -CommandName 'Deploy-SignedWDACConfig' -ParameterName 'CertPath' -ScriptBlock $ArgumentCompleterCertPath
+Register-ArgumentCompleter -CommandName 'Deploy-SignedWDACConfig' -ParameterName 'CertPath' -ScriptBlock $ArgumentCompleterCerFilePathsPicker
 Register-ArgumentCompleter -CommandName 'Deploy-SignedWDACConfig' -ParameterName 'SignToolPath' -ScriptBlock $ArgumentCompleterExeFilePathsPicker

--- a/WDACConfig/Deploy-SignedWDACConfig.psm1
+++ b/WDACConfig/Deploy-SignedWDACConfig.psm1
@@ -24,6 +24,8 @@ function Deploy-SignedWDACConfig {
 
         [parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
         [System.String]$SignToolPath,
+
+        [Parameter(Mandatory = $false)][Switch]$SignOnly,
         
         [Parameter(Mandatory = $false)][Switch]$SkipVersionCheck
     )
@@ -132,26 +134,36 @@ function Deploy-SignedWDACConfig {
 
             Remove-Item ".\$PolicyID.cip" -Force            
             Rename-Item "$PolicyID.cip.p7" -NewName "$PolicyID.cip" -Force
-            CiTool --update-policy ".\$PolicyID.cip" -json | Out-Null
-            Write-Host "`npolicy with the following details has been Signed and Deployed in Enforced Mode:" -ForegroundColor Green        
-            Write-Output "PolicyName = $PolicyName"
-            Write-Output "PolicyGUID = $PolicyID`n"
-            Remove-Item -Path ".\$PolicyID.cip" -Force
 
-            # Ask user question about whether or not to add the Signed policy xml file to the User Config Json for easier usage later
-            $userInput = ''
-            while ($userInput -notin 1, 2) {
-                $userInput = $(Write-Host 'Add the Signed policy xml file path just created to the User Configurations? Please enter 1 to Confirm or 2 to Skip.' -ForegroundColor Cyan ; Read-Host) 
-                if ($userInput -eq 1) {
-                    Set-CommonWDACConfig -SignedPolicyPath $PolicyPath
-                    &$WriteViolet "Added $PolicyPath to the User Configuration file."             
+            if (!$SignOnly) {
+
+                CiTool --update-policy ".\$PolicyID.cip" -json | Out-Null
+                Write-Host "`npolicy with the following details has been Signed and Deployed in Enforced Mode:" -ForegroundColor Green        
+                Write-Output "PolicyName = $PolicyName"
+                Write-Output "PolicyGUID = $PolicyID`n"
+                Remove-Item -Path ".\$PolicyID.cip" -Force
+
+                # Ask user question about whether or not to add the Signed policy xml file to the User Config Json for easier usage later
+                $userInput = ''
+                while ($userInput -notin 1, 2) {
+                    $userInput = $(Write-Host 'Add the Signed policy xml file path just created to the User Configurations? Please enter 1 to Confirm or 2 to Skip.' -ForegroundColor Cyan ; Read-Host) 
+                    if ($userInput -eq 1) {
+                        Set-CommonWDACConfig -SignedPolicyPath $PolicyPath
+                        &$WriteViolet "Added $PolicyPath to the User Configuration file."             
+                    }
+                    elseif ($userInput -eq 2) {                    
+                        &$WritePink 'Skipping...'                  
+                    }
+                    else {
+                        Write-Warning 'Invalid input. Please enter 1 or 2 only.'
+                    }               
                 }
-                elseif ($userInput -eq 2) {                    
-                    &$WritePink 'Skipping...'                  
-                }
-                else {
-                    Write-Warning 'Invalid input. Please enter 1 or 2 only.'
-                }               
+            }
+
+            else {            
+                Write-Host "`npolicy with the following details has been Signed and is ready for deployment:" -ForegroundColor Green
+                Write-Output "PolicyName = $PolicyName"
+                Write-Output "PolicyGUID = $PolicyID`n"
             }
         }
     }
@@ -184,6 +196,9 @@ Certificate common name
 .PARAMETER SignToolPath
 Path to the SignTool.exe - optional parameter
 
+.PARAMETER SignOnly
+Indicates that the cmdlet only signs the WDAC policy and will not deploy it to the system. Useful for when you want to deploy it elsewhere.
+
 .PARAMETER SkipVersionCheck
 Can be used with any parameter to bypass the online version check - only to be used in rare cases
 
@@ -197,4 +212,4 @@ Set-PSReadLineKeyHandler -Key Tab -Function MenuComplete
 Register-ArgumentCompleter -CommandName 'Deploy-SignedWDACConfig' -ParameterName 'CertCN' -ScriptBlock $ArgumentCompleterCertificateCN
 Register-ArgumentCompleter -CommandName 'Deploy-SignedWDACConfig' -ParameterName 'PolicyPaths' -ScriptBlock $ArgumentCompleterPolicyPaths
 Register-ArgumentCompleter -CommandName 'Deploy-SignedWDACConfig' -ParameterName 'CertPath' -ScriptBlock $ArgumentCompleterCertPath
-Register-ArgumentCompleter -CommandName 'Deploy-SignedWDACConfig' -ParameterName 'SignToolPath' -ScriptBlock $ArgumentCompleterSignToolPath
+Register-ArgumentCompleter -CommandName 'Deploy-SignedWDACConfig' -ParameterName 'SignToolPath' -ScriptBlock $ArgumentCompleterExeFilePathsPicker

--- a/WDACConfig/Edit-SignedWDACConfig.psm1
+++ b/WDACConfig/Edit-SignedWDACConfig.psm1
@@ -331,7 +331,7 @@ CiTool --update-policy "$((Get-Location).Path)\$PolicyID.cip" -json; Remove-Item
                 Try {                    
                     ################################### User Interaction ####################################
                     &$WritePink "`nAudit mode deployed, start installing your programs now"
-                    &$WriteViolet "When you've finished installing programs, Press Enter to start selecting program directories to scan`n"
+                    &$WriteHotPink "When you've finished installing programs, Press Enter to start selecting program directories to scan`n"
                     Pause
                     
                     # Store the program paths that user browses for in an array
@@ -696,7 +696,7 @@ CiTool --update-policy "$((Get-Location).Path)\$PolicyID.cip" -json; Remove-Item
                 Try {
                     ################################### User Interaction #################################### 
                     &$WritePink "`nAudit mode deployed, start installing your programs now"
-                    &$WriteViolet "When you've finished installing programs, Press Enter to start selecting program directories to scan`n"
+                    &$WriteHotPink "When you've finished installing programs, Press Enter to start selecting program directories to scan`n"
                     Pause
                   
                     # Store the program paths that user browses for in an array
@@ -915,7 +915,7 @@ CiTool --update-policy "$((Get-Location).Path)\$PolicyID.cip" -json; Remove-Item
                                             
                     # Scan PowerShell core directory and add them to the Default Windows base policy so that the module can be used after it's been deployed
                     if (Test-Path 'C:\Program Files\PowerShell') {                   
-                        &$WriteViolet "`nCreating allow rules for PowerShell in the DefaultWindows base policy so you can continue using this module after deploying it."
+                        &$WriteHotPink "`nCreating allow rules for PowerShell in the DefaultWindows base policy so you can continue using this module after deploying it."
                         New-CIPolicy -ScanPath 'C:\Program Files\PowerShell' -Level FilePublisher -NoScript -Fallback Hash -UserPEs -UserWriteablePaths -MultiplePolicyFormat -AllowFileNameFallbacks -FilePath .\AllowPowerShell.xml                        
                         Merge-CIPolicy -PolicyPaths .\DefaultWindows_Enforced.xml, .\AllowPowerShell.xml, .\SignTool.xml, '.\Microsoft recommended block rules.xml' -OutputFilePath .\BasePolicy.xml | Out-Null
                     }
@@ -1022,7 +1022,7 @@ Can be used with any parameter to bypass the online version check - only to be u
 # Set PSReadline tab completion to complete menu for easier access to available parameters - Only for the current session
 Set-PSReadLineKeyHandler -Key Tab -Function MenuComplete
 Register-ArgumentCompleter -CommandName 'Edit-SignedWDACConfig' -ParameterName 'CertCN' -ScriptBlock $ArgumentCompleterCertificateCN
-Register-ArgumentCompleter -CommandName 'Edit-SignedWDACConfig' -ParameterName 'CertPath' -ScriptBlock $ArgumentCompleterCertPath
+Register-ArgumentCompleter -CommandName 'Edit-SignedWDACConfig' -ParameterName 'CertPath' -ScriptBlock $ArgumentCompleterCerFilePathsPicker
 Register-ArgumentCompleter -CommandName 'Edit-SignedWDACConfig' -ParameterName 'SignToolPath' -ScriptBlock $ArgumentCompleterExeFilePathsPicker
 Register-ArgumentCompleter -CommandName 'Edit-SignedWDACConfig' -ParameterName 'PolicyPaths' -ScriptBlock $ArgumentCompleterPolicyPathsBasePoliciesOnly
 Register-ArgumentCompleter -CommandName 'Edit-SignedWDACConfig' -ParameterName 'SuppPolicyPaths' -ScriptBlock $ArgumentCompleterPolicyPathsSupplementalPoliciesOnly

--- a/WDACConfig/Edit-SignedWDACConfig.psm1
+++ b/WDACConfig/Edit-SignedWDACConfig.psm1
@@ -1,4 +1,4 @@
-#Requires -RunAsAdministrator 
+#Requires -RunAsAdministrator
 function Edit-SignedWDACConfig {
     [CmdletBinding(
         DefaultParameterSetName = 'Allow New Apps Audit Events',
@@ -256,7 +256,7 @@ function Edit-SignedWDACConfig {
             # The notice about variable being assigned and never used should be ignored - it's being dot-sourced from Resources file
             [datetime]$Date = Get-Date
             # An empty array that holds the Policy XML files - This array will eventually be used to create the final Supplemental policy
-            [System.Array]$PolicyXMLFilesArray = @()
+            [System.Object[]]$PolicyXMLFilesArray = @()
 
             ################################### Initiate Live Audit Mode ###################################
 
@@ -333,9 +333,9 @@ CiTool --update-policy "$((Get-Location).Path)\$PolicyID.cip" -json; Remove-Item
                     &$WritePink "`nAudit mode deployed, start installing your programs now"
                     &$WriteViolet "When you've finished installing programs, Press Enter to start selecting program directories to scan`n"
                     Pause
-
+                    
                     # Store the program paths that user browses for in an array
-                    [System.Array]$ProgramsPaths = @()
+                    [System.Object[]]$ProgramsPaths = @()
                     Write-Host "`nSelect program directories to scan" -ForegroundColor Cyan
                     # Showing folder picker GUI to the user for folder path selection
                     do {
@@ -469,7 +469,7 @@ CiTool --update-policy "$((Get-Location).Path)\$PolicyID.cip" -json; Remove-Item
                     # Any other attempts such as "Get-FileHash" or "Get-AuthenticodeSignature" fail and ConfigCI Module cmdlets totally ignore these files and do not create allow rules for them
 
                     # Finding the file(s) first and storing them in an array
-                    [System.Array]$ExesWithNoHash = @()
+                    [System.Object[]]$ExesWithNoHash = @()
                     # looping through each user-selected path(s)
                     foreach ($ProgramsPath in $ProgramsPaths) {
                         # Making sure the currently processing path has any .exe in it
@@ -621,7 +621,7 @@ CiTool --update-policy "$((Get-Location).Path)\$PolicyID.cip" -json; Remove-Item
             Remove-Item -Path '.\ProgramDir_ScanResults*.xml' -Force -ErrorAction SilentlyContinue
             Remove-Item -Path ".\SupplementalPolicy$SuppPolicyName.xml" -Force -ErrorAction SilentlyContinue
             # An empty array that holds the Policy XML files - This array will eventually be used to create the final Supplemental policy
-            [System.Array]$PolicyXMLFilesArray = @()
+            [System.Object[]]$PolicyXMLFilesArray = @()
     
             #Initiate Live Audit Mode
     
@@ -700,7 +700,7 @@ CiTool --update-policy "$((Get-Location).Path)\$PolicyID.cip" -json; Remove-Item
                     Pause
                   
                     # Store the program paths that user browses for in an array
-                    [System.Array]$ProgramsPaths = @()
+                    [System.Object[]]$ProgramsPaths = @()
                     Write-Host "`nSelect program directories to scan`n" -ForegroundColor Cyan
                     # Showing folder picker GUI to the user for folder path selection
                     do {
@@ -910,8 +910,6 @@ CiTool --update-policy "$((Get-Location).Path)\$PolicyID.cip" -json; Remove-Item
                     New-Item -Path "$env:TEMP\TemporarySignToolFile" -ItemType Directory -Force | Out-Null
                     Copy-Item -Path $SignToolPathFinal -Destination "$env:TEMP\TemporarySignToolFile" -Force
                     New-CIPolicy -ScanPath "$env:TEMP\TemporarySignToolFile" -Level FilePublisher -Fallback Hash -UserPEs -UserWriteablePaths -MultiplePolicyFormat -AllowFileNameFallbacks -FilePath .\SignTool.xml
-                    # Due to a bug Have to repeat this process twice: https://github.com/MicrosoftDocs/WDAC-Toolkit/issues/278
-                    New-CIPolicy -ScanPath "$env:TEMP\TemporarySignToolFile" -Level FilePublisher -Fallback Hash -UserPEs -UserWriteablePaths -MultiplePolicyFormat -AllowFileNameFallbacks -FilePath .\SignTool.xml
                     # Delete the Temporary folder in the TEMP folder
                     if (!$Debug) { Remove-Item -Recurse -Path "$env:TEMP\TemporarySignToolFile" -Force }
                                             
@@ -1025,6 +1023,6 @@ Can be used with any parameter to bypass the online version check - only to be u
 Set-PSReadLineKeyHandler -Key Tab -Function MenuComplete
 Register-ArgumentCompleter -CommandName 'Edit-SignedWDACConfig' -ParameterName 'CertCN' -ScriptBlock $ArgumentCompleterCertificateCN
 Register-ArgumentCompleter -CommandName 'Edit-SignedWDACConfig' -ParameterName 'CertPath' -ScriptBlock $ArgumentCompleterCertPath
-Register-ArgumentCompleter -CommandName 'Edit-SignedWDACConfig' -ParameterName 'SignToolPath' -ScriptBlock $ArgumentCompleterSignToolPath
+Register-ArgumentCompleter -CommandName 'Edit-SignedWDACConfig' -ParameterName 'SignToolPath' -ScriptBlock $ArgumentCompleterExeFilePathsPicker
 Register-ArgumentCompleter -CommandName 'Edit-SignedWDACConfig' -ParameterName 'PolicyPaths' -ScriptBlock $ArgumentCompleterPolicyPathsBasePoliciesOnly
 Register-ArgumentCompleter -CommandName 'Edit-SignedWDACConfig' -ParameterName 'SuppPolicyPaths' -ScriptBlock $ArgumentCompleterPolicyPathsSupplementalPoliciesOnly

--- a/WDACConfig/Edit-WDACConfig.psm1
+++ b/WDACConfig/Edit-WDACConfig.psm1
@@ -189,7 +189,7 @@ function Edit-WDACConfig {
             Remove-Item -Path '.\ProgramDir_ScanResults*.xml' -Force -ErrorAction SilentlyContinue
             Remove-Item -Path ".\SupplementalPolicy$SuppPolicyName.xml" -Force -ErrorAction SilentlyContinue    
             # An empty array that holds the Policy XML files - This array will eventually be used to create the final Supplemental policy
-            [System.Array]$PolicyXMLFilesArray = @()
+            [System.Object[]]$PolicyXMLFilesArray = @()
     
             #Initiate Live Audit Mode
 
@@ -267,7 +267,7 @@ CiTool --update-policy "$((Get-Location).Path)\$PolicyID.cip" -json; Remove-Item
                     Pause
 
                     # Store the program paths that user browses for in an array
-                    [System.Array]$ProgramsPaths = @()
+                    [System.Object[]]$ProgramsPaths = @()
                     Write-Host "`nSelect program directories to scan" -ForegroundColor Cyan
                     # Showing folder picker GUI to the user for folder path selection
                     do {
@@ -393,7 +393,7 @@ CiTool --update-policy "$((Get-Location).Path)\$PolicyID.cip" -json; Remove-Item
             # The notice about variable being assigned and never used should be ignored - it's being dot-sourced from Resources file
             [datetime]$Date = Get-Date
             # An empty array that holds the Policy XML files - This array will eventually be used to create the final Supplemental policy
-            [System.Array]$PolicyXMLFilesArray = @()
+            [System.Object[]]$PolicyXMLFilesArray = @()
 
             ################################### Initiate Live Audit Mode ###################################
             
@@ -450,7 +450,7 @@ CiTool --update-policy "$((Get-Location).Path)\$PolicyID.cip" -json; Remove-Item
                     Pause                 
 
                     # Store the program paths that user browses for in an array
-                    [System.Array]$ProgramsPaths = @()
+                    [System.Object[]]$ProgramsPaths = @()
                     Write-Host "`nSelect program directories to scan`n" -ForegroundColor Cyan
                     # Showing folder picker GUI to the user for folder path selection
                     do {
@@ -584,7 +584,7 @@ CiTool --update-policy "$((Get-Location).Path)\$PolicyID.cip" -json; Remove-Item
                     # Any other attempts such as "Get-FileHash" or "Get-AuthenticodeSignature" fail and ConfigCI Module cmdlets totally ignore these files and do not create allow rules for them
 
                     # Finding the file(s) first and storing them in an array
-                    [System.Array]$ExesWithNoHash = @()
+                    [System.Object[]]$ExesWithNoHash = @()
                     # looping through each user-selected path(s)
                     foreach ($ProgramsPath in $ProgramsPaths) {
                         # Making sure the currently processing path has any .exe in it

--- a/WDACConfig/Edit-WDACConfig.psm1
+++ b/WDACConfig/Edit-WDACConfig.psm1
@@ -263,7 +263,7 @@ CiTool --update-policy "$((Get-Location).Path)\$PolicyID.cip" -json; Remove-Item
                 Try {
                     ################################### User Interaction ####################################            
                     &$WritePink "`nAudit mode deployed, start installing your programs now"
-                    &$WriteViolet "When you've finished installing programs, Press Enter to start selecting program directories to scan`n"
+                    &$WriteHotPink "When you've finished installing programs, Press Enter to start selecting program directories to scan`n"
                     Pause
 
                     # Store the program paths that user browses for in an array
@@ -446,7 +446,7 @@ CiTool --update-policy "$((Get-Location).Path)\$PolicyID.cip" -json; Remove-Item
                 Try {
                     ################################### User Interaction ####################################
                     &$WritePink "`nAudit mode deployed, start installing your programs now"
-                    &$WriteViolet "When you've finished installing programs, Press Enter to start selecting program directories to scan`n"
+                    &$WriteHotPink "When you've finished installing programs, Press Enter to start selecting program directories to scan`n"
                     Pause                 
 
                     # Store the program paths that user browses for in an array

--- a/WDACConfig/Get-CommonWDACConfig.psm1
+++ b/WDACConfig/Get-CommonWDACConfig.psm1
@@ -19,6 +19,18 @@ function Get-CommonWDACConfig {
         # Stop operation as soon as there is an error anywhere, unless explicitly specified otherwise
         $ErrorActionPreference = 'Stop'        
         if (-NOT $SkipVersionCheck) { . Update-self }
+
+        # Create User configuration folder if it doesn't already exist
+        if (-NOT (Test-Path -Path "$env:USERPROFILE\.WDACConfig\")) {
+            New-Item -ItemType Directory -Path "$env:USERPROFILE\.WDACConfig\" -Force -ErrorAction Stop | Out-Null
+            Write-Debug -Message "The .WDACConfig folder in current user's folder has been created because it didn't exist."
+        }
+        
+        # Create User configuration file if it doesn't already exist
+        if (-NOT (Test-Path -Path "$env:USERPROFILE\.WDACConfig\UserConfigurations.json")) { 
+            New-Item -ItemType File -Path "$env:USERPROFILE\.WDACConfig\" -Name 'UserConfigurations.json' -Force -ErrorAction Stop | Out-Null
+            Write-Debug -Message "The UserConfigurations.json file in \.WDACConfig\ folder has been created because it didn't exist."
+        }
         
         # Scan the file with Microsoft Defender for anything malicious before it's going to be used
         Start-MpScan -ScanType CustomScan -ScanPath "$env:USERPROFILE\.WDACConfig\UserConfigurations.json"

--- a/WDACConfig/Invoke-WDACSimulation.psm1
+++ b/WDACConfig/Invoke-WDACSimulation.psm1
@@ -33,7 +33,7 @@ function Invoke-WDACSimulation {
        
         if ($FolderPath) {
             # Store the results of the Signed files
-            [System.Array]$SignedResult = @()
+            [System.Object[]]$SignedResult = @()
             # Get all of the files that WDAC supports from the user provided directory
             $CollectedFiles = (Get-ChildItem -Recurse -Path $FolderPath -File -Include '*.sys', '*.exe', '*.com', '*.dll', '*.ocx', '*.msp', '*.mst', '*.msi', '*.js', '*.vbs', '*.ps1', '*.appx').FullName
 
@@ -134,7 +134,7 @@ function Invoke-WDACSimulation {
             }
                  
             # Create an empty array to store the output objects
-            [System.Array]$FinalAllowedFilesOutputObject = @()
+            [System.Object[]]$FinalAllowedFilesOutputObject = @()
 
             # Loop through the first array and create output objects with the file path and source
             foreach ($path in $Hashresults) {

--- a/WDACConfig/New-DenyWDACConfig.psm1
+++ b/WDACConfig/New-DenyWDACConfig.psm1
@@ -90,7 +90,7 @@ function New-DenyWDACConfig {
             # remove any possible files from previous runs
             Remove-Item -Path '.\ProgramDir_ScanResults*.xml' -Force -ErrorAction SilentlyContinue
             # An array to hold the temporary xml files of each user-selected folders
-            [System.Array]$PolicyXMLFilesArray = @()
+            [System.Object[]]$PolicyXMLFilesArray = @()
 
             ######################## Process Program Folders From User input #####################
             for ($i = 0; $i -lt $ScanLocations.Count; $i++) {
@@ -163,7 +163,7 @@ function New-DenyWDACConfig {
         elseif ($Drivers) {           
 
             powershell.exe {
-                [System.Array]$DriverFilesObject = @()
+                [System.Object[]]$DriverFilesObject = @()
                 # loop through each user-selected folder paths
                 foreach ($ScanLocation in $args[0]) {
                     # DriverFile object holds the full details of all of the scanned drivers - This scan is greedy, meaning it stores as much information as it can find

--- a/WDACConfig/New-DenyWDACConfig.psm1
+++ b/WDACConfig/New-DenyWDACConfig.psm1
@@ -48,7 +48,7 @@ function New-DenyWDACConfig {
         [Switch]$NoScript,
 
         [Parameter(Mandatory = $false)] # Used by all the entire Cmdlet
-        [Switch]$Deployit,
+        [Switch]$Deploy,
         
         [Parameter(Mandatory = $false)][Switch]$SkipVersionCheck # Used by all the entire Cmdlet
     )
@@ -151,7 +151,7 @@ function New-DenyWDACConfig {
                 Remove-Item -Path '.\ProgramDir_ScanResults*.xml' -Force
             }
             
-            if ($Deployit) {                
+            if ($Deploy) {                
                 CiTool --update-policy "$policyID.cip" -json | Out-Null               
                 Write-Host -NoNewline "`n$policyID.cip for " -ForegroundColor Green
                 Write-Host -NoNewline "$PolicyName" -ForegroundColor Magenta
@@ -206,7 +206,7 @@ function New-DenyWDACConfig {
                 DenyPolicyFile = "DenyPolicy $PolicyName.xml"
                 DenyPolicyGUID = $PolicyID
             } 
-            if ($Deployit) {                
+            if ($Deploy) {                
                 CiTool --update-policy "$policyID.cip" -json | Out-Null             
                 Write-Host -NoNewline "`n$policyID.cip for " -ForegroundColor Green
                 Write-Host -NoNewline "$PolicyName" -ForegroundColor Magenta
@@ -262,7 +262,7 @@ function New-DenyWDACConfig {
                 DenyPolicyGUID = $PolicyID
             }
             
-            if ($Deployit) {                
+            if ($Deploy) {                
                 CiTool --update-policy "$policyID.cip" -json | Out-Null
                 &$WritePink "A Deny Base policy with the name $PolicyName has been deployed."
                 Remove-Item -Path "$policyID.cip" -Force

--- a/WDACConfig/New-SupplementalWDACConfig.psm1
+++ b/WDACConfig/New-SupplementalWDACConfig.psm1
@@ -36,7 +36,7 @@ function New-SupplementalWDACConfig {
         [System.String]$PolicyPath,
 
         [parameter(Mandatory = $false)] # Used by all the entire Cmdlet        
-        [Switch]$Deployit,
+        [Switch]$Deploy,
         
         [ValidateSet('OriginalFileName', 'InternalName', 'FileDescription', 'ProductName', 'PackageFamilyName', 'FilePath')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Normal')]
@@ -134,7 +134,7 @@ function New-SupplementalWDACConfig {
             if ($NoScript) { $PolicyMakerHashTable['NoScript'] = $true }                 
             if (!$NoUserPEs) { $PolicyMakerHashTable['UserPEs'] = $true } 
 
-            &$WriteViolet "`nGenerating Supplemental policy with the following specifications:"
+            &$WriteHotPink "`nGenerating Supplemental policy with the following specifications:"
             $PolicyMakerHashTable
             Write-Host "`n"
             # Create the supplemental policy via parameter splatting
@@ -152,7 +152,7 @@ function New-SupplementalWDACConfig {
                 SupplementalPolicyFile = "SupplementalPolicy $SuppPolicyName.xml"
                 SupplementalPolicyGUID = $PolicyID
             } 
-            if ($Deployit) {                
+            if ($Deploy) {                
                 CiTool --update-policy "$policyID.cip" -json | Out-Null
                 &$WritePink "A Supplemental policy with the name $SuppPolicyName has been deployed."
                 Remove-Item -Path "$policyID.cip" -Force
@@ -187,7 +187,7 @@ function New-SupplementalWDACConfig {
                 SupplementalPolicyGUID = $PolicyID
             }
     
-            if ($Deployit) {                
+            if ($Deploy) {                
                 CiTool --update-policy "$policyID.cip" -json | Out-Null
                 &$WritePink "A Supplemental policy with the name $SuppPolicyName has been deployed."
                 Remove-Item -Path "$policyID.cip" -Force                
@@ -243,7 +243,7 @@ function New-SupplementalWDACConfig {
                 SupplementalPolicyGUID = $PolicyID
             }
 
-            if ($Deployit) {                
+            if ($Deploy) {                
                 CiTool --update-policy "$policyID.cip" -json | Out-Null
                 &$WritePink "A Supplemental policy with the name $SuppPolicyName has been deployed."
                 Remove-Item -Path "$policyID.cip" -Force

--- a/WDACConfig/New-WDACConfig.psm1
+++ b/WDACConfig/New-WDACConfig.psm1
@@ -460,7 +460,7 @@ function New-WDACConfig {
             [System.String]$path = 'windows/security/application-security/application-control/windows-defender-application-control/design/microsoft-recommended-driver-block-rules.md'
         
             [System.String]$ApiUrl = "https://api.github.com/repos/$owner/$repo/commits?path=$path"
-            [System.Array]$Response = Invoke-RestMethod $ApiUrl
+            [System.Object[]]$Response = Invoke-RestMethod $ApiUrl
             [datetime]$Date = $Response[0].commit.author.date
         
             &$WriteLavender "`nThe document containing the drivers block list on GitHub was last updated on $Date"

--- a/WDACConfig/Resources.ps1
+++ b/WDACConfig/Resources.ps1
@@ -1,6 +1,6 @@
 # Stop operation as soon as there is an error anywhere, unless explicitly specified otherwise
 $ErrorActionPreference = 'Stop'
-if (-NOT ([System.Environment]::OSVersion.Version -ge '10.0.22621')) { Write-Error -Message "You're not using Windows 11 22H2, exitting..." }
+if (-NOT ([System.Environment]::OSVersion.Version -ge '10.0.22621')) { Write-Error -Message "You're not using Windows 11 22H2, exiting..." }
 
 # Get the path to SignTool
 function Get-SignTool {
@@ -320,11 +320,10 @@ function Confirm-CertCN ([string]$CN) {
 
 
 # script blocks for custom color writing
-[scriptblock]$WriteViolet = { Write-Output "$($PSStyle.Foreground.FromRGB(153,0,255))$($args[0])$($PSStyle.Reset)" }
+[scriptblock]$WriteHotPink = { Write-Output "$($PSStyle.Foreground.FromRGB(255,105,180))$($args[0])$($PSStyle.Reset)" }
 [scriptblock]$WritePink = { Write-Output "$($PSStyle.Foreground.FromRGB(255,0,230))$($args[0])$($PSStyle.Reset)" }
 [scriptblock]$WriteLavender = { Write-Output "$($PSStyle.Foreground.FromRgb(255,179,255))$($args[0])$($PSStyle.Reset)" }
 [scriptblock]$WriteTeaGreen = { Write-Output "$($PSStyle.Foreground.FromRgb(133, 222, 119))$($args[0])$($PSStyle.Reset)" }
-
 
 # Create File Rules based on hash of the files no longer available on the disk and store them in the $Rules variable
 function Get-FileRules {

--- a/WDACConfig/Resources.ps1
+++ b/WDACConfig/Resources.ps1
@@ -50,34 +50,38 @@ function Get-SignTool {
 
 # Make sure the latest version of the module is installed and if not, automatically update it, clean up any old versions
 function Update-self {
-    $currentversion = (Test-ModuleManifest "$psscriptroot\WDACConfig.psd1").Version.ToString()
+    $CurrentVersion = (Test-ModuleManifest "$psscriptroot\WDACConfig.psd1").Version.ToString()
     try {
         # First try the GitHub source
-        $latestversion = Invoke-RestMethod -Uri 'https://raw.githubusercontent.com/HotCakeX/Harden-Windows-Security/main/WDACConfig/version.txt'
+        $LatestVersion = Invoke-RestMethod -Uri 'https://raw.githubusercontent.com/HotCakeX/Harden-Windows-Security/main/WDACConfig/version.txt'
     }
     catch {
         try {
             # If GitHub source is unavailable, use the Azure DevOps source
-            $latestversion = Invoke-RestMethod -Uri 'https://dev.azure.com/SpyNetGirl/011c178a-7b92-462b-bd23-2c014528a67e/_apis/git/repositories/5304fef0-07c0-4821-a613-79c01fb75657/items?path=/WDACConfig/version.txt'        
+            $LatestVersion = Invoke-RestMethod -Uri 'https://dev.azure.com/SpyNetGirl/011c178a-7b92-462b-bd23-2c014528a67e/_apis/git/repositories/5304fef0-07c0-4821-a613-79c01fb75657/items?path=/WDACConfig/version.txt'        
         }
         catch {        
             Write-Error -Message "Couldn't verify if the latest version of the module is installed, please check your Internet connection. You can optionally bypass the online check by using -SkipVersionCheck parameter."
         }
     }
-    if ($currentversion -ne $latestversion) {
-        &$WritePink "The currently installed module's version is $currentversion while the latest version is $latestversion - Auto Updating the module now and will run your command after that 💓"
-        Remove-Module -Name WDACConfig -Force
+    if ($CurrentVersion -lt $LatestVersion) {
+        &$WritePink "The currently installed module's version is $CurrentVersion while the latest version is $LatestVersion - Auto Updating the module... 💓"
+        Remove-Module -Name 'WDACConfig' -Force
         # Do this if the module was installed properly using Install-module cmdlet
         try {
-            Uninstall-Module -Name WDACConfig -AllVersions -Force -ErrorAction Stop
-            Install-Module -Name WDACConfig -RequiredVersion $latestversion -Force              
-            Import-Module -Name WDACConfig -RequiredVersion $latestversion -Force -Global
+            Uninstall-Module -Name 'WDACConfig' -AllVersions -Force -ErrorAction Stop
+            Install-Module -Name 'WDACConfig' -RequiredVersion $LatestVersion -Force              
+            Import-Module -Name 'WDACConfig' -RequiredVersion $LatestVersion -Force -Global
         }
         # Do this if module files/folder was just copied to Documents folder and not properly installed - Should rarely happen
         catch {
-            Install-Module -Name WDACConfig -RequiredVersion $latestversion -Force
-            Import-Module -Name WDACConfig -RequiredVersion $latestversion -Force -Global
-        }            
+            Install-Module -Name 'WDACConfig' -RequiredVersion $LatestVersion -Force
+            Import-Module -Name 'WDACConfig' -RequiredVersion $LatestVersion -Force -Global
+        }    
+        # Make sure the old version isn't run after update
+        Write-Output "$($PSStyle.Foreground.FromRGB(152,255,152))Update successful, please run the cmdlet again.$($PSStyle.Reset)"          
+        break
+        return
     }
 }
 
@@ -355,21 +359,21 @@ Function Remove-ZerosFromIDs {
     param(
         [Parameter(Mandatory = $true)]
         [ValidateScript({ Test-Path -Path $_ -PathType Leaf })]
-        [string]$filePath
+        [string]$FilePath
     )    
     # Load the xml file
-    [xml]$xml = Get-Content -Path $filePath
+    [xml]$xml = Get-Content -Path $FilePath
 
     # Get all the elements with ID attribute
-    $elements = $xml.SelectNodes('//*[@ID]')
+    $Elements = $xml.SelectNodes('//*[@ID]')
 
     # Loop through the elements and replace _0 with empty string in the ID value and SignerId value
-    foreach ($element in $elements) {
-        $element.ID = $element.ID -replace '_0', ''
+    foreach ($Element in $Elements) {
+        $Element.ID = $Element.ID -replace '_0', ''
         # Check if the element has child elements with SignerId attribute
-        if ($element.HasChildNodes) {
+        if ($Element.HasChildNodes) {
             # Get the child elements with SignerId attribute
-            $childElements = $element.SelectNodes('.//*[@SignerId]')
+            $childElements = $Element.SelectNodes('.//*[@SignerId]')
             # Loop through the child elements and replace _0 with empty string in the SignerId value
             foreach ($childElement in $childElements) {
                 $childElement.SignerId = $childElement.SignerId -replace '_0', ''
@@ -378,20 +382,20 @@ Function Remove-ZerosFromIDs {
     }
 
     # Get the CiSigners element by name
-    $ciSigners = $xml.SiPolicy.CiSigners
+    $CiSigners = $xml.SiPolicy.CiSigners
 
     # Check if the CiSigners element has child elements with SignerId attribute
-    if ($ciSigners.HasChildNodes) {
+    if ($CiSigners.HasChildNodes) {
         # Get the child elements with SignerId attribute
-        $ciSignersChildren = $ciSigners.ChildNodes
+        $CiSignersChildren = $CiSigners.ChildNodes
         # Loop through the child elements and replace _0 with empty string in the SignerId value
-        foreach ($ciSignerChild in $ciSignersChildren) {
-            $ciSignerChild.SignerId = $ciSignerChild.SignerId -replace '_0', ''
+        foreach ($CiSignerChild in $CiSignersChildren) {
+            $CiSignerChild.SignerId = $CiSignerChild.SignerId -replace '_0', ''
         }
     }
 
     # Save the modified xml file
-    $xml.Save($filePath)
+    $xml.Save($FilePath)
 }
 
 
@@ -401,11 +405,11 @@ Function Move-UserModeToKernelMode {
     param(
         [Parameter(Mandatory = $true)]
         [ValidateScript({ Test-Path -Path $_ -PathType Leaf })]
-        [string]$filePath
+        [string]$FilePath
     ) 
 
     # Load the XML file as an XmlDocument object
-    $xml = [xml](Get-Content -Path $filePath)
+    $xml = [xml](Get-Content -Path $FilePath)
 
     # Get the SigningScenario nodes as an array
     $signingScenarios = $xml.SiPolicy.SigningScenarios.SigningScenario
@@ -417,20 +421,20 @@ Function Move-UserModeToKernelMode {
     $signingScenario12 = $signingScenarios | Where-Object { $_.Value -eq '12' }
 
     # Get the AllowedSigners node from the SigningScenario node with Value 12
-    $allowedSigners12 = $signingScenario12.ProductSigners.AllowedSigners
+    $AllowedSigners12 = $signingScenario12.ProductSigners.AllowedSigners
 
     # Check if the AllowedSigners node has any child nodes
-    if ($allowedSigners12.HasChildNodes) {
+    if ($AllowedSigners12.HasChildNodes) {
         # Loop through each AllowedSigner node from the SigningScenario node with Value 12
-        foreach ($allowedSigner in $allowedSigners12.AllowedSigner) {
+        foreach ($AllowedSigner in $AllowedSigners12.AllowedSigner) {
             # Create a new AllowedSigner node and copy the SignerId attribute from the original node
             # Use the namespace of the parent element when creating the new element
-            $newAllowedSigner = $xml.CreateElement('AllowedSigner', $signingScenario131.NamespaceURI)
-            $newAllowedSigner.SetAttribute('SignerId', $allowedSigner.SignerId)
+            $NewAllowedSigner = $xml.CreateElement('AllowedSigner', $signingScenario131.NamespaceURI)
+            $NewAllowedSigner.SetAttribute('SignerId', $AllowedSigner.SignerId)
 
             # Append the new AllowedSigner node to the AllowedSigners node of the SigningScenario node with Value 131
             # out-null to prevent console display
-            $signingScenario131.ProductSigners.AllowedSigners.AppendChild($newAllowedSigner) | Out-Null
+            $signingScenario131.ProductSigners.AllowedSigners.AppendChild($NewAllowedSigner) | Out-Null
         }
 
         # Remove the SigningScenario node with Value 12 from the XML document
@@ -439,11 +443,11 @@ Function Move-UserModeToKernelMode {
     }
 
     # Remove Signing Scenario 12 block only if it exists and has no allowed signers (i.e. is empty)
-    if ($signingScenario12 -and $allowedSigners12.count -eq 0) {
+    if ($signingScenario12 -and $AllowedSigners12.count -eq 0) {
         # Remove the SigningScenario node with Value 12 from the XML document
         $xml.SiPolicy.SigningScenarios.RemoveChild($signingScenario12)
     }
 
     # Save the modified XML document to a new file
-    $xml.Save($filePath)
+    $xml.Save($FilePath)
 }

--- a/WDACConfig/Resources2.ps1
+++ b/WDACConfig/Resources2.ps1
@@ -263,7 +263,13 @@ function Get-CertificateDetails {
     }
   
     # Build the certificate chain
-    $Chain = New-Object System.Security.Cryptography.X509Certificates.X509Chain
+    $Chain = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Chain
+
+    # Set the chain policy properties
+    $chain.ChainPolicy.RevocationMode = 'NoCheck'
+    $chain.ChainPolicy.RevocationFlag = 'EndCertificateOnly'
+    $chain.ChainPolicy.VerificationFlags = 'NoFlag'
+
     [void]$Chain.Build($Cert)
   
     # Check the value of the switch parameters
@@ -334,7 +340,7 @@ function Get-CertificateDetails {
 
 
 
-# Define a function that takes two file paths as input and compares the output of the Get-SignerInfo and Get-CertificateDetails functions
+# a function that takes WDAC XML policy file path and a Signed file path as inputs and compares the output of the Get-SignerInfo and Get-CertificateDetails functions
 function Compare-SignerAndCertificate {
     param(
         [ValidateScript({ Test-Path $_ -PathType Leaf })]
@@ -342,8 +348,7 @@ function Compare-SignerAndCertificate {
 
         [ValidateScript({ Test-Path $_ -PathType Leaf })]
         [Parameter(Mandatory = $true)] [string]$SignedFilePath
-    )
-  
+    )  
 
     # Get the signer information from the XML file path using the Get-SignerInfo function
     $SignerInfo = Get-SignerInfo -XmlFilePath $XmlFilePath  
@@ -357,6 +362,7 @@ function Compare-SignerAndCertificate {
     # Get the certificate details from the signed file path using the Get-CertificateDetails function with the IntermediateOnly switch parameter
     $CertificateDetails += Get-CertificateDetails -IntermediateOnly -FilePath $SignedFilePath
 
+    # Get the Nested certificate of the signed file, if any
     $ExtraCertificateDetails = Get-AuthenticodeSignatureEx -FilePath $SignedFilePath
 
     $NestedCertificate = ($ExtraCertificateDetails).NestedSignature.SignerCertificate
@@ -366,8 +372,6 @@ function Compare-SignerAndCertificate {
         # append an X509Certificate2 object to the array
         $NestedCertificateDetails += Get-CertificateDetails -IntermediateOnly -X509Certificate2 $NestedCertificate
     }
-
-
   
     # Create an empty array to store the comparison results
     [System.Object[]]$ComparisonResults = @()
@@ -394,19 +398,19 @@ function Compare-SignerAndCertificate {
         foreach ($Certificate in $CertificateDetails) {
             # Check if the signer's CertRoot (referring to the TBS value in the xml file which belongs to an intermediate cert of the file)...
             # ...matches the TBSValue of the file's certificate (TBS values of one of the intermediate certificates of the file since -IntermediateOnly parameter is used earlier and that's what FilePublisher level uses)
-            # So this checks to see if the Signer's TBS value in xml matches any of the TBS value(s) of the file's intermediate certificate(s), if yes, that means that file is allowed to run by WDAC engine
+            # So this checks to see if the Signer's TBS value in xml matches any of the TBS value(s) of the file's intermediate certificate(s), if yes, that means that file is allowed to run by the WDAC engine
             if ($Signer.CertRoot -eq $Certificate.TBSValue) {
                 # If yes, assign the certificate properties to the comparison result object and set the CertRootMatch to true
                 $ComparisonResult.CertSubjectCN = $Certificate.SubjectCN
                 $ComparisonResult.CertIssuerCN = $Certificate.IssuerCN
                 $ComparisonResult.CertNotAfter = $Certificate.NotAfter
                 $ComparisonResult.CertTBSValue = $Certificate.TBSValue
-                # if file has nested signature, only set a flag instead of setting the entire property to true
+                # if file has nested signature, only set a flag instead of setting the entire CertRootMatch property to true
                 if ($null -ne $NestedCertificate) {
                     $CertRootMatchPart1 = $true
                 }
                 else {
-                    $ComparisonResult.CertRootMatch = $true # meaning one of the TBS values of the file's intermediate certs is in the xml file signers's TBS values
+                    $ComparisonResult.CertRootMatch = $true # meaning one of the TBS values of the file's intermediate certs is in the xml file signers' TBS values
                 }
 
                 # Check if the signer's Name matches the Intermediate certificate's SubjectCN
@@ -419,11 +423,6 @@ function Compare-SignerAndCertificate {
                 break
             }
         }
-
-
-
-
-
 
         # Nested Certificate TBS processing
         if ($null -ne $NestedCertificate) {
@@ -455,24 +454,16 @@ function Compare-SignerAndCertificate {
         }
 
 
-
         # if file has nested certificates
         if ($null -ne $NestedCertificate) {
             # check if both of the file's nested certificates are available in the Signers in xml policy
             if ( $CertRootMatchPart1 -eq $true -and $CertRootMatchPart2 -eq $true) {
                 $ComparisonResult.CertRootMatch = $true # meaning all of the TBS values of the double signed file's intermediate certificates exists in the xml file's signers' TBS values
-                                                        
             }
             else {
                 $ComparisonResult.CertRootMatch = $false 
             }
-        }
-        
-
-
-
-
-
+        }        
 
         # Add the comparison result object to the comparison results array
         $ComparisonResults += $ComparisonResult
@@ -488,18 +479,13 @@ function Compare-SignerAndCertificate {
     # Get the leaf certificate details from the signed file path
     $LeafCertificateDetails += Get-CertificateDetails -LeafCertificate -FilePath $SignedFilePath
 
-
     # Store Leaf Certificate details of the 2nd certificate into another array variable if it exists
     if ($null -ne $NestedCertificate) {
         # append an X509Certificate2 object to the array
         $NestedLeafCertificateDetails += Get-CertificateDetails -LeafCertificate -X509Certificate2 $NestedCertificate
     }
 
-
-
-
-
-  
+    
     # Loop through each signer in the signer information array again
     foreach ($Signer in $SignerInfo) {
         # Find the corresponding comparison result object for this signer in the comparison results array
@@ -514,17 +500,13 @@ function Compare-SignerAndCertificate {
             }
         }
     }
-
     # Return the comparison results array
-    return $ComparisonResults
-  
+    return $ComparisonResults  
 }  
   
 
 
-# HASH COMPARISON FUNCTIONS
-
-# Define a function to load an xml file and create an output array of custom objects
+# Define a function to load an xml file and create an output array of custom objects that contain the file rules that are based on file hashes
 function Get-FileRuleOutput ($xmlPath) {
 
     # Load the xml file into a variable
@@ -540,12 +522,10 @@ function Get-FileRuleOutput ($xmlPath) {
         $hashvalue = $filerule.Hash
 
         # Extract the hash type from the FriendlyName attribute using regex
-        $hashtype = $filerule.FriendlyName -replace '.* (Hash (Sha1|Sha256|Page Sha1|Page Sha256))$', '$1'
+        $hashtype = $filerule.FriendlyName -replace '.* (Hash (Sha1|Sha256|Page Sha1|Page Sha256|Authenticode SIP Sha256))$', '$1'
 
         # Extract the file path from the FriendlyName attribute using regex
-        # $FilePathForHash = $filerule.FriendlyName -replace " (.*) (Hash (Sha1|Sha256|Page Sha1|Page Sha256))$", '$1'
-
-        $FilePathForHash = $filerule.FriendlyName -replace ' (Hash (Sha1|Sha256|Page Sha1|Page Sha256))$', ''
+        $FilePathForHash = $filerule.FriendlyName -replace ' (Hash (Sha1|Sha256|Page Sha1|Page Sha256|Authenticode SIP Sha256))$', ''
        
         # Create a custom object with the three properties
         $object = [PSCustomObject]@{
@@ -560,10 +540,15 @@ function Get-FileRuleOutput ($xmlPath) {
         }
     }
 
+    # Only show the Authenticode Hash SHA256
+    $OutPutHashInfoProcessing = $OutPutHashInfoProcessing | Where-Object { $_.hashtype -eq 'Hash Sha256' }
+
     # Return the output array
     return $OutPutHashInfoProcessing
 }
 
+
+<# NOT USED ANYMORE
 
 # Define a function to compare two xml files and return an array of objects with a custom property for the comparison result
 function Compare-XmlFiles ($refXmlPath, $tarXmlPath) {
@@ -608,6 +593,5 @@ function Compare-XmlFiles ($refXmlPath, $tarXmlPath) {
 
     }
 }
-
-
+#>
 

--- a/WDACConfig/Resources2.ps1
+++ b/WDACConfig/Resources2.ps1
@@ -17,7 +17,7 @@ function Get-SignerInfo {
     $Signers = $xml.SiPolicy.Signers.Signer
   
     # Create an empty array to store the output
-    [System.Array]$output = @()
+    [System.Object[]]$output = @()
   
     # Loop through each Signer node and extract the information
     foreach ($signer in $signers) {
@@ -35,6 +35,7 @@ function Get-SignerInfo {
     # Return the output array
     return $output
 }
+
 
 # Function to calculate the TBS of a certificate
 function Get-TBSCertificate {
@@ -140,7 +141,7 @@ function Get-AuthenticodeSignatureEx {
             
         # Define a helper function to get the timestamps of the countersigners
         function getTimeStamps($SignerInfo) {
-            [System.Array]$retValue = @()
+            [System.Object[]]$retValue = @()
             foreach ($CounterSignerInfos in $Infos.CounterSignerInfos) {                    
                 # Get the signing time attribute from the countersigner info object
                 $sTime = ($CounterSignerInfos.SignedAttributes | Where-Object { $_.Oid.Value -eq '1.2.840.113549.1.9.5' }).Values | `
@@ -348,10 +349,10 @@ function Compare-SignerAndCertificate {
     $SignerInfo = Get-SignerInfo -XmlFilePath $XmlFilePath  
    
     # Declare $CertificateDetails as an array
-    [System.Array]$CertificateDetails = @()
+    [System.Object[]]$CertificateDetails = @()
 
     # Declare $NestedCertificateDetails as an array 
-    [System.Array]$NestedCertificateDetails = @()
+    [System.Object[]]$NestedCertificateDetails = @()
 
     # Get the certificate details from the signed file path using the Get-CertificateDetails function with the IntermediateOnly switch parameter
     $CertificateDetails += Get-CertificateDetails -IntermediateOnly -FilePath $SignedFilePath
@@ -369,7 +370,7 @@ function Compare-SignerAndCertificate {
 
   
     # Create an empty array to store the comparison results
-    [System.Array]$ComparisonResults = @()
+    [System.Object[]]$ComparisonResults = @()
   
     # Loop through each signer in the signer information array
     foreach ($Signer in $SignerInfo) {
@@ -479,10 +480,10 @@ function Compare-SignerAndCertificate {
     }
 
     # Declare $LeafCertificateDetails as an array
-    [System.Array]$LeafCertificateDetails = @()
+    [System.Object[]]$LeafCertificateDetails = @()
 
     # Declare $NestedLeafCertificateDetails as an array
-    [System.Array]$NestedLeafCertificateDetails = @()
+    [System.Object[]]$NestedLeafCertificateDetails = @()
   
     # Get the leaf certificate details from the signed file path
     $LeafCertificateDetails += Get-CertificateDetails -LeafCertificate -FilePath $SignedFilePath
@@ -530,7 +531,7 @@ function Get-FileRuleOutput ($xmlPath) {
     $xml = [xml](Get-Content -Path $xmlPath)
 
     # Create an empty array to store the output
-    [System.Array]$OutPutHashInfoProcessing = @()
+    [System.Object[]]$OutPutHashInfoProcessing = @()
 
     # Loop through each file rule in the xml file
     foreach ($filerule in $xml.SiPolicy.FileRules.Allow) {
@@ -583,7 +584,7 @@ function Compare-XmlFiles ($refXmlPath, $tarXmlPath) {
         $comparison = Compare-Object -ReferenceObject $refoutput -DifferenceObject $taroutput -Property HashValue -PassThru -IncludeEqual
 
         # Create an empty array to store the output objects
-        [System.Array]$OutPutHashComparison = @()
+        [System.Object[]]$OutPutHashComparison = @()
 
         # Loop through each object in the comparison array
         foreach ($object in $comparison) {

--- a/WDACConfig/Set-CommonWDACConfig.psm1
+++ b/WDACConfig/Set-CommonWDACConfig.psm1
@@ -81,7 +81,7 @@ function Set-CommonWDACConfig {
 
         # Scan the file with Microsoft Defender for anything malicious before it's going to be used
         Start-MpScan -ScanType CustomScan -ScanPath "$env:USERPROFILE\.WDACConfig\UserConfigurations.json"
-
+        
         if ($PSBoundParameters.Count -eq 0) {
             Write-Error 'No parameter was selected.'
             break

--- a/WDACConfig/WDACConfig.psd1
+++ b/WDACConfig/WDACConfig.psd1
@@ -8,7 +8,7 @@
     # RootModule           = ""
 
     # Version number of this module.
-    ModuleVersion        = '0.2.1'
+    ModuleVersion        = '0.2.2'
 
     # Supported PSEditions
     CompatiblePSEditions = @('Core')
@@ -202,29 +202,6 @@ To get help and syntax on PowerShell console, type:
 
             # ReleaseNotes of this module
             ReleaseNotes = @'
-      
-## Version 0.2.1
-1. Added -AllowFileNameFallbacks parameter by default when creating policies. It's a great parameter that helps include files that do not have an OriginalFileName.
-2. Fixed the Microsoft recommended Block lists URLs in the code because they were changed and had to be updated
-3. Improved code quality (Security, readability, typos in the comments etc.)
-
-## Version 0.2.0
-1. Added WDAC Simulation using the new Invoke-WDACSimulation Cmdlet
-2. Added Get-CommonWDACConfig Cmdlet dedicated only to querying the User Configs and reading them. Set-CommonWDACConfig Cmdlet is only for storing User Configurations.
-3. Eliminated the need for an extra reboot in New-KernelModeWDACConfig Cmdlet. From now on, only one reboot is required and that's only during the Audit mode. For deploying the Enforced mode policy, the module replaces the Audit mode policy with the new enforced mode and it instantly becomes operative.
-4. Improved the argument completers of the Set-CommonWDACConfig Cmdlet by showing GUI for file picking.
-5. Added new parameter to the New-DenyWDACConfig Cmdlet for creating deny rule for Windows Appx apps
-6. Improved the parameter usage logic in New-KernelModeWDACConfig Cmdlet
-
-## Version 0.1.9
-Improved the New-WDACConfig -MakePolicyFromAuditLogs by accounting for situations where event viewer logs don't contain any files that are no longer on the disk even though user chooses to include them.
-Added new functionality and cmdlet New-KernelModeWDACConfig, capable of providing complete protection against all BYOVD (Bring Your Own Vulnerable Driver) scenarios
-Improved the Set-CommonWDACConfig argument completers by showing a file picker GUI when selecting certificates or browsing for custom SignTool.exe path.
-
-## Version 0.1.8
-Added Enforced mode SnapBack guarantee for the Edit-WDACConfig and Edit-SignedWDACConfig cmdlets so that even in case of power outage or computer crash, the enforcement will be restored.
-Improved the code style for better consistency.
-Added Azure source for version check as the backup endpoint.
 
 Full Change log available in GitHub releases: https://github.com/HotCakeX/Harden-Windows-Security/releases
 


### PR DESCRIPTION
# What's changed so far
1. ~~Added new parameter for `Deploy-SignedWDAC` cmdlet, called `-SignOnly`, indicating that the cmdlet will only output a signed WDAC policy ready for deployment and will not deploy it on the system. This is specially useful for when you want to deploy the policy somewhere else using the `Citool.exe` built-in tool.~~
2. Improved the UX by implementing file picker UI for when you need to browse for the SignTool.exe in `Edit-SignedWDACConfig`, `Remove-WDACConfig` and `Deploy-SignedWDACConfig`
3. Improved the self updating mechanism and its messages.
4. Fixed a bug in an edge case where `Remove-WDACConfig` cmdlet wouldn't auto complete policy names if one of the policies didn't have a friendly name.
5. `Remove-WDACConfig` cmdlet now shows `-PolicyNames` first above the `-PolicyIDs` for more convenience.
