### PR TITLE
Added Application Control Status to the System Information page

### DIFF
--- a/AppControl Manager/Pages/SystemInformation/CodeIntegrityInfo.xaml
+++ b/AppControl Manager/Pages/SystemInformation/CodeIntegrityInfo.xaml
@@ -7,33 +7,37 @@
     xmlns:ci="using:AppControlManager.CodeIntegrity"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="using:CommunityToolkit.WinUI"
+    xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     mc:Ignorable="d">
 
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
+    <ScrollViewer>
 
-        <Button x:Name="RetrieveCodeIntegrityInfo"
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <Button x:Name="RetrieveCodeIntegrityInfo"
                 Content="Retrieve Code Integrity Info"
                 Click="RetrieveCodeIntegrityInfo_Click"
                 ToolTipService.ToolTip="Retrieve the latest effective Code Integrity information from the current system"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Top"
                 Style="{StaticResource AccentButtonStyle}"
-                Margin="10"
+                Margin="0,0,0,10"
                 Grid.Row="0"/>
 
-        <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Auto" Margin="10,10,10,10">
-            <ListView Name="CodeIntegrityInfoListView" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" SelectionMode="None">
+            <ListView Grid.Row="1" Name="CodeIntegrityInfoListView" HorizontalAlignment="Center" SelectionMode="None">
                 <!-- ListView Headers -->
                 <ListView.Header>
-                    <Grid Padding="16,12" ColumnSpacing="16">
+                    <Grid ColumnSpacing="16">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
-                        <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Effective Code Integrity Features" />
+                        <TextBlock Margin="0,10,0,10" Style="{ThemeResource TitleTextBlockStyle}" HorizontalAlignment="Center" Text="Effective Code Integrity Features" />
                     </Grid>
                 </ListView.Header>
 
@@ -46,7 +50,7 @@
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
                             <!-- Bind only the Description properties from CodeIntegrityOption -->
-                            <TextBlock Text="{x:Bind Description}" Margin="0,0,0,10" />
+                            <TextBox IsReadOnly="True" TextWrapping="Wrap" Text="{x:Bind Description}" Margin="0,0,0,10" />
                         </Grid>
                     </DataTemplate>
                 </ListView.ItemTemplate>
@@ -57,6 +61,16 @@
                     </Style>
                 </ListView.ItemContainerStyle>
             </ListView>
-        </ScrollViewer>
-    </Grid>
+
+
+            <controls:WrapPanel Margin="10,10,0,10" HorizontalAlignment="Center" Orientation="Vertical" HorizontalSpacing="10" VerticalSpacing="15" Grid.Row="2">
+                <TextBlock Text="Application Control for Business Status" Style="{ThemeResource TitleTextBlockStyle}" />
+                <TextBox x:Name="UMCI" TextWrapping="Wrap" IsReadOnly="True" Header="User Mode Code Integrity" />
+                <TextBox x:Name="KMCI" TextWrapping="Wrap" IsReadOnly="True" Header="Kernel Mode Code Integrity" />
+            </controls:WrapPanel>
+
+        </Grid>
+
+    </ScrollViewer>
+
 </Page>

--- a/AppControl Manager/Pages/SystemInformation/CodeIntegrityInfo.xaml.cs
+++ b/AppControl Manager/Pages/SystemInformation/CodeIntegrityInfo.xaml.cs
@@ -1,5 +1,6 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Navigation;
 
 namespace AppControlManager.Pages;
 
@@ -9,9 +10,29 @@ public sealed partial class CodeIntegrityInfo : Page
 	{
 		this.InitializeComponent();
 
-		this.NavigationCacheMode = Microsoft.UI.Xaml.Navigation.NavigationCacheMode.Enabled;
+		this.NavigationCacheMode = NavigationCacheMode.Enabled;
 	}
 
+
+	/// <summary>
+	/// Local method to convert numbers to their actual string values
+	/// </summary>
+	/// <param name="status"></param>
+	/// <returns></returns>
+	private static string? GetPolicyStatus(uint? status) => status switch
+	{
+		0 => "Disabled/Not running",
+		1 => "Audit mode",
+		2 => "Enforced Mode",
+		_ => null
+	};
+
+
+	/// <summary>
+	/// Event handler for the retrieve code integrity information button
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="e"></param>
 	private void RetrieveCodeIntegrityInfo_Click(object sender, RoutedEventArgs e)
 	{
 		// Get the system code integrity information
@@ -19,5 +40,12 @@ public sealed partial class CodeIntegrityInfo : Page
 
 		// Bind the CodeIntegrityDetails (List<CodeIntegrityOption>) to the ListView
 		CodeIntegrityInfoListView.ItemsSource = codeIntegrityInfoResult.CodeIntegrityDetails;
+
+		// Get the Application Control Status
+		DeviceGuardStatus? DGStatus = DeviceGuardInfo.GetDeviceGuardStatus();
+
+		UMCI.Text = GetPolicyStatus(DGStatus?.UsermodeCodeIntegrityPolicyEnforcementStatus);
+		KMCI.Text = GetPolicyStatus(DGStatus?.CodeIntegrityPolicyEnforcementStatus);
+
 	}
 }

--- a/AppControl Manager/Pages/SystemInformation/CodeIntegrityInfo.xaml.cs
+++ b/AppControl Manager/Pages/SystemInformation/CodeIntegrityInfo.xaml.cs
@@ -21,7 +21,7 @@ public sealed partial class CodeIntegrityInfo : Page
 	/// <returns></returns>
 	private static string? GetPolicyStatus(uint? status) => status switch
 	{
-		0 => "Disabled/Not running",
+		1 => "Audit Mode",
 		1 => "Audit mode",
 		2 => "Enforced Mode",
 		_ => null

--- a/AppControl Manager/Pages/SystemInformation/CodeIntegrityInfo.xaml.cs
+++ b/AppControl Manager/Pages/SystemInformation/CodeIntegrityInfo.xaml.cs
@@ -21,8 +21,8 @@ public sealed partial class CodeIntegrityInfo : Page
 	/// <returns></returns>
 	private static string? GetPolicyStatus(uint? status) => status switch
 	{
+		0 => "Disabled/Not Running",
 		1 => "Audit Mode",
-		1 => "Audit mode",
 		2 => "Enforced Mode",
 		_ => null
 	};


### PR DESCRIPTION
Added Application Control Status to the [System Information page](https://github.com/HotCakeX/Harden-Windows-Security/wiki/System-Information) in the AppControl Manager.

It display the status of User Mode and Kernel Mode Application Control on the system. Valid values are:

* Enforced Mode
* Audit Mode
* Disabled/Not Running

<br>
