### PR TITLE
Update ProcessMitigations.csv

### DIFF
--- a/Payload/ProcessMitigations.csv
+++ b/Payload/ProcessMitigations.csv
@@ -173,8 +173,6 @@ explorer.exe,ForceRelocateImages,Enable,Explorer
 explorer.exe,RequireInfo,Enable,Explorer
 explorer.exe,StrictHandle,Enable,Explorer
 explorer.exe,DisableExtensionPoints,Enable,Explorer
-explorer.exe,CFG,Enable,Explorer
-explorer.exe,StrictCFG,Enable,Explorer
 explorer.exe,EnableExportAddressFilter,Enable,Explorer
 explorer.exe,EnableExportAddressFilterPlus,Enable,Explorer
 explorer.exe,EnableImportAddressFilter,Enable,Explorer


### PR DESCRIPTION
To resolve this issue https://github.com/HotCakeX/Harden-Windows-Security/issues/115, removing Strict CFG from explorer.exe process mitigations.

CFG (Control Flow Guard) is already enabled by default in Windows, just not in strict mode.

More info: https://learn.microsoft.com/en-us/microsoft-365/security/defender-endpoint/exploit-protection-reference?view=o365-worldwide#control-flow-guard-cfg
