### PR TITLE
AppControl Manager 1.5.2.0

### DIFF
--- a/AppControl Manager/.editorconfig
+++ b/AppControl Manager/.editorconfig
@@ -31,7 +31,7 @@ dotnet_diagnostic.CA1309.severity = error
 dotnet_diagnostic.CA1311.severity = error
 
 # CA1416: Validate platform compatibility
-dotnet_diagnostic.CA1416.severity = silent
+dotnet_diagnostic.CA1416.severity = error
 
 # CA5384: Do Not Use Digital Signature Algorithm (DSA)
 dotnet_diagnostic.CA5384.severity = error
@@ -389,3 +389,84 @@ dotnet_diagnostic.IDE0057.severity = error
 
 # IDE0130: Namespace does not match folder structure
 dotnet_diagnostic.IDE0130.severity = silent
+
+# CsWinRT1028: Class is not marked partial
+dotnet_diagnostic.CsWinRT1028.severity = error
+
+# CA1044: Properties should not be write only
+dotnet_diagnostic.CA1044.severity = error
+
+# CsWinRT1029: Class not trimming / AOT compatible
+dotnet_diagnostic.CsWinRT1029.severity = error
+
+# CA5404: Do not disable token validation checks
+dotnet_diagnostic.CA5404.severity = error
+
+# CA5379: Ensure Key Derivation Function algorithm is sufficiently strong
+dotnet_diagnostic.CA5379.severity = error
+
+# CA1867: Use char overload
+dotnet_diagnostic.CA1867.severity = error
+
+# CA1070: Do not declare event fields as virtual
+dotnet_diagnostic.CA1070.severity = error
+
+# CA1054: URI-like parameters should not be strings
+dotnet_diagnostic.CA1054.severity = error
+
+# CA1850: Prefer static 'HashData' method over 'ComputeHash'
+dotnet_diagnostic.CA1850.severity = error
+
+# CA3004: Review code for information disclosure vulnerabilities
+dotnet_diagnostic.CA3004.severity = error
+
+# CA1056: URI-like properties should not be strings
+dotnet_diagnostic.CA1056.severity = error
+
+# CA1055: URI-like return values should not be strings
+dotnet_diagnostic.CA1055.severity = error
+
+# CA2301: Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+dotnet_diagnostic.CA2301.severity = error
+
+# CA3010: Review code for XAML injection vulnerabilities
+dotnet_diagnostic.CA3010.severity = error
+
+# CA1837: Use 'Environment.ProcessId'
+dotnet_diagnostic.CA1837.severity = error
+
+# CA3009: Review code for XML injection vulnerabilities
+dotnet_diagnostic.CA3009.severity = error
+
+# CA3006: Review code for process command injection vulnerabilities
+dotnet_diagnostic.CA3006.severity = error
+
+# CA2328: Ensure that JsonSerializerSettings are secure
+dotnet_diagnostic.CA2328.severity = error
+
+# CA3008: Review code for XPath injection vulnerabilities
+dotnet_diagnostic.CA3008.severity = error
+
+# CA3001: Review code for SQL injection vulnerabilities
+dotnet_diagnostic.CA3001.severity = error
+
+# CA3002: Review code for XSS vulnerabilities
+dotnet_diagnostic.CA3002.severity = error
+
+# CA5385: Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+dotnet_diagnostic.CA5385.severity = error
+
+# CA5387: Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+dotnet_diagnostic.CA5387.severity = error
+
+# CA1842: Do not use 'WhenAll' with a single task
+dotnet_diagnostic.CA1842.severity = error
+
+# CA1849: Call async methods when in an async method
+dotnet_diagnostic.CA1849.severity = error
+
+# CA1843: Do not use 'WaitAll' with a single task
+dotnet_diagnostic.CA1843.severity = error
+
+# CA3007: Review code for open redirect vulnerabilities
+dotnet_diagnostic.CA3007.severity = error

