### PR TITLE
AppControl Manager 1.5.1.0

### DIFF
--- a/AppControl Manager/AppControl Manager.csproj
+++ b/AppControl Manager/AppControl Manager.csproj
@@ -80,7 +80,7 @@
     <AssemblyName>AppControlManager</AssemblyName>
     <PublishAot>False</PublishAot>
     <ErrorReport>send</ErrorReport>
-    <FileVersion>1.5.0.0</FileVersion>
+    <FileVersion>1.5.1.0</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/AppControl Manager/Logic/CertificateCreator.cs
+++ b/AppControl Manager/Logic/CertificateCreator.cs
@@ -10,7 +10,7 @@ namespace WDACConfig
     {
 
         /// <summary>
-        /// Build a self-signed on-device certificate for the purpose of AppControl policy signing
+        /// Build a self-signed on-device certificate for the purpose of App Control policy signing
         /// Use certutil -dump -v '.\codesign.cer' to view the certificate properties, such as encoding of the certificate fields like the subject
         /// </summary>
         /// <param name="CommonName"></param>

--- a/AppControl Manager/Logic/IntelGathering/LocalFilesScan.cs
+++ b/AppControl Manager/Logic/IntelGathering/LocalFilesScan.cs
@@ -75,7 +75,7 @@ namespace WDACConfig.IntelGathering
                 if (fileIsSigned)
                 {
 
-                    // The EKU OIDs of the primary signer of the file, just like the output of the Get-AuthenticodeSignature cmdlet, the ones that AppControl policy uses for EKU-based authorization
+                    // The EKU OIDs of the primary signer of the file, just like the output of the Get-AuthenticodeSignature cmdlet, the ones that App Control policy uses for EKU-based authorization
                     // Only the leaf certificate of the primary signer has EKUs, others such as root or intermediate have KUs only.
                     ekuOIDs = FileSignatureResults
                        .Where(p => p.Signer?.SignerInfos is not null)

--- a/AppControl Manager/Logic/MoveUserModeToKernelMode.cs
+++ b/AppControl Manager/Logic/MoveUserModeToKernelMode.cs
@@ -8,7 +8,7 @@ namespace WDACConfig
         /// <summary>
         /// Moves all User mode AllowedSigners in the User mode signing scenario to the Kernel mode signing scenario and then
         /// deletes the entire User mode signing scenario block
-        /// This is used during the creation of Strict Kernel-mode AppControl policy for complete BYOVD protection scenario.
+        /// This is used during the creation of Strict Kernel-mode App Control policy for complete BYOVD protection scenario.
         /// It doesn't consider <FileRulesRef> node in the SigningScenario 12 when deleting it because for kernel-mode policy everything is signed and we don't deal with unsigned files.
         /// </summary>
         /// <param name="filePath">The path to the XML file</param>

--- a/AppControl Manager/Logic/XMLOps/XMLOps.cs
+++ b/AppControl Manager/Logic/XMLOps/XMLOps.cs
@@ -4,7 +4,7 @@ namespace WDACConfig
     public static class XMLOps
     {
         /// <summary>
-        /// Uses the scan data to generate an AppControl policy and makes sure the data are unique
+        /// Uses the scan data to generate an App Control policy and makes sure the data are unique
         /// </summary>
         /// <param name="incomingData"></param>
         /// <param name="xmlFilePath"></param>

--- a/AppControl Manager/MainWindow.xaml
+++ b/AppControl Manager/MainWindow.xaml
@@ -97,17 +97,17 @@
                 <NavigationViewItem x:Name="BuildNewCertificateNavItem" Content="Build New Certificate" ToolTipService.ToolTip="Generate Certificates that are suitable for signing App Control Policies" Tag="BuildNewCertificate"/>
 
                 <!-- Make it expanded by default to show the import feature to the user at first sight -->
-                <NavigationViewItem x:Name="CreatePolicyFromEventLogsNavItem" IsExpanded="True" Content="Create policy from Event Logs" ToolTipService.ToolTip="Create AppControl policy either from the local event logs or EVTX files" Tag="EventLogsPolicyCreation">
+                <NavigationViewItem x:Name="CreatePolicyFromEventLogsNavItem" IsExpanded="True" Content="Create policy from Event Logs" ToolTipService.ToolTip="Create App Control policy either from the local event logs or EVTX files" Tag="EventLogsPolicyCreation">
 
                     <NavigationViewItem.MenuItems>
-                        <NavigationViewItem x:Name="CreatePolicyFromMDEAHNavItem" Content="Create policy from MDE Advanced Hunting" ToolTipService.ToolTip="Create AppControl policy from Microsoft Defender for Endpoint (MDE) Advanced Hunting Logs" Tag="MDEAHPolicyCreation"/>
+                        <NavigationViewItem x:Name="CreatePolicyFromMDEAHNavItem" Content="MDE Advanced Hunting" ToolTipService.ToolTip="Create App Control policy from Microsoft Defender for Endpoint (MDE) Advanced Hunting Logs" Tag="MDEAHPolicyCreation" />
                     </NavigationViewItem.MenuItems>
 
                 </NavigationViewItem>
 
                 <NavigationViewItemSeparator/>
 
-                <NavigationViewItem x:Name="DeploymentNavItem" Content="Deploy AppControl Policy" ToolTipService.ToolTip="Deploy signed or unsigned AppControl policies on the system" Tag="Deployment"/>
+                <NavigationViewItem x:Name="DeploymentNavItem" Content="Deploy App Control Policy" ToolTipService.ToolTip="Deploy signed or unsigned AppControl policies on the system" Tag="Deployment"/>
 
                 <NavigationViewItem x:Name="GetCodeIntegrityHashesNavItem" Content="Get Code Integrity Hashes" ToolTipService.ToolTip="Get Code Integrity Hashes of files" Tag="GetCIHashes"/>
 

--- a/AppControl Manager/MainWindow.xaml.cs
+++ b/AppControl Manager/MainWindow.xaml.cs
@@ -39,9 +39,9 @@ namespace WDACConfig
             { typeof(Pages.Logs), "Logs" },
             { typeof(Pages.Simulation), "Simulation" },
             { typeof(Pages.Update), "Update" },
-            { typeof(Pages.Deployment), "Deploy AppControl Policy" },
+            { typeof(Pages.Deployment), "Deploy App Control Policy" },
             { typeof(Pages.EventLogsPolicyCreation), "Create policy from Event Logs" },
-            { typeof(Pages.MDEAHPolicyCreation), "Create policy from MDE Advanced Hunting" },
+            { typeof(Pages.MDEAHPolicyCreation), "MDE Advanced Hunting" },
             { typeof(Pages.AllowNewApps), "Allow New Apps" },
             { typeof(Pages.BuildNewCertificate), "Build New Certificate" },
             { typeof(Pages.UpdatePageCustomMSIXPath), "Custom MSIX Path" }, // sub-page
@@ -304,7 +304,7 @@ namespace WDACConfig
                             Source = new Scan()
                         };
 
-                        // Create Policy from MDE Advanced Hunting
+                        // MDE Advanced Hunting
                         CreatePolicyFromMDEAHNavItem.Icon = new AnimatedIcon
                         {
                             Margin = new Thickness(0, -8, -8, -8),
@@ -434,7 +434,7 @@ namespace WDACConfig
                             Foreground = accentBrush
                         };
 
-                        // Create Policy from MDE Advanced Hunting
+                        // MDE Advanced Hunting
                         CreatePolicyFromMDEAHNavItem.Icon = new FontIcon
                         {
                             Glyph = "\uEB44",
@@ -548,7 +548,7 @@ namespace WDACConfig
                             Glyph = "\uEA18"
                         };
 
-                        // Create Policy from MDE Advanced Hunting
+                        // MDE Advanced Hunting
                         CreatePolicyFromMDEAHNavItem.Icon = new FontIcon
                         {
                             Glyph = "\uEB44"

--- a/AppControl Manager/Package.appxmanifest
+++ b/AppControl Manager/Package.appxmanifest
@@ -11,7 +11,7 @@
   <Identity
     Name="AppControlManager"
     Publisher="CN=SelfSignedCertForAppControlManager"
-    Version="1.5.0.0" />
+    Version="1.5.1.0" />
 
   <mp:PhoneIdentity PhoneProductId="199a23ec-7cb6-4ab5-ab50-8baca348bc79" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/AppControl Manager/Pages/AllowNewApps/AllowNewAppsStart.xaml
+++ b/AppControl Manager/Pages/AllowNewApps/AllowNewAppsStart.xaml
@@ -34,7 +34,7 @@
 
             </Grid.Resources>
 
-            <controls:WrapPanel Grid.Row="0" VerticalSpacing="15" HorizontalSpacing="15" Orientation="Horizontal" Margin="6,10,6,10">
+            <controls:WrapPanel Grid.Row="0" VerticalSpacing="15" HorizontalSpacing="15" Orientation="Vertical" Margin="6,10,6,10">
 
                 <TextBlock
 TextWrapping="WrapWholeWords"
@@ -46,9 +46,15 @@ Style="{StaticResource BodyTextBlockStyle}">
 </Span>
                 </TextBlock>
 
+                <HyperlinkButton Content="Guide" NavigateUri="https://github.com/HotCakeX/Harden-Windows-Security/wiki/Allow-New-Apps" />
+
+                <StackPanel Orientation="Horizontal" Spacing="15">
+
                 <Button x:Name="ResetStepsButton" Click="ResetStepsButton_Click" Style="{StaticResource AccentButtonStyle}" Content="Reset Steps" ToolTipService.ToolTip="Will reset the steps and if the base policy is deployed in Audit mode, will redeploy it in Enforced mode." />
 
                 <ProgressRing IsActive="False" x:Name="ResetProgressRing"/>
+
+                </StackPanel>
 
             </controls:WrapPanel>
 

--- a/AppControl Manager/Pages/BuildNewCertificate.xaml
+++ b/AppControl Manager/Pages/BuildNewCertificate.xaml
@@ -47,7 +47,7 @@
 
             </Grid.Resources>
 
-            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Horizontal" Margin="6,10,6,10">
+            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,10,6,10">
 
                 <TextBlock
 TextWrapping="WrapWholeWords"
@@ -57,6 +57,8 @@ Style="{StaticResource BodyTextBlockStyle}">
     Build <Bold>Code Signing</Bold> Certificates that are suitable for signing <Run Foreground="{ThemeResource SystemAccentColor}">App Control</Run> Policies.
 </Span>
                 </TextBlock>
+
+                <HyperlinkButton Content="Guide" NavigateUri="https://github.com/HotCakeX/Harden-Windows-Security/wiki/Build-New-Certificate" />
 
             </controls:WrapPanel>
 
@@ -102,8 +104,8 @@ Style="{StaticResource BodyTextBlockStyle}">
 
                     <ComboBox SelectedIndex="0" x:Name="KeySizeComboBox">
                         <ComboBoxItem Content="4096"/>
-                        <ComboBoxItem Content="8192"/>
-                        <ComboBoxItem Content="16384"/>
+                        <ComboBoxItem Content="8192" IsEnabled="False"/>
+                        <ComboBoxItem Content="16384" IsEnabled="False"/>
                     </ComboBox>
 
                 </controls:SettingsCard>

--- a/AppControl Manager/Pages/ConfigurePolicyRuleOptions.xaml
+++ b/AppControl Manager/Pages/ConfigurePolicyRuleOptions.xaml
@@ -46,7 +46,7 @@ Style="{StaticResource BodyTextBlockStyle}">
   </Span>
                 </TextBlock>
 
-                <HyperlinkButton Content="Refer to this chart for more info about each rule option" NavigateUri="https://learn.microsoft.com/en-us/windows/security/application-security/application-control/app-control-for-business/design/select-types-of-rules-to-create#table-1-app-control-for-business-policy---policy-rule-options" />
+                <HyperlinkButton Content="Guide" NavigateUri="https://github.com/HotCakeX/Harden-Windows-Security/wiki/Configure-Policy-Rule-Options" />
 
             </controls:WrapPanel>
 

--- a/AppControl Manager/Pages/CreatePolicy.xaml
+++ b/AppControl Manager/Pages/CreatePolicy.xaml
@@ -35,7 +35,7 @@
             </Grid.RowDefinitions>
 
 
-            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Horizontal" Margin="6,10,6,10">
+            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,10,6,10">
 
                 <TextBlock
 TextWrapping="WrapWholeWords"
@@ -50,6 +50,7 @@ Style="{StaticResource BodyTextBlockStyle}">
 </Span>
                 </TextBlock>
 
+                <HyperlinkButton Content="Guide" NavigateUri="https://github.com/HotCakeX/Harden-Windows-Security/wiki/Create-App-Control-Policy" />
 
             </controls:WrapPanel>
 
@@ -83,7 +84,7 @@ Style="{StaticResource AccentButtonStyle}" Click="AllowMicrosoftCreateAndDeploy_
 
                         <controls:SettingsCard Description="Indicates that the created/deployed policy will have (Enabled:Audit Mode) policy rule option and will generate audit logs instead of blocking files."
                                Header="Audit">
-                            <ToggleSwitch x:Name="AllowMicrosoftAudit" />
+                            <ToggleSwitch x:Name="AllowMicrosoftAudit" Toggled="AllowMicrosoftAudit_Toggled" />
 
                         </controls:SettingsCard>
 
@@ -95,13 +96,14 @@ Style="{StaticResource AccentButtonStyle}" Click="AllowMicrosoftCreateAndDeploy_
 
                                 <NumberBox x:Name="AllowMicrosoftLogSizeInput"
     Header="Enter a number for Log Size in MB"
-Value="2"
-SpinButtonPlacementMode="Inline"
-SmallChange="1"
-LargeChange="10" Minimum="2" Maximum="1000000" Margin="0,0,30,0" ToolTipService.ToolTip="This is the Maximum Capacity of the Code Integrity Operational Log Size" />
+    Value="2"
+    SpinButtonPlacementMode="Inline"
+    SmallChange="1"
+    IsEnabled="False"                                      
+    LargeChange="10" Minimum="2" Maximum="1000000" Margin="0,0,30,0" ToolTipService.ToolTip="This is the Maximum Capacity of the Code Integrity Operational Log Size" />
 
 
-                                <ToggleSwitch x:Name="AllowMicrosoftLogSizeInputEnabled" Toggled="AllowMicrosoftLogSizeInputEnabled_Toggled" />
+                                <ToggleSwitch x:Name="AllowMicrosoftLogSizeInputEnabled" IsEnabled="False" Toggled="AllowMicrosoftLogSizeInputEnabled_Toggled" />
 
                             </controls:WrapPanel>
 
@@ -132,6 +134,80 @@ LargeChange="10" Minimum="2" Maximum="1000000" Margin="0,0,30,0" ToolTipService.
 
 
 
+
+                <!-- Default Windows -->
+
+                <controls:SettingsExpander x:Name="DefaultWindowsSettings"
+                           Description="This policy will allow files that come by default with Windows OS to run (including Office products) and everything else will be blocked."
+                           Header="Create Default Windows Policy"
+                           HeaderIcon="{ui:FontIcon Glyph=&#xE71D;}">
+
+                    <controls:WrapPanel Orientation="Horizontal" HorizontalSpacing="6" VerticalSpacing="10">
+
+                        <Button x:Name="DefaultWindowsCreate" Content="Create"
+            Style="{StaticResource AccentButtonStyle}" Margin="0,0,15,0" Click="DefaultWindowsCreate_Click" />
+
+                        <Button x:Name="DefaultWindowsCreateAndDeploy" Content="Create And Deploy"
+Style="{StaticResource AccentButtonStyle}" Click="DefaultWindowsCreateAndDeploy_Click" Margin="0,0,15,0" />
+
+                    </controls:WrapPanel>
+
+                    <controls:SettingsExpander.Items>
+
+                        <controls:SettingsCard Description="Indicates that the created/deployed policy will have (Enabled:Audit Mode) policy rule option and will generate audit logs instead of blocking files."
+                               Header="Audit">
+
+                            <ToggleSwitch x:Name="DefaultWindowsAudit" Toggled="DefaultWindowsAudit_Toggled" />
+
+                        </controls:SettingsCard>
+
+                        <controls:SettingsCard Description="Specifies the log size for Microsoft-Windows-CodeIntegrity/Operational events."
+         Header="Log Size">
+
+                            <controls:WrapPanel Orientation="Horizontal">
+
+
+                                <NumberBox x:Name="DefaultWindowsLogSizeInput"
+                    Header="Enter a number for Log Size in MB"
+                    IsEnabled="False"
+                    Value="2"
+                    SpinButtonPlacementMode="Inline"
+                    SmallChange="1"
+                    LargeChange="10" Minimum="2" Maximum="1000000" Margin="0,0,30,0" ToolTipService.ToolTip="This is the Maximum Capacity of the Code Integrity Operational Log Size" />
+
+
+                                <ToggleSwitch x:Name="DefaultWindowsLogSizeInputEnabled" IsEnabled="False" Toggled="DefaultWindowsLogSizeInputEnabled_Toggled" />
+
+                            </controls:WrapPanel>
+
+
+                        </controls:SettingsCard>
+
+
+
+                        <controls:SettingsCard Description="Indicates that the created/deployed policy will have (Require EV Signers) policy rule option which will only allow kernel-mode drivers signed with an EV certificate to run."
+         Header="Require EVSigners">
+                            <ToggleSwitch x:Name="DefaultWindowsRequireEVSigners" />
+                        </controls:SettingsCard>
+
+                        <controls:SettingsCard Description="Enables script enforcement for the policy which will severely limit the attack surface of PowerShell by requiring only scripts/modules signed and allowed in the Code Integrity policy to run."
+         Header="Enable Script Enforcement">
+                            <ToggleSwitch x:Name="DefaultWindowsEnableScriptEnforcement" />
+                        </controls:SettingsCard>
+
+                        <controls:SettingsCard Description="Indicates that the created/deployed policy will have (Enabled:Boot Audit on Failure) and (Enabled:Advanced Boot Options Menu) policy rule options. Useful for testing the policy and having recovery options available when something goes wrong. Not recommended to be used in the final production-ready policy due to security reasons."
+         Header="Test Mode">
+                            <ToggleSwitch x:Name="DefaultWindowsTestMode" />
+                        </controls:SettingsCard>
+
+
+                    </controls:SettingsExpander.Items>
+
+                </controls:SettingsExpander>
+
+
+
+
                 <!-- Signed and Reputable -->
 
                 <controls:SettingsExpander x:Name="SignedAndReputableSettings"
@@ -154,7 +230,8 @@ Style="{StaticResource AccentButtonStyle}" Click="SignedAndReputableCreateAndDep
 
                         <controls:SettingsCard Description="Indicates that the created/deployed policy will have (Enabled:Audit Mode) policy rule option and will generate audit logs instead of blocking files."
                                Header="Audit">
-                            <ToggleSwitch x:Name="SignedAndReputableAudit" />
+
+                            <ToggleSwitch x:Name="SignedAndReputableAudit" Toggled="SignedAndReputableAudit_Toggled" />
 
                         </controls:SettingsCard>
 
@@ -166,14 +243,15 @@ Style="{StaticResource AccentButtonStyle}" Click="SignedAndReputableCreateAndDep
 
 
                                 <NumberBox x:Name="SignedAndReputableLogSizeInput"
-    Header="Enter a number for Log Size in MB"
-    Value="2"
-    SpinButtonPlacementMode="Inline"
-    SmallChange="1"
-    LargeChange="10" Minimum="2" Maximum="1000000" Margin="0,0,30,0" ToolTipService.ToolTip="This is the Maximum Capacity of the Code Integrity Operational Log Size" />
+                        Header="Enter a number for Log Size in MB"
+                        IsEnabled="False"
+                        Value="2"
+                        SpinButtonPlacementMode="Inline"
+                        SmallChange="1"
+                        LargeChange="10" Minimum="2" Maximum="1000000" Margin="0,0,30,0" ToolTipService.ToolTip="This is the Maximum Capacity of the Code Integrity Operational Log Size" />
 
 
-                                <ToggleSwitch x:Name="SignedAndReputableLogSizeInputEnabled" Toggled="SignedAndReputableLogSizeInputEnabled_Toggled" />
+                                <ToggleSwitch x:Name="SignedAndReputableLogSizeInputEnabled" IsEnabled="False" Toggled="SignedAndReputableLogSizeInputEnabled_Toggled" />
 
                             </controls:WrapPanel>
 

--- a/AppControl Manager/Pages/CreateSupplementalPolicy.xaml
+++ b/AppControl Manager/Pages/CreateSupplementalPolicy.xaml
@@ -46,7 +46,7 @@
 
             </Grid.Resources>
 
-            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Horizontal" Margin="6,10,6,10">
+            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,10,6,10">
 
                 <TextBlock
 TextWrapping="WrapWholeWords"
@@ -56,6 +56,8 @@ Style="{StaticResource BodyTextBlockStyle}">
     Create a <Bold>Supplemental</Bold> policy that will <Run Foreground="{ThemeResource SystemAccentColor}">expand</Run> the scope of a base policy. Supplemental policies can only allow files, they cannot have deny rules in them.
 </Span>
                 </TextBlock>
+
+                <HyperlinkButton Content="Guide" NavigateUri="https://github.com/HotCakeX/Harden-Windows-Security/wiki/Create-Supplemental-App-Control-Policy" />
 
             </controls:WrapPanel>
 
@@ -267,7 +269,7 @@ Header="Base Policy File" IsClickEnabled="True" IsActionIconVisible="False" Clic
                                 <RadioButton Content="User Mode" IsChecked="True" Checked="UserModeRadioButton_Checked"/>
                                 <RadioButton Content="Kernel Mode" Checked="KernelModeRadioButton_Checked"/>
                             </RadioButtons>
-                            
+
                         </controls:SettingsCard>
 
                     </controls:SettingsExpander.Items>

--- a/AppControl Manager/Pages/Deployment.xaml
+++ b/AppControl Manager/Pages/Deployment.xaml
@@ -47,7 +47,7 @@
 
             </Grid.Resources>
 
-            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Horizontal" Margin="6,10,6,10">
+            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,10,6,10">
 
                 <TextBlock
 TextWrapping="WrapWholeWords"
@@ -57,6 +57,8 @@ Style="{StaticResource BodyTextBlockStyle}">
     Deploy <Bold>unsigned</Bold> <Run Foreground="{ThemeResource SystemAccentColor}">App Control</Run> Policies.
 </Span>
                 </TextBlock>
+
+                <HyperlinkButton Content="Guide" NavigateUri="https://github.com/HotCakeX/Harden-Windows-Security/wiki/Deploy-App-Control-Policy" />
 
             </controls:WrapPanel>
 

--- a/AppControl Manager/Pages/EventLogsPolicyCreation.xaml
+++ b/AppControl Manager/Pages/EventLogsPolicyCreation.xaml
@@ -82,7 +82,7 @@
         </Grid.Resources>
 
 
-        <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Horizontal" Margin="6,10,6,10">
+        <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,10,6,10">
 
             <TextBlock
 TextWrapping="WrapWholeWords"
@@ -97,6 +97,9 @@ Style="{StaticResource BodyTextBlockStyle}">
     to define output configuration and generate the XML policy file.
 </Span>
             </TextBlock>
+
+            <HyperlinkButton Content="Guide" NavigateUri="https://github.com/HotCakeX/Harden-Windows-Security/wiki/Create-Policy-From-Event-Logs" />
+
         </controls:WrapPanel>
 
         <Border

--- a/AppControl Manager/Pages/GetCIHashes.xaml
+++ b/AppControl Manager/Pages/GetCIHashes.xaml
@@ -18,7 +18,7 @@
             </Grid.RowDefinitions>
 
 
-            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Horizontal" Margin="6,10,6,10">
+            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,10,6,10">
 
                 <TextBlock
 TextWrapping="WrapWholeWords"
@@ -29,6 +29,8 @@ Style="{StaticResource BodyTextBlockStyle}">
         <Run Foreground="{ThemeResource SystemAccentColor}">hashes</Run>
     of files.</Span>
                 </TextBlock>
+
+                <HyperlinkButton Content="Guide" NavigateUri="https://github.com/HotCakeX/Harden-Windows-Security/wiki/Get-Code-Integrity-Hashes" />
 
             </controls:WrapPanel>
 

--- a/AppControl Manager/Pages/GetSecurePolicySettings.xaml
+++ b/AppControl Manager/Pages/GetSecurePolicySettings.xaml
@@ -43,7 +43,8 @@ Style="{StaticResource BodyTextBlockStyle}">
      on the system. </Span>
                 </TextBlock>
 
-                <HyperlinkButton Content="Check out this page for more info" NavigateUri="https://github.com/HotCakeX/Harden-Windows-Security/wiki/Get-CIPolicySetting" />
+                <HyperlinkButton Content="Guide" NavigateUri="https://github.com/HotCakeX/Harden-Windows-Security/wiki/Get-Secure-Policy-Settings" />
+
             </controls:WrapPanel>
 
         <Border

--- a/AppControl Manager/Pages/GitHubDocumentation.xaml
+++ b/AppControl Manager/Pages/GitHubDocumentation.xaml
@@ -6,6 +6,10 @@
     xmlns:local="using:WDACConfig.Pages"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="using:CommunityToolkit.WinUI"
+    xmlns:controls="using:CommunityToolkit.WinUI.Controls"
+    xmlns:tk7controls="using:CommunityToolkit.WinUI.UI.Controls"
+    xmlns:animations="using:CommunityToolkit.WinUI.Animations"
     mc:Ignorable="d">
 
     <Grid>
@@ -15,9 +19,9 @@
         </Grid.RowDefinitions>
 
         <!-- Navigation Bar -->
-        <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Top" Height="35" Margin="0,15,0,15">
+        <controls:WrapPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Center" HorizontalSpacing="5" VerticalSpacing="5" VerticalAlignment="Top" Margin="0,5,0,15">
             <!-- Back Button with Icon - Set initially to falce until it makes sense to be enabled -->
-            <Button Click="BackButton_Click" IsEnabled="False" x:Name="BackButton" Margin="5,0,5,0">
+            <Button Click="BackButton_Click" IsEnabled="False" x:Name="BackButton">
                 <StackPanel Orientation="Horizontal">
                     <SymbolIcon Symbol="Back"/>
                     <TextBlock Text="Back" Margin="5,0,0,0"/>
@@ -25,7 +29,7 @@
             </Button>
 
             <!-- Forward Button with Icon - Set initially to falce until it makes sense to be enabled -->
-            <Button Click="ForwardButton_Click" IsEnabled="False" x:Name="ForwardButton" Margin="5,0,5,0">
+            <Button Click="ForwardButton_Click" IsEnabled="False" x:Name="ForwardButton">
                 <StackPanel Orientation="Horizontal">
                     <SymbolIcon Symbol="Forward"/>
                     <TextBlock Text="Forward" Margin="5,0,0,0"/>
@@ -33,7 +37,7 @@
             </Button>
 
             <!-- Reload Button with Icon -->
-            <Button Click="ReloadButton_Click" Margin="5,0,5,0">
+            <Button Click="ReloadButton_Click">
                 <StackPanel Orientation="Horizontal">
                     <SymbolIcon Symbol="Refresh"/>
                     <TextBlock Text="Reload" Margin="5,0,0,0"/>
@@ -41,14 +45,14 @@
             </Button>
 
             <!-- Home Button with Icon -->
-            <Button Click="HomeButton_Click" Margin="5,0,5,0">
+            <Button Click="HomeButton_Click">
                 <StackPanel Orientation="Horizontal">
                     <!-- Using FontIcon to show a "Home" symbol from Segoe MDL2 Assets -->
                     <FontIcon Glyph="" FontFamily="Segoe MDL2 Assets"/>
                     <TextBlock Text="Home" Margin="5,0,0,0"/>
                 </StackPanel>
             </Button>
-        </StackPanel>
+        </controls:WrapPanel>
 
         <!-- WebView2 Control -->
         <WebView2

--- a/AppControl Manager/Pages/MDEAHPolicyCreation.xaml
+++ b/AppControl Manager/Pages/MDEAHPolicyCreation.xaml
@@ -71,7 +71,7 @@
 
         </Grid.Resources>
 
-        <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Horizontal" Margin="6,10,6,10">
+        <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,10,6,10">
 
             <TextBlock
     TextWrapping="WrapWholeWords"
@@ -87,6 +87,8 @@
         to define output configuration and generate the XML policy file.
     </Span>
             </TextBlock>
+
+            <HyperlinkButton Content="Guide" NavigateUri="https://github.com/HotCakeX/Harden-Windows-Security/wiki/Create-Policy-From-MDE-Advanced-Hunting" />
 
         </controls:WrapPanel>
 

--- a/AppControl Manager/Pages/MicrosoftDocumentation.xaml
+++ b/AppControl Manager/Pages/MicrosoftDocumentation.xaml
@@ -6,6 +6,10 @@
     xmlns:local="using:WDACConfig.Pages"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="using:CommunityToolkit.WinUI"
+    xmlns:controls="using:CommunityToolkit.WinUI.Controls"
+    xmlns:tk7controls="using:CommunityToolkit.WinUI.UI.Controls"
+    xmlns:animations="using:CommunityToolkit.WinUI.Animations"
     mc:Ignorable="d">
 
     <Grid>
@@ -15,9 +19,9 @@
         </Grid.RowDefinitions>
 
         <!-- Navigation Bar -->
-        <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Top" Height="35" Margin="0,15,0,15">
+        <controls:WrapPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Center" HorizontalSpacing="5" VerticalSpacing="5" VerticalAlignment="Top" Margin="0,5,0,15">
             <!-- Back Button with Icon - Set initially to falce until it makes sense to be enabled -->
-            <Button Click="BackButton_Click" IsEnabled="False" x:Name="BackButton" Margin="5,0,5,0">
+            <Button Click="BackButton_Click" IsEnabled="False" x:Name="BackButton">
                 <StackPanel Orientation="Horizontal">
                     <SymbolIcon Symbol="Back"/>
                     <TextBlock Text="Back" Margin="5,0,0,0"/>
@@ -25,7 +29,7 @@
             </Button>
 
             <!-- Forward Button with Icon - Set initially to falce until it makes sense to be enabled -->
-            <Button Click="ForwardButton_Click" IsEnabled="False" x:Name="ForwardButton" Margin="5,0,5,0">
+            <Button Click="ForwardButton_Click" IsEnabled="False" x:Name="ForwardButton">
                 <StackPanel Orientation="Horizontal">
                     <SymbolIcon Symbol="Forward"/>
                     <TextBlock Text="Forward" Margin="5,0,0,0"/>
@@ -33,7 +37,7 @@
             </Button>
 
             <!-- Reload Button with Icon -->
-            <Button Click="ReloadButton_Click" Margin="5,0,5,0">
+            <Button Click="ReloadButton_Click">
                 <StackPanel Orientation="Horizontal">
                     <SymbolIcon Symbol="Refresh"/>
                     <TextBlock Text="Reload" Margin="5,0,0,0"/>
@@ -41,14 +45,14 @@
             </Button>
 
             <!-- Home Button with Icon -->
-            <Button Click="HomeButton_Click" Margin="5,0,5,0">
+            <Button Click="HomeButton_Click">
                 <StackPanel Orientation="Horizontal">
                     <!-- Using FontIcon to show a "Home" symbol from Segoe MDL2 Assets -->
                     <FontIcon Glyph="" FontFamily="Segoe MDL2 Assets"/>
                     <TextBlock Text="Home" Margin="5,0,0,0"/>
                 </StackPanel>
             </Button>
-        </StackPanel>
+        </controls:WrapPanel>
 
         <!-- WebView2 Control -->
         <WebView2

--- a/AppControl Manager/Pages/Simulation.xaml
+++ b/AppControl Manager/Pages/Simulation.xaml
@@ -32,7 +32,7 @@
         </Grid.Resources>
 
 
-        <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Horizontal" Margin="6,10,6,10">
+        <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,10,6,10">
 
             <TextBlock
 TextWrapping="WrapWholeWords"
@@ -47,8 +47,8 @@ Style="{StaticResource BodyTextBlockStyle}">
 </Span>
             </TextBlock>
 
+            <HyperlinkButton Content="Guide" NavigateUri="https://github.com/HotCakeX/Harden-Windows-Security/wiki/Simulation" />
 
-            <HyperlinkButton Content="Watch the YouTube video for guidance" NavigateUri="https://github.com/HotCakeX/Harden-Windows-Security"  />
         </controls:WrapPanel>
 
         <Border

--- a/AppControl Manager/Pages/SystemInformation/SystemInformation.xaml
+++ b/AppControl Manager/Pages/SystemInformation/SystemInformation.xaml
@@ -17,7 +17,7 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Horizontal" Margin="6,10,6,10">
+        <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,10,6,10">
 
             <TextBlock
 TextWrapping="WrapWholeWords"
@@ -31,6 +31,7 @@ Style="{StaticResource BodyTextBlockStyle}">
 </Span>
             </TextBlock>
 
+            <HyperlinkButton Content="Guide" NavigateUri="https://github.com/HotCakeX/Harden-Windows-Security/wiki/System-Information" />
 
         </controls:WrapPanel>
 

--- a/AppControl Manager/Pages/Update.xaml
+++ b/AppControl Manager/Pages/Update.xaml
@@ -35,7 +35,7 @@
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
-            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Horizontal" Margin="6,10,6,10">
+            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,10,6,10">
 
                 <TextBlock
 TextWrapping="WrapWholeWords"
@@ -45,6 +45,8 @@ Style="{StaticResource BodyTextBlockStyle}">
     Check for <Run Foreground="{ThemeResource SystemAccentColor}">updates</Run> in this page. You can also enable automatic update check which will happen once at startup and you will be notified whenever a new version is available.
 </Span>
                 </TextBlock>
+
+                <HyperlinkButton Content="Guide" NavigateUri="https://github.com/HotCakeX/Harden-Windows-Security/wiki/Update" />
 
             </controls:WrapPanel>
 

--- a/AppControl Manager/Pages/UpdatePageCustomMSIXPath.xaml
+++ b/AppControl Manager/Pages/UpdatePageCustomMSIXPath.xaml
@@ -41,7 +41,7 @@
                     <win:RepositionThemeTransition IsStaggeringEnabled="False" />
                 </win:StackPanel.ChildrenTransitions>
 
-                <controls:SettingsCard 
+                <controls:SettingsCard
                            Description="Browse for the AppControl Manager MSIX file path on your device and then go back to the update page to install it. Its file name must match the following patterns: (FileName_x.x.x.x_x64.msix) or (FileName_x.x.x.x_arm64.msix)"
                            Header="Optional: select MSIX file path"
                            HeaderIcon="{ui:FontIcon Glyph=&#xF83E;}" IsClickEnabled="True" IsActionIconVisible="False" Click="BrowseForCustomMSIXPathButton_Click">

--- a/AppControl Manager/app.manifest
+++ b/AppControl Manager/app.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- INFO: https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests -->
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.5.0.0" name="AppControlManager"/>
+  <assemblyIdentity version="1.5.1.0" name="AppControlManager"/>
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>


### PR DESCRIPTION
# What's New

* Enhanced Parsing Logic for MDE Advanced Hunting: The CSV parsing process no longer relies on static column positions. Instead, it dynamically identifies the location of each field, ensuring accurate parsing regardless of column order changes in the CSV file, improving robustness for any future changes. Fixed -> https://github.com/HotCakeX/Harden-Windows-Security/discussions/423

* Default Windows Template Policy: A new feature has been added to the policy creation page, enabling the creation of a default Windows template policy with ease.

* Integrated Documentation Links: Links to the latest AppControl Manager documentation have been added across relevant pages. Users can now quickly access step-by-step guides by clicking a dedicated button whenever guidance is needed.

* Fixed menu item text for MDE Advanced Hunting, it wasn't showing the full content.

* Made the navigation buttons in documentation pages more responsive.

* Improved the UX when using the log size and audit mode options in the Create Policy page.

<br>

