### PR TITLE
Fixed an error encountered when using Windows PowerShell

### DIFF
--- a/Harden-Windows-Security Module/Main files/Resources/Harden-Windows-Security.ps1
+++ b/Harden-Windows-Security Module/Main files/Resources/Harden-Windows-Security.ps1
@@ -2023,7 +2023,10 @@ IMPORTANT: Make sure to keep it in a safe place, e.g., in OneDrive's Personal Va
                 Write-Progress -Id 0 -Activity 'Optional Windows Features' -Status "Step $CurrentMainStep/$TotalMainSteps" -PercentComplete ($CurrentMainStep / $TotalMainSteps * 100)
 
                 # PowerShell Core (only if installed from Microsoft Store) has problem with these commands: https://github.com/PowerShell/PowerShell/issues/13866#issuecomment-1519066710
-                Import-Module -Name 'DISM' -UseWindowsPowerShell -Force -WarningAction SilentlyContinue
+                # Windows Powershell (old one) doesn't support the -UseWindowsPowerShell parameter, so only performing the import if PS Core is installed from Microsoft Store
+                if (($PSHome -like '*C:\Program Files\WindowsApps\Microsoft.PowerShell*') -and ($PSVersionTable.PSEdition -eq 'Core')) {
+                    Import-Module -Name 'DISM' -UseWindowsPowerShell -Force -WarningAction SilentlyContinue
+                }
 
                 Edit-Addons -Type Feature -FeatureAction Disabling -FeatureName 'MicrosoftWindowsPowerShellV2'
                 Edit-Addons -Type Feature -FeatureAction Disabling -FeatureName 'MicrosoftWindowsPowerShellV2Root'

--- a/Harden-Windows-Security.ps1
+++ b/Harden-Windows-Security.ps1
@@ -2023,7 +2023,10 @@ IMPORTANT: Make sure to keep it in a safe place, e.g., in OneDrive's Personal Va
                 Write-Progress -Id 0 -Activity 'Optional Windows Features' -Status "Step $CurrentMainStep/$TotalMainSteps" -PercentComplete ($CurrentMainStep / $TotalMainSteps * 100)
 
                 # PowerShell Core (only if installed from Microsoft Store) has problem with these commands: https://github.com/PowerShell/PowerShell/issues/13866#issuecomment-1519066710
-                Import-Module -Name 'DISM' -UseWindowsPowerShell -Force -WarningAction SilentlyContinue
+                # Windows Powershell (old one) doesn't support the -UseWindowsPowerShell parameter, so only performing the import if PS Core is installed from Microsoft Store
+                if (($PSHome -like '*C:\Program Files\WindowsApps\Microsoft.PowerShell*') -and ($PSVersionTable.PSEdition -eq 'Core')) {
+                    Import-Module -Name 'DISM' -UseWindowsPowerShell -Force -WarningAction SilentlyContinue
+                }
 
                 Edit-Addons -Type Feature -FeatureAction Disabling -FeatureName 'MicrosoftWindowsPowerShellV2'
                 Edit-Addons -Type Feature -FeatureAction Disabling -FeatureName 'MicrosoftWindowsPowerShellV2Root'


### PR DESCRIPTION
# What's Changed
* Added a fix for an error encountered when using Windows PowerShell (old one) in the Optional Windows Features category. The module doesn't need it since it already requires PowerShell Core. If you use the old Windows PowerShell, use [this method](https://github.com/HotCakeX/Harden-Windows-Security?tab=readme-ov-file#-apply-the-latest-hardening-measures-directly-from-this-github-repository) as shown on the readme page.