--- a/AppControl Manager/AppControl Manager.csproj
+++ b/AppControl Manager/AppControl Manager.csproj
@@ -3,7 +3,10 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net9.0-windows10.0.26100.0</TargetFramework>
-    <TargetPlatformMinVersion>10.0.26100.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.22621.0</TargetPlatformMinVersion>
+
+    <!-- https://learn.microsoft.com/en-us/dotnet/standard/frameworks#support-older-os-versions -->
+    <SupportedOSPlatformVersion>10.0.22621.0</SupportedOSPlatformVersion>
 
     <!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/package-validation/overview -->
     <EnablePackageValidation>true</EnablePackageValidation>
@@ -53,7 +56,6 @@
     <!-- <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings> -->
     <!-- <TrimmerSingleWarn>false</TrimmerSingleWarn> -->
 
-    <SupportedOSPlatformVersion>10.0.26100.0</SupportedOSPlatformVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <Description>An application that simplifies management of Application Control in Windows.</Description>
     <PackageProjectUrl>https://github.com/HotCakeX/Harden-Windows-Security</PackageProjectUrl>
@@ -85,6 +87,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <StartupObject>WDACConfig.Program</StartupObject>
+    <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
 
     <!-- https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/unsafe-code -->
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/AppControl Manager/AppControl Manager.csproj
+++ b/AppControl Manager/AppControl Manager.csproj
@@ -80,7 +80,7 @@
     <AssemblyName>AppControlManager</AssemblyName>
     <PublishAot>False</PublishAot>
     <ErrorReport>send</ErrorReport>
-    <FileVersion>1.5.1.0</FileVersion>
+    <FileVersion>1.5.2.0</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/AppControl Manager/Logic/IntelGathering/FileIdentity.cs
+++ b/AppControl Manager/Logic/IntelGathering/FileIdentity.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace WDACConfig.IntelGathering
 {
@@ -64,6 +65,13 @@ namespace WDACConfig.IntelGathering
         // Determines whether the file is signed by ECC algorithm or not
         // AppControl does not support ECC Signed files yet
         public bool? IsECCSigned { get; set; }
+
+
+        // Computed property to gather all OPUSInfo from FileSignerInfos and save them in a comma-separated string for displaying purposes only
+        public string Opus => string.Join(", ", FileSignerInfos
+            .Where(signerInfo => !string.IsNullOrEmpty(signerInfo.OPUSInfo))
+            .Select(signerInfo => signerInfo.OPUSInfo));
+
     }
 
 }

--- a/AppControl Manager/Logic/IntelGathering/GetEventLogsData.cs
+++ b/AppControl Manager/Logic/IntelGathering/GetEventLogsData.cs
@@ -1074,17 +1074,17 @@ namespace WDACConfig.IntelGathering
                 Task<HashSet<FileIdentity>> appLockerTask = Task.Run(() => AppLockerEventsRetriever(AppLockerEvtxFilePath));
 
                 // Await both tasks to complete
-                _ = await Task.WhenAll(codeIntegrityTask, appLockerTask);
+                HashSet<FileIdentity>[] results = await Task.WhenAll(codeIntegrityTask, appLockerTask);
 
-                // Keep the Code Integrity task's HashSet output since it's the main category and will have the majority of the events
-                combinedResult = codeIntegrityTask.Result;
+                // Assign the Code Integrity task's HashSet output since it's the main category and will have the majority of the events
+                combinedResult = results[0];
 
                 // If there are AppLocker logs
