### PR TITLE
Implementing LibraryImports instead of DllImports for improved performance

### DIFF
--- a/AppControl Manager/Logic/AllCertificatesGrabber.cs
+++ b/AppControl Manager/Logic/AllCertificatesGrabber.cs
@@ -207,7 +207,7 @@ namespace WDACConfig
                     // Call WinVerifyTrust to verify trust on the file
                     WinTrust.WinVerifyTrustResult verifyTrustResult = WinTrust.WinVerifyTrust(
                         IntPtr.Zero,
-                        WinTrust.GenericWinTrustVerifyActionGuid,
+                        ref WinTrust.GenericWinTrustVerifyActionGuid,
                         winTrustDataPointer
                     );
 
@@ -314,7 +314,7 @@ namespace WDACConfig
 
                         // Convert TrustedData back to pointer and call WinVerifyTrust to close the structure
                         Marshal.StructureToPtr(TrustedData, winTrustDataPointer, false);
-                        _ = WinTrust.WinVerifyTrust(IntPtr.Zero, WinTrust.GenericWinTrustVerifyActionGuid, winTrustDataPointer);
+                        _ = WinTrust.WinVerifyTrust(IntPtr.Zero, ref WinTrust.GenericWinTrustVerifyActionGuid, winTrustDataPointer);
                     }
 
                     // Free memory allocated to winTrustDataPointer

--- a/AppControl Manager/Logic/GetOpusData.cs
+++ b/AppControl Manager/Logic/GetOpusData.cs
@@ -4,28 +4,25 @@ using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.Pkcs;
 
-#pragma warning disable SYSLIB1054
-
 namespace WDACConfig
 {
-    public static class Opus
+    public static partial class Opus
     {
-        internal static class Crypt32
+        internal static partial class Crypt32
         {
 
             // More info: https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-cryptdecodeobject
-            [DllImport("crypt32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-            internal static extern bool CryptDecodeObject(
-                        uint dwCertEncodingType,        // Specifies the encoding type used in the encoded message
-                        IntPtr lpszStructType,          // Pointer to a null-terminated ANSI string that identifies the type of the structure to be decoded
-                        [In] byte[] pbEncoded,          // Pointer to a buffer that contains the encoded structure
-                        uint cbEncoded,                 // Size, in bytes, of the pbEncoded buffer
-                        uint dwFlags,                   // Flags that modify the behavior of the function
-                        [Out] IntPtr pvStructInto,      // Pointer to a buffer that receives the decoded structure
-                        ref uint pcbStructInfo          // Pointer to a variable that specifies the size, in bytes, of the pvStructInfo buffer
-                    );
-
-
+            [LibraryImport("crypt32.dll", StringMarshalling = StringMarshalling.Utf16, SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            internal static partial bool CryptDecodeObject(
+                uint dwCertEncodingType,        // Specifies the encoding type used in the encoded message
+                IntPtr lpszStructType,          // Pointer to a null-terminated ANSI string that identifies the type of the structure to be decoded
+               [In] byte[] pbEncoded,           // Pointer to a buffer that contains the encoded structure
+                uint cbEncoded,                 // Size, in bytes, of the pbEncoded buffer
+                uint dwFlags,                   // Flags that modify the behavior of the function
+                IntPtr pvStructInto,            // Pointer to a buffer that receives the decoded structure
+                ref uint pcbStructInfo          // Pointer to a variable that specifies the size, in bytes, of the pvStructInfo buffer
+            );
         }
 
         // More info about this at the end of the code

--- a/AppControl Manager/Logic/Types And Definitions/WinTrust.cs
+++ b/AppControl Manager/Logic/Types And Definitions/WinTrust.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-#pragma warning disable SYSLIB1054
-
 namespace WDACConfig
 {
     // This class contains all of the WinTrust related functions and codes
@@ -113,17 +111,15 @@ namespace WDACConfig
         // Constants related to WinTrust
         internal const uint StateActionVerify = 1;
         internal const uint StateActionClose = 2;
-        internal static readonly Guid GenericWinTrustVerifyActionGuid = new("{00AAC56B-CD44-11d0-8CC2-00C04FC295EE}");
+        internal static Guid GenericWinTrustVerifyActionGuid = new("{00AAC56B-CD44-11d0-8CC2-00C04FC295EE}");
 
-
-        // External method declarations for WinVerifyTrust and WTHelperProvDataFromStateData
-        [DllImport("wintrust.dll", CharSet = CharSet.Unicode)]
 
         // https://learn.microsoft.com/en-us/windows/win32/api/wintrust/nf-wintrust-winverifytrust
+        [LibraryImport("wintrust.dll", EntryPoint = "WinVerifyTrust")]
         // Set to return a WinVerifyTrustResult enum
-        internal static extern WinVerifyTrustResult WinVerifyTrust(
+        internal static partial WinVerifyTrustResult WinVerifyTrust(
             IntPtr hwnd,
-            [MarshalAs(UnmanagedType.LPStruct)] Guid pgActionID,
+            ref Guid pgActionID,
             IntPtr pWVTData);
 
         // https://learn.microsoft.com/en-us/windows/win32/api/wintrust/nf-wintrust-wthelperprovdatafromstatedata


### PR DESCRIPTION
* Fixed CA1838 in the `CryptoAPI` class.
* Changed the`CertGetNameStringW` to use LibraryImport.
* Changed `CryptDecodeObject` in Opus class to use LibraryImport.
* Changed `WinVerifyTrust` in WinTrust class to use LibraryImport.

No DllImport exists in the code anymore.

<br>


