### PR TITLE
api.nuget.org - all lowercase URLs

### DIFF
--- a/Harden-Windows-Security.ps1
+++ b/Harden-Windows-Security.ps1
@@ -276,8 +276,8 @@ public static class SecureStringGenerator
 
         if ([System.String]::IsNullOrWhiteSpace($SignTool)) {
             Write-Verbose -Message 'Finding the latest version of the Microsoft.Windows.SDK.BuildTools package from NuGet and Downloading it'
-            [System.String]$LatestSignToolVersion = (Invoke-RestMethod -Uri 'https://api.nuget.org/v3-flatcontainer/Microsoft.Windows.SDK.BuildTools/index.json').versions | Select-Object -Last 1
-            Invoke-WebRequest -Uri "https://api.nuget.org/v3-flatcontainer/Microsoft.Windows.SDK.BuildTools/${LatestSignToolVersion}/Microsoft.Windows.SDK.BuildTools.${LatestSignToolVersion}.nupkg" -OutFile (Join-Path -Path $WorkingDir -ChildPath 'Microsoft.Windows.SDK.BuildTools.zip')
+            [System.String]$LatestSignToolVersion = (Invoke-RestMethod -Uri 'https://api.nuget.org/v3-flatcontainer/microsoft.windows.sdk.buildtools/index.json').versions | Select-Object -Last 1
+            Invoke-WebRequest -Uri "https://api.nuget.org/v3-flatcontainer/microsoft.windows.sdk.buildtools/${LatestSignToolVersion}/microsoft.windows.sdk.buildtools.${LatestSignToolVersion}.nupkg" -OutFile (Join-Path -Path $WorkingDir -ChildPath 'Microsoft.Windows.SDK.BuildTools.zip')
             Write-Verbose -Message 'Extracting the nupkg'
             Expand-Archive -Path "$WorkingDir\Microsoft.Windows.SDK.BuildTools.zip" -DestinationPath $WorkingDir -Force # Saving .nupkg as .zip to satisfy Windows PowerShell
             Write-Verbose -Message 'Finding the Signtool.exe path in the extracted directory'


### PR DESCRIPTION
**Change all api.nuget.org URLs to all lowercase** 

I was seeing download errors when trying to install the AppControl Manager.

Example:

> BlobNotFound The specified blob does not exist.

The offending line in the .ps1 was 279, which points to api.nuget.org and was written in CamelCase.

According to[ this issue](https://github.com/NuGet/NuGetGallery/issues/9600) on NuGetGallery, this is expected and can happen depending on which CDN is used.

They point to the Nuget documentation, which demands all package ID be lowercased.

After changing this in the .ps1, I was able to install the tool successfully.

<!--
Thank you for submitting a pull request!

* [ ] Please verify that your code is up-to-date with the `main` branch.
* [ ] Define the current behavior and the new behavior we should expect with the changes in this PR.
* [ ] Link any issues that this PR will fix.
-->