-                if (appLockerTask.Result.Count > 0)
+                if (results[1].Count > 0)
                 {
 
                     // Add elements from the AppLocker task's result, using Add to preserve uniqueness since the HashSet has its custom comparer
-                    foreach (FileIdentity item in appLockerTask.Result)
+                    foreach (FileIdentity item in results[1])
                     {
                         _ = combinedResult.Add(item);
                     }

--- a/AppControl Manager/Logic/IntelGathering/OptimizeMDECSVData.cs
+++ b/AppControl Manager/Logic/IntelGathering/OptimizeMDECSVData.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;

--- a/AppControl Manager/Logic/IntelGathering/OptimizeMDECSVData.cs
+++ b/AppControl Manager/Logic/IntelGathering/OptimizeMDECSVData.cs
@@ -246,13 +246,13 @@ namespace WDACConfig.IntelGathering
                 string field = fields[i];
 
                 // If the field is a JSON field, we don't want to remove quotes
-                if (field.StartsWith("{", StringComparison.OrdinalIgnoreCase) && field.EndsWith("}", StringComparison.OrdinalIgnoreCase))
+                if (field.StartsWith('{') && field.EndsWith('}'))
                 {
                     continue; // Skip JSON fields
                 }
 
                 // Remove leading and trailing quotes if they exist (for non-JSON fields)
-                if (field.StartsWith("\"", StringComparison.OrdinalIgnoreCase) && field.EndsWith("\"", StringComparison.OrdinalIgnoreCase) && field.Length > 1)
+                if (field.StartsWith('"') && field.EndsWith('"') && field.Length > 1)
                 {
                     fields[i] = field[1..^1];
                 }

--- a/AppControl Manager/Package.appxmanifest
+++ b/AppControl Manager/Package.appxmanifest
@@ -11,7 +11,7 @@
   <Identity
     Name="AppControlManager"
     Publisher="CN=SelfSignedCertForAppControlManager"
-    Version="1.5.1.0" />
+    Version="1.5.2.0" />
 
   <mp:PhoneIdentity PhoneProductId="199a23ec-7cb6-4ab5-ab50-8baca348bc79" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/AppControl Manager/Pages/CreateSupplementalPolicyFilesAndFoldersScanResults.xaml
+++ b/AppControl Manager/Pages/CreateSupplementalPolicyFilesAndFoldersScanResults.xaml
@@ -134,7 +134,6 @@ Style="{StaticResource BodyTextBlockStyle}">
                 <tk7controls:DataGrid.Columns>
                     <tk7controls:DataGridTextColumn Header="File Name" Binding="{Binding FileName}" Width="Auto" Tag="FileName"/>
                     <tk7controls:DataGridTextColumn Header="Signature Status" Binding="{Binding SignatureStatus}" Tag="SignatureStatus" Width="Auto"/>
-                    <tk7controls:DataGridTextColumn Header="Action" Binding="{Binding Action}" Width="Auto" Tag="Action"/>
                     <tk7controls:DataGridTextColumn Header="Original File Name" Binding="{Binding OriginalFileName}" Width="Auto" Tag="OriginalFileName"/>
                     <tk7controls:DataGridTextColumn Header="InternalName" Binding="{Binding InternalName}" Width="Auto" Tag="InternalName"/>
                     <tk7controls:DataGridTextColumn Header="File Description" Binding="{Binding FileDescription}" Width="Auto" Tag="FileDescription"/>
@@ -142,9 +141,7 @@ Style="{StaticResource BodyTextBlockStyle}">
                     <tk7controls:DataGridTextColumn Header="File Version" Binding="{Binding FileVersion}" Width="Auto" Tag="FileVersion"/>
                     <tk7controls:DataGridTextColumn Header="Package Family Name" Binding="{Binding PackageFamilyName}" Width="Auto" Tag="PackageFamilyName"/>
                     <tk7controls:DataGridTextColumn Header="SHA256 Hash" Binding="{Binding SHA256Hash}" Width="Auto" Tag="SHA256Hash"/>
-                    <tk7controls:DataGridTextColumn Header="SHA1 Hash" Binding="{Binding SHA1Hash}" Width="Auto" Tag="SHA1Hash"/>
-                    <tk7controls:DataGridTextColumn Header="SHA256 Flat Hash" Binding="{Binding SHA256FlatHash}" Width="Auto" Tag="SHA256FlatHash"/>
-                    <tk7controls:DataGridTextColumn Header="SHA1 Flat Hash" Binding="{Binding SHA1FlatHash}" Width="Auto" Tag="SHA1FlatHash"/>
+                    <tk7controls:DataGridTextColumn Header="SHA1 Hash" Binding="{Binding SHA1Hash}" Width="Auto" Tag="SHA1Hash"/>                    
                     <tk7controls:DataGridTextColumn Header="Signing Scenario" Binding="{Binding SISigningScenario}" Width="Auto" Tag="SISigningScenario"/>
                     <tk7controls:DataGridTextColumn Header="File Path" Binding="{Binding FilePath}" Width="Auto" Tag="FilePath"/>
                     <tk7controls:DataGridTextColumn Header="SHA1 Page Hash" Binding="{Binding SHA1PageHash}" Width="Auto" Tag="SHA1PageHash"/>
@@ -152,6 +149,7 @@ Style="{StaticResource BodyTextBlockStyle}">
                     <tk7controls:DataGridTextColumn Header="Has WHQL Signer" Binding="{Binding HasWHQLSigner}" Width="Auto" Tag="HasWHQLSigner"/>
                     <tk7controls:DataGridTextColumn Header="File Publishers" Binding="{Binding FilePublishersToDisplay}" Width="Auto" Tag="FilePublishersToDisplay"/>
                     <tk7controls:DataGridTextColumn Header="Is ECC Signed" Binding="{Binding IsECCSigned}" Width="Auto" Tag="IsECCSigned"/>
+                    <tk7controls:DataGridTextColumn Header="Opus Data" Binding="{Binding Opus}" Width="Auto" Tag="Opus"/>
                 </tk7controls:DataGrid.Columns>
             </tk7controls:DataGrid>
         </Border>

--- a/AppControl Manager/Pages/CreateSupplementalPolicyFilesAndFoldersScanResults.xaml.cs
+++ b/AppControl Manager/Pages/CreateSupplementalPolicyFilesAndFoldersScanResults.xaml.cs
@@ -79,7 +79,6 @@ namespace WDACConfig.Pages
                 filteredResults = filteredResults.Where(output =>
                     (output.FileName is not null && output.FileName.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)) ||
                     (output.SignatureStatus.ToString().Contains(searchTerm, StringComparison.OrdinalIgnoreCase)) ||
-                    (output.Action.ToString().Contains(searchTerm, StringComparison.OrdinalIgnoreCase)) ||
                     (output.OriginalFileName is not null && output.OriginalFileName.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)) ||
                     (output.InternalName is not null && output.InternalName.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)) ||
                     (output.FileDescription is not null && output.FileDescription.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)) ||
