### PR TITLE
Fixed Winget Dependency in action workflow

### DIFF
--- a/.github/workflows/Build AppControl Manager MSIX Package.yml
+++ b/.github/workflows/Build AppControl Manager MSIX Package.yml
@@ -24,25 +24,32 @@ jobs:
           [string]$WingetRepoURL = 'https://api.github.com/repos/microsoft/winget-cli/releases'
           $WingetReleases = Invoke-RestMethod -Uri $WingetRepoURL
           $LatestRelease = $WingetReleases | Select-Object -First 1
-          [string]$WingetURL2 = $LatestRelease.assets.browser_download_url | Where-Object { $_.EndsWith('.msixbundle') } | Select-Object -First 1
-          [string]$WingetLicense = $LatestRelease.assets.browser_download_url | Where-Object { $_.EndsWith('License1.xml') } | Select-Object -First 1
+          # Direct Winget package link from the latest release
+          [string]$WingetURL2 = $LatestRelease.assets.browser_download_url | Where-Object -FilterScript { $_.EndsWith('.msixbundle') } | Select-Object -First 1
+          [string]$WingetLicense = $LatestRelease.assets.browser_download_url | Where-Object -FilterScript { $_.EndsWith('License1.xml') } | Select-Object -First 1
+          [string]$LatestWingetReleaseDependenciesZipURL = "https://github.com/microsoft/winget-cli/releases/download/$($LatestRelease.tag_name)/DesktopAppInstaller_Dependencies.zip"
           [hashtable]$Downloads = @{
-              'VCLibs.appx'            = 'https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx'
-              'Microsoft.UI.Xaml.appx' = 'https://github.com/microsoft/microsoft-ui-xaml/releases/download/v2.8.6/Microsoft.UI.Xaml.2.8.x64.appx'
-              'Winget.msixbundle'      = 'https://aka.ms/getwinget'
-              'License1.xml'           = $WingetLicense
+              'DesktopAppInstaller_Dependencies.zip' = $LatestWingetReleaseDependenciesZipURL
+              'Winget.msixbundle'                    = 'https://aka.ms/getwinget'
+              'License1.xml'                         = $WingetLicense
           }
           $Downloads.GetEnumerator() | ForEach-Object -Parallel {
               $FileName = $_.Key
               $URL = $_.Value
               Invoke-RestMethod -Uri $URL -OutFile $FileName
           }
-          Add-AppxProvisionedPackage -Online -PackagePath 'Winget.msixbundle' -DependencyPackagePath 'Microsoft.UI.Xaml.appx', 'VCLibs.appx' -LicensePath 'License1.xml'
+          Expand-Archive -Path 'DesktopAppInstaller_Dependencies.zip' -DestinationPath .\ -Force
+          [string[]]$DependencyPaths = (Get-ChildItem -Path .\x64 -Filter '*.appx' -File).FullName
+          Add-AppxProvisionedPackage -Online -PackagePath 'Winget.msixbundle' -DependencyPackagePath $DependencyPaths -LicensePath 'License1.xml'
+          
+          # Add the dependency paths to the GitHub environment to be used in the next step
+          Add-Content -Path $env:GITHUB_ENV -Value "WINGET_DEPENDENCY1=$($DependencyPaths[0])"
+          Add-Content -Path $env:GITHUB_ENV -Value "WINGET_DEPENDENCY2=$($DependencyPaths[1])"
 
       - name: Finishing setting up Winget
         shell: powershell
         run: |
-          Add-AppPackage -Path 'Winget.msixbundle' -DependencyPath 'Microsoft.UI.Xaml.appx', 'VCLibs.appx' -ForceTargetApplicationShutdown -ForceUpdateFromAnyVersion
+          Add-AppPackage -Path 'Winget.msixbundle' -DependencyPath  "${{ env.WINGET_DEPENDENCY1 }}", "${{ env.WINGET_DEPENDENCY2 }}" -ForceTargetApplicationShutdown -ForceUpdateFromAnyVersion
           # Add-AppPackage on Windows Server throws error so we use Windows PowerShell for this section.
 
       - name: Installing the necessary programs


### PR DESCRIPTION
Latest version of Winget requires a newer dependency version that is supplied by the official release itself

https://github.com/microsoft/winget-cli/releases/tag/v1.9.25180

more info
https://github.com/microsoft/winget-cli/discussions/4937

That dependency which the action used to get from this permalink:
```
https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx
```
has not been updated to the latest version.