@@ -88,9 +87,9 @@ namespace WDACConfig.Pages
                     (output.PackageFamilyName is not null && output.PackageFamilyName.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)) ||
                     (output.SHA1PageHash is not null && output.SHA1PageHash.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)) ||
                     (output.FilePath is not null && output.FilePath.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)) ||
-                    (output.SHA256FlatHash is not null && output.SHA256FlatHash.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)) ||
                     (output.SHA256Hash is not null && output.SHA256Hash.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)) ||
-                    output.FilePublishersToDisplay.Contains(searchTerm)
+                    output.FilePublishersToDisplay.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ||
+                    output.Opus.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)
                 );
             }
 
@@ -141,10 +140,6 @@ namespace WDACConfig.Pages
             {
                 SortColumn(e, output => output.SignatureStatus);
             }
-            else if (string.Equals(e.Column.Tag?.ToString(), "Action", StringComparison.OrdinalIgnoreCase))
-            {
-                SortColumn(e, output => output.Action);
-            }
             else if (string.Equals(e.Column.Tag?.ToString(), "OriginalFileName", StringComparison.OrdinalIgnoreCase))
             {
                 SortColumn(e, output => output.OriginalFileName);
@@ -177,14 +172,6 @@ namespace WDACConfig.Pages
             {
                 SortColumn(e, output => output.SHA1Hash);
             }
-            else if (string.Equals(e.Column.Tag?.ToString(), "SHA256FlatHash", StringComparison.OrdinalIgnoreCase))
-            {
-                SortColumn(e, output => output.SHA256FlatHash);
-            }
-            else if (string.Equals(e.Column.Tag?.ToString(), "SHA1FlatHash", StringComparison.OrdinalIgnoreCase))
-            {
-                SortColumn(e, output => output.SHA1FlatHash);
-            }
             else if (string.Equals(e.Column.Tag?.ToString(), "SISigningScenario", StringComparison.OrdinalIgnoreCase))
             {
                 SortColumn(e, output => output.SISigningScenario);
@@ -213,6 +200,11 @@ namespace WDACConfig.Pages
             {
                 SortColumn(e, output => output.IsECCSigned);
             }
+            else if (string.Equals(e.Column.Tag?.ToString(), "Opus", StringComparison.OrdinalIgnoreCase))
+            {
+                SortColumn(e, output => output.Opus);
+            }
+
 
             // Clear SortDirection for other columns
             foreach (DataGridColumn column in FileIdentitiesDataGrid.Columns)
@@ -343,7 +335,6 @@ namespace WDACConfig.Pages
             return new StringBuilder()
                 .AppendLine($"File Name: {row.FileName}")
                 .AppendLine($"Signature Status: {row.SignatureStatus}")
-                .AppendLine($"Action: {row.Action}")
                 .AppendLine($"Original File Name: {row.OriginalFileName}")
                 .AppendLine($"Internal Name: {row.InternalName}")
                 .AppendLine($"File Description: {row.FileDescription}")
@@ -352,8 +343,6 @@ namespace WDACConfig.Pages
                 .AppendLine($"Package Family Name: {row.PackageFamilyName}")
                 .AppendLine($"SHA256 Hash: {row.SHA256Hash}")
                 .AppendLine($"SHA1 Hash: {row.SHA1Hash}")
-                .AppendLine($"SHA256 Flat Hash: {row.SHA256FlatHash}")
-                .AppendLine($"SHA1 Flat Hash: {row.SHA1FlatHash}")
                 .AppendLine($"Signing Scenario: {row.SISigningScenario}")
                 .AppendLine($"File Path: {row.FilePath}")
                 .AppendLine($"SHA1 Page Hash: {row.SHA1PageHash}")
@@ -361,6 +350,7 @@ namespace WDACConfig.Pages
                 .AppendLine($"Has WHQL Signer: {row.HasWHQLSigner}")
                 .AppendLine($"File Publishers: {row.FilePublishersToDisplay}")
                 .AppendLine($"Is ECC Signed: {row.IsECCSigned}")
+                .AppendLine($"Opus Data: {row.Opus}")
                 .ToString();
         }
 
@@ -387,7 +377,6 @@ namespace WDACConfig.Pages
             {
                 { "File Name", CopyFileName_Click },
                 { "Signature Status", CopySignatureStatus_Click },
-                { "Action", CopyAction_Click },
                 { "Original File Name", CopyOriginalFileName_Click },
                 { "Internal Name", CopyInternalName_Click },
                 { "File Description", CopyFileDescription_Click },
@@ -396,15 +385,14 @@ namespace WDACConfig.Pages
                 { "Package Family Name", CopyPackageFamilyName_Click },
                 { "SHA256 Hash", CopySHA256Hash_Click },
                 { "SHA1 Hash", CopySHA1Hash_Click },
-                { "SHA256 Flat Hash", CopySHA256FlatHash_Click },
-                { "SHA1 Flat Hash", CopySHA1FlatHash_Click },
                 { "Signing Scenario", CopySigningScenario_Click },
                 { "File Path", CopyFilePath_Click },
                 { "SHA1 Page Hash", CopySHA1PageHash_Click },
                 { "SHA256 Page Hash", CopySHA256PageHash_Click },
                 { "Has WHQL Signer", CopyHasWHQLSigner_Click },
                 { "File Publishers", CopyFilePublishersToDisplay_Click },
-                { "Is ECC Signed", CopyIsECCSigned_Click }
+                { "Is ECC Signed", CopyIsECCSigned_Click },
+                { "Opus Data", CopyOpus_Click }
             };
 
             // Add menu items with specific click events for each column
@@ -429,7 +417,6 @@ namespace WDACConfig.Pages
         // Click event handlers for each property
         private void CopyFileName_Click(object sender, RoutedEventArgs e) => CopyToClipboard((item) => item.FileName);
         private void CopySignatureStatus_Click(object sender, RoutedEventArgs e) => CopyToClipboard((item) => item.SignatureStatus.ToString());
-        private void CopyAction_Click(object sender, RoutedEventArgs e) => CopyToClipboard((item) => item.Action.ToString());
         private void CopyOriginalFileName_Click(object sender, RoutedEventArgs e) => CopyToClipboard((item) => item.OriginalFileName);
         private void CopyInternalName_Click(object sender, RoutedEventArgs e) => CopyToClipboard((item) => item.InternalName);
         private void CopyFileDescription_Click(object sender, RoutedEventArgs e) => CopyToClipboard((item) => item.FileDescription);
@@ -438,15 +425,14 @@ namespace WDACConfig.Pages
         private void CopyPackageFamilyName_Click(object sender, RoutedEventArgs e) => CopyToClipboard((item) => item.PackageFamilyName);
         private void CopySHA256Hash_Click(object sender, RoutedEventArgs e) => CopyToClipboard((item) => item.SHA256Hash);
         private void CopySHA1Hash_Click(object sender, RoutedEventArgs e) => CopyToClipboard((item) => item.SHA1Hash);
-        private void CopySHA256FlatHash_Click(object sender, RoutedEventArgs e) => CopyToClipboard((item) => item.SHA256FlatHash);
-        private void CopySHA1FlatHash_Click(object sender, RoutedEventArgs e) => CopyToClipboard((item) => item.SHA1FlatHash);
         private void CopySigningScenario_Click(object sender, RoutedEventArgs e) => CopyToClipboard((item) => item.SISigningScenario.ToString());
         private void CopyFilePath_Click(object sender, RoutedEventArgs e) => CopyToClipboard((item) => item.FilePath);
         private void CopySHA1PageHash_Click(object sender, RoutedEventArgs e) => CopyToClipboard((item) => item.SHA1PageHash);
         private void CopySHA256PageHash_Click(object sender, RoutedEventArgs e) => CopyToClipboard((item) => item.SHA256PageHash);
         private void CopyHasWHQLSigner_Click(object sender, RoutedEventArgs e) => CopyToClipboard((item) => item.HasWHQLSigner.ToString());
-        private void CopyFilePublishersToDisplay_Click(object sender, RoutedEventArgs e) => CopyToClipboard((item) => item.FilePublishersToDisplay.ToString());
+        private void CopyFilePublishersToDisplay_Click(object sender, RoutedEventArgs e) => CopyToClipboard((item) => item.FilePublishersToDisplay);
         private void CopyIsECCSigned_Click(object sender, RoutedEventArgs e) => CopyToClipboard((item) => item.IsECCSigned.ToString());
+        private void CopyOpus_Click(object sender, RoutedEventArgs e) => CopyToClipboard((item) => item.Opus);
 
 
         /// <summary>

--- a/AppControl Manager/Pages/EventLogsPolicyCreation.xaml.cs
+++ b/AppControl Manager/Pages/EventLogsPolicyCreation.xaml.cs
@@ -141,7 +141,7 @@ namespace WDACConfig.Pages
                     (output.FilePath is not null && output.FilePath.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)) ||
                     (output.SHA256FlatHash is not null && output.SHA256FlatHash.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)) ||
                     (output.SHA256Hash is not null && output.SHA256Hash.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)) ||
-                    output.FilePublishersToDisplay.Contains(searchTerm)
+                    output.FilePublishersToDisplay.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)
                 );
             }
 

--- a/AppControl Manager/Pages/MDEAHPolicyCreation.xaml.cs
+++ b/AppControl Manager/Pages/MDEAHPolicyCreation.xaml.cs
@@ -137,7 +137,7 @@ namespace WDACConfig.Pages
                     (output.FilePath is not null && output.FilePath.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)) ||
                     (output.SHA256FlatHash is not null && output.SHA256FlatHash.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)) ||
                     (output.SHA256Hash is not null && output.SHA256Hash.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)) ||
-                    output.FilePublishersToDisplay.Contains(searchTerm)
+                    output.FilePublishersToDisplay.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)
                 );
             }
 

--- a/AppControl Manager/Pages/SystemInformation/ViewCurrentPolicies.xaml.cs
+++ b/AppControl Manager/Pages/SystemInformation/ViewCurrentPolicies.xaml.cs
@@ -135,8 +135,8 @@ namespace WDACConfig.Pages
             // Get the selected policy from the DataGrid
             selectedPolicy = (CiPolicyInfo)DeployedPolicies.SelectedItem;
 
-            // Check if a non-system policy was actually selected and if it's unsigned or supplemental
-            if (selectedPolicy is not null && !selectedPolicy.IsSystemPolicy && (!selectedPolicy.IsSignedPolicy || !string.Equals(selectedPolicy.BasePolicyID, selectedPolicy.PolicyID, StringComparison.OrdinalIgnoreCase)))
+            // Check if a non-system policy was actually selected and if it's unsigned or supplemental and if it exists on the disk
+            if (selectedPolicy is not null && !selectedPolicy.IsSystemPolicy && selectedPolicy.IsOnDisk && (!selectedPolicy.IsSignedPolicy || !string.Equals(selectedPolicy.BasePolicyID, selectedPolicy.PolicyID, StringComparison.OrdinalIgnoreCase)))
             {
                 // Enable the RemoveUnsignedOrSupplementalPolicyButton for unsigned policies
                 RemoveUnsignedOrSupplementalPolicyButton.IsEnabled = true;
@@ -164,8 +164,8 @@ namespace WDACConfig.Pages
 
             string AppControlPolicyName = "AppControlManagerSupplementalPolicy";
 
-            // Make sure we have a valid selected non-system policy that is unsigned or supplemental
-            if (selectedPolicy is not null && !selectedPolicy.IsSystemPolicy && (!selectedPolicy.IsSignedPolicy || !string.Equals(selectedPolicy.BasePolicyID, selectedPolicy.PolicyID, StringComparison.OrdinalIgnoreCase)))
+            // Make sure we have a valid selected non-system policy that is unsigned or supplemental and is on disk
+            if (selectedPolicy is not null && !selectedPolicy.IsSystemPolicy && selectedPolicy.IsOnDisk && (!selectedPolicy.IsSignedPolicy || !string.Equals(selectedPolicy.BasePolicyID, selectedPolicy.PolicyID, StringComparison.OrdinalIgnoreCase)))
             {
 
                 // Check if the selected policy has the FriendlyName "AppControlManagerSupplementalPolicy"

--- a/AppControl Manager/app.manifest
+++ b/AppControl Manager/app.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- INFO: https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests -->
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.5.1.0" name="AppControlManager"/>
+  <assemblyIdentity version="1.5.2.0" name="AppControlManager"/>
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>


### PR DESCRIPTION
# What's New

* Added support for Windows 11 build 23H2. This is in response to multiple community feedbacks that are always helpful and welcome. Closes #435 
* Completely switched to source-generated LibraryImports, improving performance. => https://github.com/HotCakeX/Harden-Windows-Security/pull/433
* Implemented several new code analyzers that ensure a cleaner, safer, high performance and better code.
* Improved the scanned data result DataGrid in Supplemental policy creation page. Removed 3 unused columns that don't apply to local file scans, added 1 new column to display each scanned file's Opus data.

Overall, this is a relatively small update. Big changes are coming in version 1.6 with many new features!

<br>

***In case you missed it, i posted a new video demoing AppControl Manager, check it out here
https://www.youtube.com/watch?v=SzMs13n7elE***

