### PR TITLE
Implementing signed policy scenarios

### DIFF
--- a/AppControl Manager/App.xaml.cs
+++ b/AppControl Manager/App.xaml.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using AppControlManager.Logging;
 using CommunityToolkit.WinUI;
+using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;

--- a/AppControl Manager/CustomUIElements/SigningDetailsDialog.xaml
+++ b/AppControl Manager/CustomUIElements/SigningDetailsDialog.xaml
@@ -1,0 +1,162 @@
+<ContentDialog
+    x:Class="AppControlManager.CustomUIElements.SigningDetailsDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:AppControlManager.CustomUIElements"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="using:CommunityToolkit.WinUI"
+    xmlns:controls="using:CommunityToolkit.WinUI.Controls"
+    xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    mc:Ignorable="d"
+    Title="Signing Details"
+    PrimaryButtonText="Submit"
+    CloseButtonText="Cancel"
+    IsPrimaryButtonEnabled="False"
+    DefaultButton="Primary"
+    BorderThickness="1"
+    CornerRadius="8"
+    Style="{ThemeResource DefaultContentDialogStyle}"
+    BorderBrush="{ThemeResource AccentFillColorDefaultBrush}">
+
+    <ContentDialog.Resources>
+        <!--  These styles can be referenced to create a consistent SettingsPage layout  -->
+
+        <!--  Spacing between cards  -->
+        <x:Double x:Key="SettingsCardSpacing">4</x:Double>
+
+        <!--  Style (inc. the correct spacing) of a section header  -->
+        <Style x:Key="SettingsSectionHeaderTextBlockStyle"
+     BasedOn="{StaticResource BodyStrongTextBlockStyle}"
+     TargetType="TextBlock">
+            <Style.Setters>
+                <Setter Property="Margin" Value="1,30,0,6" />
+            </Style.Setters>
+        </Style>
+
+        <!-- https://github.com/microsoft/microsoft-ui-xaml/issues/424 -->
+        <x:Double x:Key="ContentDialogMaxWidth">2000</x:Double>
+    </ContentDialog.Resources>
+
+    <ScrollView>
+
+        <Grid>
+
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <TextBlock IsTextSelectionEnabled="True" Grid.Row="0" TextWrapping="Wrap" VerticalAlignment="Top" Text="Please provide the required details that will be used to sign the XML App Control Policies." />
+
+            <InfoBar
+                Margin="15"
+                Grid.Row="1"
+                BorderThickness="0"
+                CornerRadius="0"
+                IsIconVisible="True"
+                IsOpen="True"
+                IsClosable="False"
+                Message="You can configure the following details in the app settings once, eliminating the need to enter them repeatedly"
+                Severity="Informational">
+                <InfoBar.ActionButton>
+                    <Button Content="Go to Settings" Click="OpenAppSettingsButton_Click" />
+                </InfoBar.ActionButton>
+            </InfoBar>
+
+
+            <StackPanel HorizontalAlignment="Stretch"
+            Spacing="{StaticResource SettingsCardSpacing}" Grid.Row="2">
+
+                <win:StackPanel.ChildrenTransitions>
+                    <win:EntranceThemeTransition FromVerticalOffset="50" />
+                    <win:RepositionThemeTransition IsStaggeringEnabled="False" />
+                </win:StackPanel.ChildrenTransitions>
+
+
+                <controls:SettingsCard Header="Certificate File"
+                 Description="Its details will be added to the policy file"
+                 HeaderIcon="{ui:FontIcon Glyph=&#xEA86;}">
+
+                    <controls:WrapPanel Orientation="Vertical" VerticalSpacing="10" HorizontalSpacing="10">
+
+                        <Button x:Name="CertFileBrowseButton" HorizontalAlignment="Center" Click="CertFileBrowseButton_Click" Content="Browse"/>
+                        <TextBox MaxWidth="700" x:Name="CertFilePathTextBox" TextWrapping="Wrap" PlaceholderText=".cer file path" />
+
+                    </controls:WrapPanel>
+
+                </controls:SettingsCard>
+
+                <controls:SettingsCard Header="Certificate Common Name"
+                 Description="Used during the signing operation"                      
+                 HeaderIcon="{ui:FontIcon Glyph=&#xEA86;}">
+
+                    <controls:WrapPanel Orientation="Vertical" HorizontalSpacing="10" VerticalSpacing="10">
+
+                        <AutoSuggestBox x:Name="CertificateCommonNameAutoSuggestBox"
+                           MaxWidth="700"
+                            QueryIcon="Find"
+                            GotFocus="CertificateCommonNameAutoSuggestBox_GotFocus"
+                            TextChanged="CertificateCNAutoSuggestBox_TextChanged"
+                            PlaceholderText="Find Certificate Common Names"/>
+
+                    </controls:WrapPanel>
+
+                </controls:SettingsCard>
+
+
+
+                <controls:SettingsCard Header="SignTool Path"
+                Description="Used to sign the policy CIP file"
+                HeaderIcon="{ui:FontIcon Glyph=&#xEA86;}">
+
+                    <controls:WrapPanel VerticalSpacing="10" HorizontalSpacing="10" Orientation="Vertical">
+
+                        <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center" Margin="0,0,0,5" ToolTipService.ToolTip="Automatically downloads the signtool.exe from Microsoft servers">
+                            <ToggleSwitch x:Name="AutoAcquireSignTool" Toggled="AutoAcquireSignTool_Toggled" />
+                            <TextBlock Text="Auto Acquire" Margin="0,8.7,0,0" />
+                        </StackPanel>
+
+                        <Button x:Name="SignToolBrowseButton" Click="SignToolBrowseButton_Click" HorizontalAlignment="Center" Content="Browse"/>
+                        <TextBox MaxWidth="700" x:Name="SignToolPathTextBox" PlaceholderText="SignTool.exe Path" TextWrapping="Wrap"/>
+
+                    </controls:WrapPanel>
+
+
+                </controls:SettingsCard>
+
+
+            </StackPanel>
+
+            <controls:WrapPanel Grid.Row="3" Orientation="Vertical" HorizontalSpacing="10" VerticalSpacing="10" Margin="10,15,10,0" HorizontalAlignment="Center">
+
+                <Button HorizontalAlignment="Center" ToolTipService.ToolTip="Verify the settings before submitting them"
+            Click="VerifyButton_Click"
+            x:Name="VerifyButton">
+
+                    <Button.Content>
+                        <StackPanel Orientation="Horizontal" Padding="10,5,10,5">
+                            <ProgressRing VerticalAlignment="Center" x:Name="VerifyButtonProgressRing" Margin="0,0,10,0" Visibility="Collapsed" IsIndeterminate="True"/>
+                            <TextBlock x:Name="VerifyButtonContentTextBlock" VerticalAlignment="Center" FontWeight="SemiBold" Text="Verify"/>
+                        </StackPanel>
+                    </Button.Content>
+                    
+                </Button>
+
+
+                <TeachingTip x:Name="VerifyButtonTeachingTip"
+                            Target="{x:Bind VerifyButton}"
+                            Title="Error">
+                </TeachingTip>
+
+            </controls:WrapPanel>
+
+        </Grid>
+
+    </ScrollView>
+
+
+
+</ContentDialog>

--- a/AppControl Manager/CustomUIElements/SigningDetailsDialog.xaml.cs
+++ b/AppControl Manager/CustomUIElements/SigningDetailsDialog.xaml.cs
@@ -1,0 +1,359 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace AppControlManager.CustomUIElements;
+
+// https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.contentdialog
+
+internal sealed partial class SigningDetailsDialog : ContentDialog
+{
+	// Properties to access the input value
+	internal string? CertificatePath { get; private set; }
+	internal string? CertificateCommonName { get; private set; }
+	internal string? SignToolPath { get; private set; }
+
+	// To track whether verification is running so it won't happen again
+	// Enabling/Disabling Verification button causes the Primary button to not have its theme properly for some reason
+	private bool VerificationRunning;
+
+	// To store the selectable Certificate common names
+	private HashSet<string> CertCommonNames = [];
+
+
+	internal SigningDetailsDialog()
+	{
+		this.InitializeComponent();
+
+		XamlRoot = App.MainWindow?.Content.XamlRoot;
+
+		// Populate the AutoSuggestBox with possible certificate common names available on the system
+		FetchLatestCertificateCNs();
+
+		// Get the user configurations
+		UserConfiguration currentUserConfigs = UserConfiguration.Get();
+
+		// Fill in the text boxes based on the current user configs
+		CertFilePathTextBox.Text = currentUserConfigs.CertificatePath;
+		CertificateCommonNameAutoSuggestBox.Text = currentUserConfigs.CertificateCommonName;
+		SignToolPathTextBox.Text = currentUserConfigs.SignToolCustomPath;
+
+		// Assign the data from user configurations to the local variables
+		CertificatePath = currentUserConfigs.CertificatePath;
+		CertificateCommonName = currentUserConfigs.CertificateCommonName;
+		SignToolPath = currentUserConfigs.SignToolCustomPath;
+	}
+
+
+	/// <summary>
+	/// Event handler for AutoSuggestBox
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="args"></param>
+	private void CertificateCNAutoSuggestBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
+	{
+		if (args.Reason == AutoSuggestionBoxTextChangeReason.UserInput)
+		{
+			string query = sender.Text.ToLowerInvariant();
+
+			// Filter menu items based on the search query
+			List<string> suggestions = [.. CertCommonNames.Where(name => name.Contains(query, StringComparison.OrdinalIgnoreCase))];
+
+			// Set the filtered items as suggestions in the AutoSuggestBox
+			sender.ItemsSource = suggestions;
+		}
+	}
+
+
+	/// <summary>
+	/// Start suggesting when tap or mouse click happens
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="e"></param>
+	private void CertificateCommonNameAutoSuggestBox_GotFocus(object sender, RoutedEventArgs e)
+	{
+		// Set the filtered items as suggestions in the AutoSuggestBox
+		((AutoSuggestBox)sender).ItemsSource = CertCommonNames;
+	}
+
+
+	/// <summary>
+	/// Get all of the common names of the certificates in the user/my certificate store over time
+	/// </summary>
+	private async void FetchLatestCertificateCNs()
+	{
+		await Task.Run(() =>
+		{
+			CertCommonNames = CertCNFetcher.GetCertCNs();
+		});
+	}
+
+
+	/// <summary>
+	/// Event handler for the button that navigates to the Settings page
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="e"></param>
+	private void OpenAppSettingsButton_Click(object sender, RoutedEventArgs e)
+	{
+		// Hide the dialog box
+		this.Hide();
+
+		MainWindow.Instance.NavView_Navigate(typeof(Pages.Settings), null);
+	}
+
+
+	/// <summary>
+	/// Event handler for the primary button click
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="args"></param>
+	private void OnPrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+	{
+		// Fill in the text boxes based on the current user configs
+		CertificatePath = CertFilePathTextBox.Text;
+		CertificateCommonName = CertificateCommonNameAutoSuggestBox.Text;
+		SignToolPath = SignToolPathTextBox.Text;
+	}
+
+
+	/// <summary>
+	/// Event handler for the toggle switch to automatically download SignTool.exe from the Microsoft servers
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="e"></param>
+	private void AutoAcquireSignTool_Toggled(object sender, RoutedEventArgs e)
+	{
+		if (AutoAcquireSignTool.IsOn)
+		{
+			SignToolBrowseButton.IsEnabled = false;
+			SignToolPathTextBox.IsEnabled = false;
+		}
+		else
+		{
+			SignToolBrowseButton.IsEnabled = true;
+			SignToolPathTextBox.IsEnabled = true;
+		}
+	}
+
+
+	/// <summary>
+	/// Disables the input UI elements
+	/// </summary>
+	private void DisableUIElements()
+	{
+		SignToolPathTextBox.IsEnabled = false;
+		CertificateCommonNameAutoSuggestBox.IsEnabled = false;
+		AutoAcquireSignTool.IsEnabled = false;
+		CertFileBrowseButton.IsEnabled = false;
+		SignToolBrowseButton.IsEnabled = false;
+		CertFilePathTextBox.IsEnabled = false;
+	}
+
+
+	/// <summary>
+	/// Enables the input UI elements
+	/// </summary>
+	private void EnableUIElements()
+	{
+		SignToolPathTextBox.IsEnabled = true;
+		CertificateCommonNameAutoSuggestBox.IsEnabled = true;
+		AutoAcquireSignTool.IsEnabled = true;
+		CertFileBrowseButton.IsEnabled = true;
+		SignToolBrowseButton.IsEnabled = true;
+		CertFilePathTextBox.IsEnabled = true;
+	}
+
+
+	/// <summary>
+	/// To show the Teaching Tip for the Verify button
+	/// </summary>
+	/// <param name="message"></param>
+	private void ShowTeachingTip(string message)
+	{
+		VerifyButtonTeachingTip.IsOpen = true;
+
+		VerifyButtonTeachingTip.Subtitle = message;
+	}
+
+
+	/// <summary>
+	/// Event handler for the Verify button
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="e"></param>
+	private async void VerifyButton_Click(object sender, RoutedEventArgs e)
+	{
+
+		if (VerificationRunning)
+		{
+			return;
+		}
+
+		bool everythingChecksOut = false;
+
+		VerificationRunning = true;
+
+		try
+		{
+			// Disable UI elements during verification
+			DisableUIElements();
+
+			VerifyButtonContentTextBlock.Text = "Verify";
+
+			VerifyButtonProgressRing.Visibility = Visibility.Visible;
+
+			// Disable the submit button until all checks are done (in case it was enabled)
+			this.IsPrimaryButtonEnabled = false;
+
+			VerifyButtonTeachingTip.IsOpen = false;
+
+			// Verify the certificate
+			if (string.IsNullOrWhiteSpace(CertFilePathTextBox.Text))
+			{
+				ShowTeachingTip("Please select a certificate file.");
+				return;
+			}
+
+			if (!File.Exists(CertFilePathTextBox.Text))
+			{
+				ShowTeachingTip("The selected certificate file path does not exist");
+				return;
+			}
+
+			if (!string.Equals(Path.GetExtension(CertFilePathTextBox.Text), ".cer", StringComparison.OrdinalIgnoreCase))
+			{
+				ShowTeachingTip("You need to select a certificate file path with (.cer) extension.");
+				return;
+			}
+
+
+			// Verify Certificate Common Name
+			if (string.IsNullOrWhiteSpace(CertificateCommonNameAutoSuggestBox.Text))
+			{
+				ShowTeachingTip("Please select a certificate common name from the suggestions.");
+				return;
+			}
+
+			if (!CertCommonNames.Contains(CertificateCommonNameAutoSuggestBox.Text))
+			{
+				ShowTeachingTip("No certificate was found in the Current User personal store with the selected Common Name.");
+				return;
+			}
+
+
+			// Verify the SignTool
+			if (!AutoAcquireSignTool.IsOn)
+			{
+
+				if (string.IsNullOrWhiteSpace(SignToolPathTextBox.Text))
+				{
+					ShowTeachingTip("Please select the path to SignTool.exe or enable the auto-acquire option.");
+					return;
+				}
+
+				if (!File.Exists(SignToolPathTextBox.Text))
+				{
+					ShowTeachingTip("SignTool.exe does not exist in the selected path. You can enable the auto-acquire option if you don't have it.");
+					return;
+				}
+
+				if (!string.Equals(Path.GetExtension(SignToolPathTextBox.Text), ".exe", StringComparison.OrdinalIgnoreCase))
+				{
+					ShowTeachingTip("The SignTool path must end with (.exe). You can enable the auto-acquire option if you don't have it.");
+					return;
+				}
+			}
+			else
+			{
+				try
+				{
+					VerifyButtonContentTextBlock.Text = "Downloading SignTool";
+
+					string newSignToolPath;
+
+					// Get the SignTool.exe path
+					newSignToolPath = await Task.Run(() => SignToolHelper.GetSignToolPath());
+
+					// Assign it to the local variable
+					SignToolPath = newSignToolPath;
+
+					// Set it to the UI text box
+					SignToolPathTextBox.Text = newSignToolPath;
+				}
+
+				finally
+				{
+					VerifyButtonContentTextBlock.Text = "Verify";
+				}
+			}
+
+
+			// If everything checks out then enable the Primary button for submission
+			this.IsPrimaryButtonEnabled = true;
+
+			everythingChecksOut = true;
+
+			// Set the SignTool.exe path that was verified to be valid to the user configurations
+			_ = UserConfiguration.Set(SignToolCustomPath: SignToolPath);
+		}
+		finally
+		{
+			VerifyButtonProgressRing.Visibility = Visibility.Collapsed;
+
+			// If verification failed then re-enable the UI elements
+			if (!everythingChecksOut)
+			{
+				EnableUIElements();
+			}
+			else
+			{
+				VerifyButtonContentTextBlock.Text = "Verification Successful";
+			}
+
+			VerificationRunning = false;
+		}
+	}
+
+
+	/// <summary>
+	/// Event handler for SignTool.exe browse button
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="e"></param>
+	private void SignToolBrowseButton_Click(object sender, RoutedEventArgs e)
+	{
+		string filter = "Executable file|*.exe";
+
+		string? selectedFiles = FileDialogHelper.ShowFilePickerDialog(filter);
+
+		if (!string.IsNullOrWhiteSpace(selectedFiles))
+		{
+			SignToolPath = selectedFiles;
+			SignToolPathTextBox.Text = selectedFiles;
+		}
+	}
+
+
+	/// <summary>
+	/// Event handler for browse for certificate .cer file button
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="e"></param>
+	private void CertFileBrowseButton_Click(object sender, RoutedEventArgs e)
+	{
+		string filter = "Certificate file|*.cer";
+
+		string? selectedFiles = FileDialogHelper.ShowFilePickerDialog(filter);
+
+		if (!string.IsNullOrWhiteSpace(selectedFiles))
+		{
+			CertificatePath = selectedFiles;
+			CertFilePathTextBox.Text = selectedFiles;
+		}
+	}
+}

--- a/AppControl Manager/CustomUIElements/SigningDetailsDialogForRemoval.xaml
+++ b/AppControl Manager/CustomUIElements/SigningDetailsDialogForRemoval.xaml
@@ -1,0 +1,184 @@
+<ContentDialog
+    x:Class="AppControlManager.CustomUIElements.SigningDetailsDialogForRemoval"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:AppControlManager.CustomUIElements"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="using:CommunityToolkit.WinUI"
+    xmlns:controls="using:CommunityToolkit.WinUI.Controls"
+    xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    mc:Ignorable="d"
+    Title="Signing Details"
+    PrimaryButtonText="Submit"
+    CloseButtonText="Cancel"
+    IsPrimaryButtonEnabled="False"
+    DefaultButton="Primary"
+    BorderThickness="1"
+    CornerRadius="8"
+    Style="{ThemeResource DefaultContentDialogStyle}"
+    BorderBrush="{ThemeResource AccentFillColorDefaultBrush}">
+
+    <ContentDialog.Resources>
+        <!--  These styles can be referenced to create a consistent SettingsPage layout  -->
+
+        <!--  Spacing between cards  -->
+        <x:Double x:Key="SettingsCardSpacing">4</x:Double>
+
+        <!--  Style (inc. the correct spacing) of a section header  -->
+        <Style x:Key="SettingsSectionHeaderTextBlockStyle"
+     BasedOn="{StaticResource BodyStrongTextBlockStyle}"
+     TargetType="TextBlock">
+            <Style.Setters>
+                <Setter Property="Margin" Value="1,30,0,6" />
+            </Style.Setters>
+        </Style>
+
+        <!-- https://github.com/microsoft/microsoft-ui-xaml/issues/424 -->
+        <x:Double x:Key="ContentDialogMaxWidth">2000</x:Double>
+    </ContentDialog.Resources>
+
+    <ScrollView>
+
+        <Grid>
+
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <TextBlock IsTextSelectionEnabled="True" Grid.Row="0" TextWrapping="Wrap" VerticalAlignment="Top" Text="Please provide the required details that will be used to re-sign the XML App Control Policy so that it will be removable on next reboot." />
+
+            <InfoBar
+                Margin="15"
+                Grid.Row="1"
+                BorderThickness="0"
+                CornerRadius="0"
+                IsIconVisible="True"
+                IsOpen="True"
+                IsClosable="False"
+                Message="You can configure the following details in the app settings once, eliminating the need to enter them repeatedly"
+                Severity="Informational">
+                <InfoBar.ActionButton>
+                    <Button Content="Go to Settings" Click="OpenAppSettingsButton_Click" />
+                </InfoBar.ActionButton>
+            </InfoBar>
+
+
+            <StackPanel HorizontalAlignment="Stretch"
+            Spacing="{StaticResource SettingsCardSpacing}" Grid.Row="2">
+
+                <win:StackPanel.ChildrenTransitions>
+                    <win:EntranceThemeTransition FromVerticalOffset="50" />
+                    <win:RepositionThemeTransition IsStaggeringEnabled="False" />
+                </win:StackPanel.ChildrenTransitions>
+
+
+                <controls:SettingsCard Header="Certificate File"
+                 Description="Its details will be added to the policy file"
+                 HeaderIcon="{ui:FontIcon Glyph=&#xEA86;}">
+
+                    <controls:WrapPanel Orientation="Vertical" VerticalSpacing="10" HorizontalSpacing="10">
+
+                        <Button x:Name="CertFileBrowseButton" HorizontalAlignment="Center" Click="CertFileBrowseButton_Click" Content="Browse"/>
+                        <TextBox MaxWidth="700" x:Name="CertFilePathTextBox" TextWrapping="Wrap" PlaceholderText=".cer file path" />
+
+                    </controls:WrapPanel>
+
+                </controls:SettingsCard>
+
+                <controls:SettingsCard Header="Certificate Common Name"
+                 Description="Used during the signing operation"                      
+                 HeaderIcon="{ui:FontIcon Glyph=&#xEA86;}">
+
+                    <controls:WrapPanel Orientation="Vertical" HorizontalSpacing="10" VerticalSpacing="10">
+
+                        <AutoSuggestBox x:Name="CertificateCommonNameAutoSuggestBox"
+                           MaxWidth="700"
+                            QueryIcon="Find"
+                            GotFocus="CertificateCommonNameAutoSuggestBox_GotFocus"
+                            TextChanged="CertificateCNAutoSuggestBox_TextChanged"
+                            PlaceholderText="Find Certificate Common Names"/>
+
+                    </controls:WrapPanel>
+
+                </controls:SettingsCard>
+
+
+
+                <controls:SettingsCard Header="SignTool Path"
+                Description="Used to sign the policy CIP file"
+                HeaderIcon="{ui:FontIcon Glyph=&#xEA86;}">
+
+                    <controls:WrapPanel VerticalSpacing="10" HorizontalSpacing="10" Orientation="Vertical">
+
+                        <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center" Margin="0,0,0,5" ToolTipService.ToolTip="Automatically downloads the signtool.exe from Microsoft servers">
+                            <ToggleSwitch x:Name="AutoAcquireSignTool" Toggled="AutoAcquireSignTool_Toggled" />
+                            <TextBlock Text="Auto Acquire" Margin="0,8.7,0,0" />
+                        </StackPanel>
+
+                        <Button x:Name="SignToolBrowseButton" Click="SignToolBrowseButton_Click" HorizontalAlignment="Center" Content="Browse"/>
+                        <TextBox MaxWidth="700" x:Name="SignToolPathTextBox" PlaceholderText="SignTool.exe Path" TextWrapping="Wrap"/>
+
+                    </controls:WrapPanel>
+
+
+                </controls:SettingsCard>
+
+
+
+
+
+                <controls:SettingsCard Header="XML File"
+                    Description="The XML file of the Signed policy that is going to be removed"
+                    HeaderIcon="{ui:FontIcon Glyph=&#xEA86;}">
+
+                    <controls:WrapPanel VerticalSpacing="10" HorizontalSpacing="10" Orientation="Vertical">
+
+                        <Button x:Name="XMLPolicyFileBrowseButton" Click="XMLPolicyFileBrowseButton_Click" HorizontalAlignment="Center" Content="Browse"/>
+                      
+                        <TextBox MaxWidth="700" x:Name="XMLPolicyFileTextBox" PlaceholderText="XML file path" TextWrapping="Wrap"/>
+
+                    </controls:WrapPanel>
+
+
+                </controls:SettingsCard>
+
+
+
+
+
+            </StackPanel>
+
+            <controls:WrapPanel Grid.Row="3" Orientation="Vertical" HorizontalSpacing="10" VerticalSpacing="10" Margin="10,15,10,0" HorizontalAlignment="Center">
+
+                <Button HorizontalAlignment="Center" ToolTipService.ToolTip="Verify the settings before submitting them"
+            Click="VerifyButton_Click"
+            x:Name="VerifyButton">
+
+                    <Button.Content>
+                        <StackPanel Orientation="Horizontal" Padding="10,5,10,5">
+                            <ProgressRing VerticalAlignment="Center" x:Name="VerifyButtonProgressRing" Margin="0,0,10,0" Visibility="Collapsed" IsIndeterminate="True"/>
+                            <TextBlock x:Name="VerifyButtonContentTextBlock" VerticalAlignment="Center" FontWeight="SemiBold" Text="Verify"/>
+                        </StackPanel>
+                    </Button.Content>
+
+                </Button>
+
+
+                <TeachingTip x:Name="VerifyButtonTeachingTip"
+                            Target="{x:Bind VerifyButton}"
+                            Title="Error">
+                </TeachingTip>
+
+            </controls:WrapPanel>
+
+        </Grid>
+
+    </ScrollView>
+
+
+
+</ContentDialog>

--- a/AppControl Manager/CustomUIElements/SigningDetailsDialogForRemoval.xaml.cs
+++ b/AppControl Manager/CustomUIElements/SigningDetailsDialogForRemoval.xaml.cs
@@ -1,0 +1,461 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace AppControlManager.CustomUIElements;
+
+// https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.contentdialog
+
+internal sealed partial class SigningDetailsDialogForRemoval : ContentDialog
+{
+	// Properties to access the input value
+	internal string? CertificatePath { get; private set; }
+	internal string? CertificateCommonName { get; private set; }
+	internal string? SignToolPath { get; private set; }
+	internal string? XMLPolicyPath { get; private set; }
+
+	// To track whether verification is running so it won't happen again
+	// Enabling/Disabling Verification button causes the Primary button to not have its theme properly for some reason
+	private bool VerificationRunning;
+
+	// To store the selectable Certificate common names
+	private HashSet<string> CertCommonNames = [];
+
+	// To save the policy IDs of the currently deployed base policies coming from the calling method
+	private readonly List<string?> basePolicyIDs;
+
+	private readonly string policyIDBeingRemoved;
+
+	internal SigningDetailsDialogForRemoval(List<string?> currentlyDeployedBasePolicyIDs, string idBeingRemoved)
+	{
+		this.InitializeComponent();
+
+		XamlRoot = App.MainWindow?.Content.XamlRoot;
+
+		// Populate the AutoSuggestBox with possible certificate common names available on the system
+		FetchLatestCertificateCNs();
+
+		basePolicyIDs = currentlyDeployedBasePolicyIDs;
+
+		policyIDBeingRemoved = idBeingRemoved;
+
+		// Get the user configurations
+		UserConfiguration currentUserConfigs = UserConfiguration.Get();
+
+		// Fill in the text boxes based on the current user configs
+		CertFilePathTextBox.Text = currentUserConfigs.CertificatePath;
+		CertificateCommonNameAutoSuggestBox.Text = currentUserConfigs.CertificateCommonName;
+		SignToolPathTextBox.Text = currentUserConfigs.SignToolCustomPath;
+
+		// Assign the data from user configurations to the local variables
+		CertificatePath = currentUserConfigs.CertificatePath;
+		CertificateCommonName = currentUserConfigs.CertificateCommonName;
+		SignToolPath = currentUserConfigs.SignToolCustomPath;
+	}
+
+
+	/// <summary>
+	/// Event handler for AutoSuggestBox
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="args"></param>
+	private void CertificateCNAutoSuggestBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
+	{
+		if (args.Reason == AutoSuggestionBoxTextChangeReason.UserInput)
+		{
+			string query = sender.Text.ToLowerInvariant();
+
+			// Filter menu items based on the search query
+			List<string> suggestions = [.. CertCommonNames.Where(name => name.Contains(query, StringComparison.OrdinalIgnoreCase))];
+
+			// Set the filtered items as suggestions in the AutoSuggestBox
+			sender.ItemsSource = suggestions;
+		}
+	}
+
+
+	/// <summary>
+	/// Start suggesting when tap or mouse click happens
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="e"></param>
+	private void CertificateCommonNameAutoSuggestBox_GotFocus(object sender, RoutedEventArgs e)
+	{
+		// Set the filtered items as suggestions in the AutoSuggestBox
+		((AutoSuggestBox)sender).ItemsSource = CertCommonNames;
+	}
+
+
+	/// <summary>
+	/// Get all of the common names of the certificates in the user/my certificate store over time
+	/// </summary>
+	private async void FetchLatestCertificateCNs()
+	{
+		await Task.Run(() =>
+		{
+			CertCommonNames = CertCNFetcher.GetCertCNs();
+		});
+	}
+
+
+	/// <summary>
+	/// Event handler for the button that navigates to the Settings page
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="e"></param>
+	private void OpenAppSettingsButton_Click(object sender, RoutedEventArgs e)
+	{
+		// Hide the dialog box
+		this.Hide();
+
+		MainWindow.Instance.NavView_Navigate(typeof(Pages.Settings), null);
+	}
+
+
+	/// <summary>
+	/// Event handler for the primary button click
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="args"></param>
+	private void OnPrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+	{
+		// Grab the details from the text boxes in the UI and assign them to the local variables
+		// So that the method that calls this content dialog can access them
+		CertificatePath = CertFilePathTextBox.Text;
+		CertificateCommonName = CertificateCommonNameAutoSuggestBox.Text;
+		SignToolPath = SignToolPathTextBox.Text;
+		XMLPolicyPath = XMLPolicyFileTextBox.Text;
+	}
+
+
+	/// <summary>
+	/// Event handler for the toggle switch to automatically download SignTool.exe from the Microsoft servers
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="e"></param>
+	private void AutoAcquireSignTool_Toggled(object sender, RoutedEventArgs e)
+	{
+		if (AutoAcquireSignTool.IsOn)
+		{
+			SignToolBrowseButton.IsEnabled = false;
+			SignToolPathTextBox.IsEnabled = false;
+		}
+		else
+		{
+			SignToolBrowseButton.IsEnabled = true;
+			SignToolPathTextBox.IsEnabled = true;
+		}
+	}
+
+
+	/// <summary>
+	/// Disables the input UI elements
+	/// </summary>
+	private void DisableUIElements()
+	{
+		SignToolPathTextBox.IsEnabled = false;
+		CertificateCommonNameAutoSuggestBox.IsEnabled = false;
+		AutoAcquireSignTool.IsEnabled = false;
+		CertFileBrowseButton.IsEnabled = false;
+		SignToolBrowseButton.IsEnabled = false;
+		CertFilePathTextBox.IsEnabled = false;
+		XMLPolicyFileBrowseButton.IsEnabled = false;
+	}
+
+
+	/// <summary>
+	/// Enables the input UI elements
+	/// </summary>
+	private void EnableUIElements()
+	{
+		SignToolPathTextBox.IsEnabled = true;
+		CertificateCommonNameAutoSuggestBox.IsEnabled = true;
+		AutoAcquireSignTool.IsEnabled = true;
+		CertFileBrowseButton.IsEnabled = true;
+		SignToolBrowseButton.IsEnabled = true;
+		CertFilePathTextBox.IsEnabled = true;
+		XMLPolicyFileBrowseButton.IsEnabled = true;
+	}
+
+
+	/// <summary>
+	/// To show the Teaching Tip for the Verify button
+	/// </summary>
+	/// <param name="message"></param>
+	private void ShowTeachingTip(string message)
+	{
+		VerifyButtonTeachingTip.IsOpen = true;
+
+		VerifyButtonTeachingTip.Subtitle = message;
+	}
+
+
+	/// <summary>
+	/// Event handler for the Verify button
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="e"></param>
+	private async void VerifyButton_Click(object sender, RoutedEventArgs e)
+	{
+
+		if (VerificationRunning)
+		{
+			return;
+		}
+
+		bool everythingChecksOut = false;
+
+		VerificationRunning = true;
+
+		try
+		{
+			// Disable UI elements during verification
+			DisableUIElements();
+
+			VerifyButtonContentTextBlock.Text = "Verify";
+
+			VerifyButtonProgressRing.Visibility = Visibility.Visible;
+
+			// Disable the submit button until all checks are done (in case it was enabled)
+			this.IsPrimaryButtonEnabled = false;
+
+			VerifyButtonTeachingTip.IsOpen = false;
+
+			#region Verify the certificate
+
+			if (string.IsNullOrWhiteSpace(CertFilePathTextBox.Text))
+			{
+				ShowTeachingTip("Please select a certificate file.");
+				return;
+			}
+
+			if (!File.Exists(CertFilePathTextBox.Text))
+			{
+				ShowTeachingTip("The selected certificate file path does not exist");
+				return;
+			}
+
+			if (!string.Equals(Path.GetExtension(CertFilePathTextBox.Text), ".cer", StringComparison.OrdinalIgnoreCase))
+			{
+				ShowTeachingTip("You need to select a certificate file path with (.cer) extension.");
+				return;
+			}
+
+			#endregion
+
+
+			#region Verify Certificate Common Name
+
+			if (string.IsNullOrWhiteSpace(CertificateCommonNameAutoSuggestBox.Text))
+			{
+				ShowTeachingTip("Please select a certificate common name from the suggestions.");
+				return;
+			}
+
+			if (!CertCommonNames.Contains(CertificateCommonNameAutoSuggestBox.Text))
+			{
+				ShowTeachingTip("No certificate was found in the Current User personal store with the selected Common Name.");
+				return;
+			}
+
+			#endregion
+
+
+			#region Verify the XML policy path
+
+
+			if (string.IsNullOrWhiteSpace(XMLPolicyFileTextBox.Text))
+			{
+				ShowTeachingTip("Please select the XML policy file of the policy being removed.");
+				return;
+			}
+
+			if (!File.Exists(XMLPolicyFileTextBox.Text))
+			{
+				ShowTeachingTip("The selected XML policy file path does not exist");
+				return;
+			}
+
+			if (!string.Equals(Path.GetExtension(XMLPolicyFileTextBox.Text), ".xml", StringComparison.OrdinalIgnoreCase))
+			{
+				ShowTeachingTip("You need to select a XML file path with (.xml) extension.");
+				return;
+			}
+
+
+			string? possibleDeployedPolicy = null;
+			string policyPathFromUI = XMLPolicyFileTextBox.Text;
+			SiPolicy.SiPolicy? policyObject = null;
+
+			await Task.Run(() =>
+			{
+				// Instantiate the selected XML policy file
+				policyObject = SiPolicy.Management.Initialize(policyPathFromUI);
+
+				// See if the deployed base policy IDs contain the ID of the policy being removed
+				// Only checking among base policies because supplemental policies can be removed normally whether they're signed or not
+				possibleDeployedPolicy = basePolicyIDs.FirstOrDefault(
+				   x => string.Equals($"{{{x}}}", policyObject.PolicyID, StringComparison.OrdinalIgnoreCase));
+			});
+
+			if (possibleDeployedPolicy is null)
+			{
+				ShowTeachingTip("The selected XML policy file is not deployed on the system.");
+				return;
+			}
+
+			if (!string.Equals(policyObject!.PolicyID, $"{{{policyIDBeingRemoved}}}", StringComparison.OrdinalIgnoreCase))
+			{
+				ShowTeachingTip("The selected XML policy file is not the one being removed.");
+				return;
+			}
+
+			if (policyObject.PolicyType is SiPolicy.PolicyType.SupplementalPolicy)
+			{
+				ShowTeachingTip("Supplemental policies can be removed normally without requiring re-signing.");
+				return;
+			}
+
+			#endregion
+
+
+			#region Verify the SignTool
+
+
+			if (!AutoAcquireSignTool.IsOn)
+			{
+
+				if (string.IsNullOrWhiteSpace(SignToolPathTextBox.Text))
+				{
+					ShowTeachingTip("Please select the path to SignTool.exe or enable the auto-acquire option.");
+					return;
+				}
+
+				if (!File.Exists(SignToolPathTextBox.Text))
+				{
+					ShowTeachingTip("SignTool.exe does not exist in the selected path. You can enable the auto-acquire option if you don't have it.");
+					return;
+				}
+
+				if (!string.Equals(Path.GetExtension(SignToolPathTextBox.Text), ".exe", StringComparison.OrdinalIgnoreCase))
+				{
+					ShowTeachingTip("The SignTool path must end with (.exe). You can enable the auto-acquire option if you don't have it.");
+					return;
+				}
+			}
+			else
+			{
+				try
+				{
+					VerifyButtonContentTextBlock.Text = "Downloading SignTool";
+
+					string newSignToolPath;
+
+					// Get the SignTool.exe path
+					newSignToolPath = await Task.Run(() => SignToolHelper.GetSignToolPath());
+
+					// Assign it to the local variable
+					SignToolPath = newSignToolPath;
+
+					// Set it to the UI text box
+					SignToolPathTextBox.Text = newSignToolPath;
+				}
+
+				finally
+				{
+					VerifyButtonContentTextBlock.Text = "Verify";
+				}
+			}
+
+
+			#endregion
+
+
+			// If everything checks out then enable the Primary button for submission
+			this.IsPrimaryButtonEnabled = true;
+
+			everythingChecksOut = true;
+
+			// Set the SignTool.exe path that was verified to be valid to the user configurations
+			_ = UserConfiguration.Set(SignToolCustomPath: SignToolPath);
+		}
+		finally
+		{
+			VerifyButtonProgressRing.Visibility = Visibility.Collapsed;
+
+			// If verification failed then re-enable the UI elements
+			if (!everythingChecksOut)
+			{
+				EnableUIElements();
+			}
+			else
+			{
+				VerifyButtonContentTextBlock.Text = "Verification Successful";
+			}
+
+			VerificationRunning = false;
+		}
+	}
+
+
+	/// <summary>
+	/// Event handler for SignTool.exe browse button
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="e"></param>
+	private void SignToolBrowseButton_Click(object sender, RoutedEventArgs e)
+	{
+		string filter = "Executable file|*.exe";
+
+		string? selectedFiles = FileDialogHelper.ShowFilePickerDialog(filter);
+
+		if (!string.IsNullOrWhiteSpace(selectedFiles))
+		{
+			SignToolPath = selectedFiles;
+			SignToolPathTextBox.Text = selectedFiles;
+		}
+	}
+
+
+	/// <summary>
+	/// Event handler for browse for certificate .cer file button
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="e"></param>
+	private void CertFileBrowseButton_Click(object sender, RoutedEventArgs e)
+	{
+		string filter = "Certificate file|*.cer";
+
+		string? selectedFiles = FileDialogHelper.ShowFilePickerDialog(filter);
+
+		if (!string.IsNullOrWhiteSpace(selectedFiles))
+		{
+			CertificatePath = selectedFiles;
+			CertFilePathTextBox.Text = selectedFiles;
+		}
+	}
+
+
+	/// <summary>
+	/// Event handler for the XML policy file browse button
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="e"></param>
+	private void XMLPolicyFileBrowseButton_Click(object sender, RoutedEventArgs e)
+	{
+		string? selectedFiles = FileDialogHelper.ShowFilePickerDialog(GlobalVars.XMLFilePickerFilter);
+
+		if (!string.IsNullOrWhiteSpace(selectedFiles))
+		{
+			XMLPolicyPath = selectedFiles;
+			XMLPolicyFileTextBox.Text = selectedFiles;
+		}
+	}
+
+
+
+}

--- a/AppControl Manager/Logic/GlobalVars.cs
+++ b/AppControl Manager/Logic/GlobalVars.cs
@@ -40,6 +40,20 @@ internal static class GlobalVars
 	// Handle of the main Window - acquired in the MainWindow.xaml.cs
 	internal static nint hWnd;
 
+	// The filter for the file picker dialog to select XML files
+	internal const string XMLFilePickerFilter = "XML file|*.xml";
+
+	// Name of the special automatic supplemental policy
+	internal const string AppControlManagerSpecialPolicyName = "AppControlManagerSupplementalPolicy";
+
+	// Get the base directory where the app is running
+	internal static readonly string AppControlManagerSpecialPolicyPath = Path.Combine(AppContext.BaseDirectory, "Resources", $"{AppControlManagerSpecialPolicyName}.xml");
+
+	// Get the current OS version
+	internal static readonly Version CurrentOSVersion = Environment.OSVersion.Version;
+
+	internal static readonly Version VersionFor24H2 = new(10, 0, 26100, 0);
+
 	static GlobalVars()
 	{
 		// Ensure the directory exists

--- a/AppControl Manager/Logic/Main/AppControlSimulation.cs
+++ b/AppControl Manager/Logic/Main/AppControlSimulation.cs
@@ -7,11 +7,11 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using AppControlManager.Logging;
+using AppControlManager.XMLOps;
 using Microsoft.UI.Xaml.Controls;
 
 namespace AppControlManager;
@@ -133,12 +133,7 @@ internal static class AppControlSimulation
 
 		#region Region Making Sure No AllowAll Rule Exists
 
-		// Define the regex pattern to match the desired XML element
-		string pattern = @"<Allow ID=""ID_ALLOW_.*"" FriendlyName="".*"" FileName=""\*"".*/>";
-		Regex allowAllRegex = new(pattern, RegexOptions.Compiled);
-
-		// Check if the pattern matches the XML content
-		if (allowAllRegex.IsMatch(xmlContent))
+		if (CheckForAllowAll.Check(xmlFilePath))
 		{
 			Logger.Write($"The supplied XML file '{xmlFilePath}' contains a rule that allows all files.");
 

--- a/AppControl Manager/Logic/Main/BasePolicyCreator.cs
+++ b/AppControl Manager/Logic/Main/BasePolicyCreator.cs
@@ -331,11 +331,8 @@ internal static partial class BasePolicyCreator
 		// Extracted the XML content from the markdown string will saved in this variable
 		string xmlContent;
 
-		// Regex pattern to capture XML content between ```xml and ```
-		string pattern = @"```xml\s*(.*?)\s*```";
-
 		// Extract the XML content with Regex
-		Match match = Regex.Match(msftDriverBlockRulesAsString, pattern, RegexOptions.Singleline);
+		Match match = MyRegex1().Match(msftDriverBlockRulesAsString);
 
 		if (match.Success)
 		{
@@ -556,11 +553,8 @@ internal static partial class BasePolicyCreator
 		// Extracted the XML content from the markdown string will saved in this variable
 		string xmlContent;
 
-		// Regex pattern to capture XML content between ```xml and ```
-		string pattern = @"```xml\s*(.*?)\s*```";
-
 		// Extract the XML content with Regex
-		Match match = Regex.Match(msftUserModeBlockRulesAsString, pattern, RegexOptions.Singleline);
+		Match match = MyRegex1().Match(msftUserModeBlockRulesAsString);
 
 		if (match.Success)
 		{
@@ -718,4 +712,9 @@ internal static partial class BasePolicyCreator
 
 	[GeneratedRegex(@"<VersionEx>(.*?)<\/VersionEx>", RegexOptions.Compiled)]
 	private static partial Regex MyRegex();
+
+	// Regex pattern to capture XML content between ```xml and ```
+	[GeneratedRegex(@"```xml\s*(.*?)\s*```", RegexOptions.Compiled | RegexOptions.Singleline)]
+	private static partial Regex MyRegex1();
+
 }

--- a/AppControl Manager/Logic/SignToolHelper.cs
+++ b/AppControl Manager/Logic/SignToolHelper.cs
@@ -22,13 +22,10 @@ internal static class SignToolHelper
 	/// <exception cref="InvalidOperationException"></exception>
 	internal static void Sign(FileInfo ciPath, FileInfo signToolPathFinal, string certCN)
 	{
-		// Validate inputs
-		ArgumentNullException.ThrowIfNull(ciPath);
-		ArgumentNullException.ThrowIfNull(signToolPathFinal);
-		if (string.IsNullOrEmpty(certCN)) throw new ArgumentException("Certificate Common Name cannot be null or empty.", nameof(certCN));
-
 		// Build the arguments for the process
 		string arguments = $"sign /v /n \"{certCN}\" /p7 . /p7co 1.3.6.1.4.1.311.79.1 /fd certHash \"{ciPath.Name}\"";
+
+		Logger.Write($"Signing {ciPath.FullName}");
 
 		// Set up the process start info
 		ProcessStartInfo startInfo = new()

--- a/AppControl Manager/Logic/SupplementalForSelf.cs
+++ b/AppControl Manager/Logic/SupplementalForSelf.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using AppControlManager.Logging;
+using AppControlManager.SiPolicyIntel;
 
 namespace AppControlManager;
 
@@ -15,14 +16,8 @@ internal static class SupplementalForSelf
 	/// <param name="StagingArea"></param>
 	internal static void Deploy(string StagingArea, string basePolicyID)
 	{
-
-		string policyName = "AppControlManagerSupplementalPolicy";
-
-		// Get the base directory where the app is running
-		string xmlFilePath = Path.Combine(AppContext.BaseDirectory, @"Resources\AppControlManagerSupplementalPolicy.xml");
-
 		// Instantiate the policy
-		CodeIntegrityPolicy codeIntegrityPolicy = new(xmlFilePath, null);
+		CodeIntegrityPolicy codeIntegrityPolicy = new(GlobalVars.AppControlManagerSpecialPolicyPath, null);
 
 		#region Replace the BasePolicyID of the Supplemental Policy and reset its PolicyID which is necessary in order to have more than 1 of these supplemental policies deployed on the system
 
@@ -38,14 +33,14 @@ internal static class SupplementalForSelf
 
 		#endregion
 
-		string savePath = Path.Combine(StagingArea, $"{policyName}.xml");
+		string savePath = Path.Combine(StagingArea, $"{GlobalVars.AppControlManagerSpecialPolicyName}.xml");
 
-		string cipPath = Path.Combine(StagingArea, $"{policyName}.cip");
+		string cipPath = Path.Combine(StagingArea, $"{GlobalVars.AppControlManagerSpecialPolicyName}.cip");
 
 		// Save the XML to the path as XML file
 		codeIntegrityPolicy.XmlDocument.Save(savePath);
 
-		Logger.Write($"Checking the deployment status of '{policyName}' Supplemental policy");
+		Logger.Write($"Checking the deployment status of '{GlobalVars.AppControlManagerSpecialPolicyName}' Supplemental policy");
 
 		// Get all the deployed supplemental policies to see if our policy is among them
 
@@ -53,22 +48,108 @@ internal static class SupplementalForSelf
 
 		List<CiPolicyInfo> CurrentlyDeployedSupplementalPolicyNoFilter = CiToolHelper.GetPolicies(false, false, true);
 
-		List<CiPolicyInfo> CurrentlyDeployedSupplementalPolicy1stFilter = [.. CurrentlyDeployedSupplementalPolicyNoFilter.Where(policy => string.Equals(policy.FriendlyName, policyName, StringComparison.OrdinalIgnoreCase))];
+		List<CiPolicyInfo> CurrentlyDeployedSupplementalPolicy1stFilter = [.. CurrentlyDeployedSupplementalPolicyNoFilter.Where(policy => string.Equals(policy.FriendlyName, GlobalVars.AppControlManagerSpecialPolicyName, StringComparison.OrdinalIgnoreCase))];
 
 		List<CiPolicyInfo> CurrentlyDeployedSupplementalPolicy = [.. CurrentlyDeployedSupplementalPolicy1stFilter.Where(policy => string.Equals(policy.BasePolicyID, trimmedBasePolicyID, StringComparison.OrdinalIgnoreCase))];
 
 		if (CurrentlyDeployedSupplementalPolicy.Count > 0)
 		{
-			Logger.Write($"Supplemental policy named {policyName} is already deployed for the base policy with the BasePolicyID {basePolicyID}, skipping its deployment.");
+			Logger.Write($"Supplemental policy named {GlobalVars.AppControlManagerSpecialPolicyName} is already deployed for the base policy with the BasePolicyID {basePolicyID}, skipping its deployment.");
 		}
 		else
 		{
-			Logger.Write($"Supplemental policy named {policyName} is not deployed for the base policy with the BasePolicyID {basePolicyID}, deploying it now.");
+			Logger.Write($"Supplemental policy named {GlobalVars.AppControlManagerSpecialPolicyName} is not deployed for the base policy with the BasePolicyID {basePolicyID}, deploying it now.");
 
 			PolicyToCIPConverter.Convert(savePath, cipPath);
 
 			CiToolHelper.UpdatePolicy(cipPath);
 		}
+
+	}
+
+
+	/// <summary>
+	/// Signs and Deploys the Supplemental Policy that allows the Application to be allowed to run after deployment
+	/// Each Base policy should have this supplemental policy
+	/// </summary>
+	/// <param name="StagingArea"></param>
+	internal static void DeploySigned(string basePolicyID, string CertPath, string SignToolPath, string CertCN)
+	{
+
+		DirectoryInfo stagingArea = StagingArea.NewStagingArea("SignedSupplementalPolicySpecialDeployment");
+
+		// Instantiate the policy
+		CodeIntegrityPolicy codeIntegrityPolicy = new(GlobalVars.AppControlManagerSpecialPolicyPath, null);
+
+		#region Replace the BasePolicyID of the Supplemental Policy and reset its PolicyID which is necessary in order to have more than 1 of these supplemental policies deployed on the system
+
+		codeIntegrityPolicy.BasePolicyIDNode.InnerText = basePolicyID;
+
+		// Generate a new GUID
+		Guid newRandomGUID = Guid.CreateVersion7();
+
+		// Convert it to string
+		string newRandomGUIDString = $"{{{newRandomGUID.ToString().ToUpperInvariant()}}}";
+
+		codeIntegrityPolicy.PolicyIDNode.InnerText = newRandomGUIDString;
+
+		#endregion
+
+		string savePath = Path.Combine(stagingArea.FullName, $"{GlobalVars.AppControlManagerSpecialPolicyName}.xml");
+
+		// Save the XML to the path as XML file
+		codeIntegrityPolicy.XmlDocument.Save(savePath);
+
+		Logger.Write($"Checking the deployment status of '{GlobalVars.AppControlManagerSpecialPolicyName}' Supplemental policy");
+
+		// Get all the deployed supplemental policies to see if our policy is among them
+
+		string trimmedBasePolicyID = basePolicyID.Trim('{', '}');
+
+		// Get all of the supplemental policies on the system
+		List<CiPolicyInfo> CurrentlyDeployedSupplementalPolicyNoFilter = CiToolHelper.GetPolicies(false, false, true);
+
+		// Filter based on their name
+		List<CiPolicyInfo> CurrentlyDeployedSupplementalPolicy1stFilter = [.. CurrentlyDeployedSupplementalPolicyNoFilter.Where(policy => string.Equals(policy.FriendlyName, GlobalVars.AppControlManagerSpecialPolicyName, StringComparison.OrdinalIgnoreCase))];
+
+		// Only keep unsigned policies that have the same BasePolicyID as the one we are deploying
+		List<CiPolicyInfo> CurrentlyDeployedSupplementalPolicy = [.. CurrentlyDeployedSupplementalPolicy1stFilter.Where(policy => string.Equals(policy.BasePolicyID, trimmedBasePolicyID, StringComparison.OrdinalIgnoreCase) && !policy.IsSignedPolicy)];
+
+		if (CurrentlyDeployedSupplementalPolicy.Count > 0)
+		{
+			foreach (CiPolicyInfo item in CurrentlyDeployedSupplementalPolicy)
+			{
+				Logger.Write($"Removing unsigned Supplemental policy with the ID {item.PolicyID!} and name {item.FriendlyName} because its Signed version will be deployed.");
+				CiToolHelper.RemovePolicy(item.PolicyID!);
+			}
+		}
+
+
+		// Add the certificate's details to the policy
+		_ = AddSigningDetails.Add(savePath, CertPath);
+
+		// Remove the unsigned policy rule option from the policy
+		CiRuleOptions.Set(filePath: savePath, rulesToRemove: [CiRuleOptions.PolicyRuleOptions.EnabledUnsignedSystemIntegrityPolicy]);
+
+		// Define the path for the CIP file
+		string randomString = GUIDGenerator.GenerateUniqueGUID();
+		string xmlFileName = Path.GetFileName(savePath);
+		string CIPFilePath = Path.Combine(stagingArea.FullName, $"{xmlFileName}-{randomString}.cip");
+
+		string CIPp7SignedFilePath = Path.Combine(stagingArea.FullName, $"{xmlFileName}-{randomString}.cip.p7");
+
+		// Convert the XML file to CIP
+		PolicyToCIPConverter.Convert(savePath, CIPFilePath);
+
+		// Sign the CIP
+		SignToolHelper.Sign(new FileInfo(CIPFilePath), new FileInfo(SignToolPath), CertCN);
+
+		// Rename the .p7 signed file to .cip 
+		File.Move(CIPp7SignedFilePath, CIPFilePath, true);
+
+		// Deploy the signed CIP file
+		CiToolHelper.UpdatePolicy(CIPFilePath);
+
 
 	}
 

--- a/AppControl Manager/MainWindow.xaml.cs
+++ b/AppControl Manager/MainWindow.xaml.cs
@@ -1489,9 +1489,8 @@ public sealed partial class MainWindow : Window
 	/// <param name="e"></param>
 	private void SidebarBasePolicyBrowseButton_Click(object sender, RoutedEventArgs e)
 	{
-		string filter = "XML file|*.xml";
 
-		string? selectedFile = FileDialogHelper.ShowFilePickerDialog(filter);
+		string? selectedFile = FileDialogHelper.ShowFilePickerDialog(GlobalVars.XMLFilePickerFilter);
 
 		if (!string.IsNullOrEmpty(selectedFile))
 		{

--- a/AppControl Manager/Pages/AllowNewApps/AllowNewAppsStart.xaml
+++ b/AppControl Manager/Pages/AllowNewApps/AllowNewAppsStart.xaml
@@ -37,7 +37,7 @@
 
             </Grid.Resources>
 
-            <controls:WrapPanel Grid.Row="0" VerticalSpacing="15" HorizontalSpacing="15" Orientation="Vertical" Margin="6,10,6,10">
+            <controls:WrapPanel Grid.Row="0" VerticalSpacing="15" HorizontalSpacing="15" Orientation="Horizontal" Margin="6,5,6,5">
 
                 <TextBlock
 TextWrapping="WrapWholeWords"
@@ -49,9 +49,9 @@ Style="{StaticResource BodyTextBlockStyle}">
 </Span>
                 </TextBlock>
 
-                <HyperlinkButton Content="Guide" NavigateUri="https://github.com/HotCakeX/Harden-Windows-Security/wiki/Allow-New-Apps" />
+                <HyperlinkButton Margin="0,-8,0,8" Content="Guide" NavigateUri="https://github.com/HotCakeX/Harden-Windows-Security/wiki/Allow-New-Apps" />
 
-                <StackPanel Orientation="Horizontal" Spacing="15">
+                <StackPanel Orientation="Horizontal" Spacing="15" Margin="0,-6,0,10">
 
                     <Button x:Name="ResetStepsButton" Click="ResetStepsButton_Click" Style="{StaticResource AccentButtonStyle}" Content="Reset Steps" ToolTipService.ToolTip="Will reset the steps and if the base policy is deployed in Audit mode, will redeploy it in Enforced mode." />
 

--- a/AppControl Manager/Pages/BuildNewCertificate.xaml
+++ b/AppControl Manager/Pages/BuildNewCertificate.xaml
@@ -47,7 +47,7 @@
 
             </Grid.Resources>
 
-            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,10,6,10">
+            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Horizontal" Margin="6,5,6,5">
 
                 <TextBlock
 TextWrapping="WrapWholeWords"
@@ -58,7 +58,7 @@ Style="{StaticResource BodyTextBlockStyle}">
 </Span>
                 </TextBlock>
 
-                <HyperlinkButton Content="Guide" NavigateUri="https://github.com/HotCakeX/Harden-Windows-Security/wiki/Build-New-Certificate" />
+                <HyperlinkButton Margin="0,-6,0,0" Content="Guide" NavigateUri="https://github.com/HotCakeX/Harden-Windows-Security/wiki/Build-New-Certificate" />
 
             </controls:WrapPanel>
 

--- a/AppControl Manager/Pages/ConfigurePolicyRuleOptions.xaml
+++ b/AppControl Manager/Pages/ConfigurePolicyRuleOptions.xaml
@@ -34,7 +34,7 @@
             </Grid.RowDefinitions>
 
 
-            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,10,6,10">
+            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Horizontal" Margin="6,5,6,5">
 
                 <TextBlock
 TextWrapping="WrapWholeWords"
@@ -47,7 +47,7 @@ Style="{StaticResource BodyTextBlockStyle}">
   </Span>
                 </TextBlock>
 
-                <HyperlinkButton Content="Guide" NavigateUri="https://github.com/HotCakeX/Harden-Windows-Security/wiki/Configure-Policy-Rule-Options" />
+                <HyperlinkButton Margin="0,-6,0,0" Content="Guide" NavigateUri="https://github.com/HotCakeX/Harden-Windows-Security/wiki/Configure-Policy-Rule-Options" />
 
             </controls:WrapPanel>
 

--- a/AppControl Manager/Pages/CreatePolicy.xaml.cs
+++ b/AppControl Manager/Pages/CreatePolicy.xaml.cs
@@ -656,6 +656,9 @@ public sealed partial class CreatePolicy : Page
 
 			RecommendedDriverBlockRulesInfoBar.IsClosable = true;
 
+			// Expand the settings card to make the InfoBar visible
+			RecommendedDriverBlockRulesSettings.IsExpanded = true;
+
 			if (errorsOccurred)
 			{
 				RecommendedDriverBlockRulesInfoBar.Severity = InfoBarSeverity.Error;

--- a/AppControl Manager/Pages/CreateSupplementalPolicy.xaml.cs
+++ b/AppControl Manager/Pages/CreateSupplementalPolicy.xaml.cs
@@ -811,7 +811,7 @@ public sealed partial class CreateSupplementalPolicy : Page, Sidebar.IAnimatedIc
 
 				foreach (string certificate in CertificatesBasedCertFilePaths)
 				{
-					//  Create a certificate object from the .cer file
+					// Create a certificate object from the .cer file
 					X509Certificate2 CertObject = X509CertificateLoader.LoadCertificateFromFile(certificate);
 
 					// Create rule for the certificate based on the first element in its chain

--- a/AppControl Manager/Pages/CreateSupplementalPolicy.xaml.cs
+++ b/AppControl Manager/Pages/CreateSupplementalPolicy.xaml.cs
@@ -238,9 +238,8 @@ public sealed partial class CreateSupplementalPolicy : Page, Sidebar.IAnimatedIc
 	/// <param name="e"></param>
 	private void FilesAndFoldersBrowseForBasePolicySettingsCard_Click(object sender, RoutedEventArgs e)
 	{
-		string filter = "XML file|*.xml";
 
-		string? selectedFile = FileDialogHelper.ShowFilePickerDialog(filter);
+		string? selectedFile = FileDialogHelper.ShowFilePickerDialog(GlobalVars.XMLFilePickerFilter);
 
 		if (!string.IsNullOrEmpty(selectedFile))
 		{
@@ -263,9 +262,8 @@ public sealed partial class CreateSupplementalPolicy : Page, Sidebar.IAnimatedIc
 	/// <param name="e"></param>
 	private void FilesAndFoldersBrowseForBasePolicyButton_Click(object sender, RoutedEventArgs e)
 	{
-		string filter = "XML file|*.xml";
 
-		string? selectedFile = FileDialogHelper.ShowFilePickerDialog(filter);
+		string? selectedFile = FileDialogHelper.ShowFilePickerDialog(GlobalVars.XMLFilePickerFilter);
 
 		if (!string.IsNullOrEmpty(selectedFile))
 		{
@@ -699,9 +697,8 @@ public sealed partial class CreateSupplementalPolicy : Page, Sidebar.IAnimatedIc
 
 	private void CertificatesBrowseForBasePolicySettingsCard_Click(object sender, RoutedEventArgs e)
 	{
-		string filter = "XML file|*.xml";
 
-		string? selectedFile = FileDialogHelper.ShowFilePickerDialog(filter);
+		string? selectedFile = FileDialogHelper.ShowFilePickerDialog(GlobalVars.XMLFilePickerFilter);
 
 		if (!string.IsNullOrEmpty(selectedFile))
 		{
@@ -716,9 +713,8 @@ public sealed partial class CreateSupplementalPolicy : Page, Sidebar.IAnimatedIc
 
 	private void CertificatesBrowseForBasePolicyButton_Click(object sender, RoutedEventArgs e)
 	{
-		string filter = "XML file|*.xml";
 
-		string? selectedFile = FileDialogHelper.ShowFilePickerDialog(filter);
+		string? selectedFile = FileDialogHelper.ShowFilePickerDialog(GlobalVars.XMLFilePickerFilter);
 
 		if (!string.IsNullOrEmpty(selectedFile))
 		{

--- a/AppControl Manager/Pages/Deployment.xaml
+++ b/AppControl Manager/Pages/Deployment.xaml
@@ -83,9 +83,9 @@
                 </win:StackPanel.ChildrenTransitions>
 
                 <controls:SettingsCard
-                Description="Browse for unsigned XML policy file(s) to deploy on the system"
+                Description="Browse for XML policy file(s) to deploy unsigned on the system"
                 Header="Select unsigned XML policy file(s)"
-                HeaderIcon="{ui:FontIcon Glyph=&#xE8E5;}" IsClickEnabled="False" IsActionIconVisible="False">
+                HeaderIcon="{ui:FontIcon Glyph=&#xE82D;}" IsClickEnabled="False" IsActionIconVisible="False">
 
                     <controls:WrapPanel HorizontalSpacing="15" VerticalSpacing="15">
 
@@ -147,10 +147,80 @@
 
                 </controls:SettingsCard>
 
+
+
+                <controls:SettingsCard
+            Description="Browse for XML policy file(s) to Sign and deploy on the system"
+            Header="Select signed XML policy file(s)"
+            HeaderIcon="{ui:FontIcon Glyph=&#xEF3F;}" IsClickEnabled="False" IsActionIconVisible="False">
+
+                    <controls:WrapPanel HorizontalSpacing="15" VerticalSpacing="15">
+
+                        <Button x:Name="BrowseForSignedXMLPolicyFilesButton" Click="BrowseForSignedXMLPolicyFilesButton_Click">
+                            <Button.Content>
+                                <controls:WrapPanel Orientation="Horizontal">
+
+                                    <AnimatedIcon x:Name="SignedXMLFilesLightAnimatedIcon" Visibility="Collapsed" Height="20" Margin="0,0,5,0" Width="20">
+                                        <AnimatedIcon.Source>
+                                            <animatedvisuals:Light/>
+                                        </AnimatedIcon.Source>
+                                    </AnimatedIcon>
+
+                                    <TextBlock Text="Browse" />
+
+                                </controls:WrapPanel>
+                            </Button.Content>
+
+                            <Button.Flyout>
+                                <Flyout x:Name="BrowseForSignedXMLPolicyFilesButton_Flyout">
+
+                                    <controls:WrapPanel Orientation="Vertical" HorizontalSpacing="15" VerticalSpacing="15">
+
+                                        <Button Content="Clear" Click="BrowseForSignedXMLPolicyFilesButton_Flyout_Clear_Click" />
+
+                                        <TextBlock Text="View the XML files you selected." TextWrapping="WrapWholeWords" />
+
+                                        <TextBox x:Name="BrowseForSignedXMLPolicyFilesButton_SelectedFilesTextBox"
+                    TextWrapping="Wrap" AcceptsReturn="True" IsSpellCheckEnabled="False"
+                    SelectionHighlightColor="Pink" MinWidth="400" IsReadOnly="True" />
+
+                                    </controls:WrapPanel>
+
+                                </Flyout>
+                            </Button.Flyout>
+
+                        </Button>
+
+                        <Button HorizontalAlignment="Center" x:Name="DeploySignedXMLButton"
+                                HorizontalContentAlignment="Center" Click="DeploySignedXMLButton_Click">
+                            <Button.Content>
+                                <StackPanel Orientation="Horizontal">
+                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Center">
+                                        <FontIcon Glyph="&#xE8B6;" Margin="0,0,8,0" />
+                                        <TextBlock x:Name="DeploySignedXMLButtonContentTextBlock" Text="Deploy"/>
+                                    </StackPanel>
+                                </StackPanel>
+                            </Button.Content>
+
+                        </Button>
+
+                        <TeachingTip x:Name="DeploySignedXMLButtonTeachingTip"
+    Target="{x:Bind DeploySignedXMLButton}"
+    Title="No File was selected"
+    Subtitle="You need to select Signed XML files to deploy first.">
+                        </TeachingTip>
+
+                    </controls:WrapPanel>
+
+                </controls:SettingsCard>
+
+
+
+
                 <controls:SettingsCard 
                     Description="Browse for CIP Binary file(s) to deploy on the system"
                     Header="Select CIP Binary file(s)"
-                    HeaderIcon="{ui:FontIcon Glyph=&#xE8E5;}" IsClickEnabled="False" IsActionIconVisible="False" >
+                    HeaderIcon="{ui:FontIcon Glyph=&#xEF3E;}" IsClickEnabled="False" IsActionIconVisible="False" >
 
                     <controls:WrapPanel HorizontalSpacing="15" VerticalSpacing="15">
 

--- a/AppControl Manager/Pages/Deployment.xaml
+++ b/AppControl Manager/Pages/Deployment.xaml
@@ -10,6 +10,7 @@
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     xmlns:tk7controls="using:CommunityToolkit.WinUI.UI.Controls"
     xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:animatedvisuals="using:AnimatedVisuals"
     mc:Ignorable="d">
 
     <Page.Resources>
@@ -31,7 +32,6 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
@@ -50,72 +50,155 @@
             <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,10,6,10">
 
                 <TextBlock
-TextWrapping="WrapWholeWords"
-Style="{StaticResource BodyTextBlockStyle}">
-
-<Span>
-    Deploy <Bold>unsigned</Bold> <Run Foreground="{ThemeResource SystemAccentColor}">App Control</Run> Policies.
-</Span>
+                    TextWrapping="WrapWholeWords"
+                    Style="{StaticResource BodyTextBlockStyle}">
+                    <Span>
+                        Deploy <Bold>any type </Bold> of <Run Foreground="{ThemeResource SystemAccentColor}">App Control</Run> Policy.
+                    </Span>
                 </TextBlock>
 
                 <HyperlinkButton Content="Guide" NavigateUri="https://github.com/HotCakeX/Harden-Windows-Security/wiki/Deploy-App-Control-Policy" />
 
             </controls:WrapPanel>
 
-            <Button Grid.Row="1" HorizontalAlignment="Center" x:Name="DeployButton"
-                    HorizontalContentAlignment="Center" Margin="15" Click="DeployButton_Click">
-                <Button.Content>
-                    <StackPanel Orientation="Horizontal">
-                        <ProgressRing Visibility="Collapsed" x:Name="ProgressRing" Margin="5,5,15,5" Value="0" IsIndeterminate="True" Minimum="0" Maximum="100"/>
-
-                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Center">
-                            <FontIcon Glyph="&#xE8B6;" Margin="5" />
-                            <TextBlock Text="Deploy" Margin="5"/>
-                        </StackPanel>
-
-                    </StackPanel>
-                </Button.Content>
-            </Button>
-
-            <TeachingTip x:Name="DeployButtonTeachingTip"
-            Target="{x:Bind DeployButton}"
-            Title="No File was selected"
-            Subtitle="You need to select some files to deploy first.">
-            </TeachingTip>
 
             <InfoBar
                 x:Name="StatusInfoBar"
                 IsOpen="False"
                 Visibility="Collapsed"
                 Severity="Informational"
-                Grid.Row="2">
-
+                Grid.Row="1">
+                <InfoBar.Content>
+                    <ProgressBar Margin="0,0,0,15" Visibility="Collapsed" x:Name="MainProgressRing" Value="0" IsIndeterminate="True" Minimum="0" Maximum="100"/>
+                </InfoBar.Content>
             </InfoBar>
 
 
             <StackPanel HorizontalAlignment="Stretch"
-             Spacing="{StaticResource SettingsCardSpacing}" Grid.Row="3" Margin="0,40,0,0">
+             Spacing="{StaticResource SettingsCardSpacing}" Grid.Row="2" Margin="0,40,0,0">
 
                 <win:StackPanel.ChildrenTransitions>
                     <win:EntranceThemeTransition FromVerticalOffset="50" />
                     <win:RepositionThemeTransition IsStaggeringEnabled="False" />
                 </win:StackPanel.ChildrenTransitions>
 
-                <controls:SettingsCard x:Name="BrowseForXMLPolicyFilesSettingsCard"
-                Description="Browse for XML policy file(s) to deploy on the system"
-                Header="Select XML policy file(s)"
-                HeaderIcon="{ui:FontIcon Glyph=&#xE8E5;}" IsClickEnabled="True" IsActionIconVisible="False" Click="BrowseForXMLPolicyFilesSettingsCard_Click">
+                <controls:SettingsCard
+                Description="Browse for unsigned XML policy file(s) to deploy on the system"
+                Header="Select unsigned XML policy file(s)"
+                HeaderIcon="{ui:FontIcon Glyph=&#xE8E5;}" IsClickEnabled="False" IsActionIconVisible="False">
 
-                    <Button Content="Browse" x:Name="BrowseForXMLPolicyFilesButton" Click="BrowseForXMLPolicyFilesButton_Click" />
+                    <controls:WrapPanel HorizontalSpacing="15" VerticalSpacing="15">
+
+                        <Button x:Name="BrowseForXMLPolicyFilesButton" Click="BrowseForXMLPolicyFilesButton_Click">
+                            <Button.Content>
+                                <controls:WrapPanel Orientation="Horizontal">
+
+                                    <AnimatedIcon x:Name="UnsignedXMLFilesLightAnimatedIcon" Height="20" Margin="0,0,5,0" Width="20">
+                                        <AnimatedIcon.Source>
+                                            <animatedvisuals:Light/>
+                                        </AnimatedIcon.Source>
+                                    </AnimatedIcon>
+
+                                    <TextBlock Text="Browse" />
+
+                                </controls:WrapPanel>
+                            </Button.Content>
+
+                            <Button.Flyout>
+                                <Flyout x:Name="BrowseForXMLPolicyFilesButton_Flyout">
+
+                                    <controls:WrapPanel Orientation="Vertical" HorizontalSpacing="15" VerticalSpacing="15">
+
+                                        <Button Content="Clear" Click="BrowseForXMLPolicyFilesButton_Flyout_Clear_Click" />
+
+                                        <TextBlock Text="View the XML files you selected." TextWrapping="WrapWholeWords" />
+
+                                        <TextBox x:Name="BrowseForXMLPolicyFilesButton_SelectedFilesTextBox"
+                                            TextWrapping="Wrap" AcceptsReturn="True" IsSpellCheckEnabled="False"
+                                            SelectionHighlightColor="Pink" MinWidth="400" IsReadOnly="True" />
+
+                                    </controls:WrapPanel>
+
+                                </Flyout>
+                            </Button.Flyout>
+
+                        </Button>
+
+                        <Button HorizontalAlignment="Center" x:Name="DeployUnsignedXMLButton"
+                        HorizontalContentAlignment="Center" Click="DeployUnsignedXMLButton_Click">
+                            <Button.Content>
+                                <StackPanel Orientation="Horizontal">
+                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Center">
+                                        <FontIcon Glyph="&#xE8B6;" Margin="0,0,8,0" />
+                                        <TextBlock Text="Deploy"/>
+                                    </StackPanel>
+                                </StackPanel>
+                            </Button.Content>
+
+                        </Button>
+
+                        <TeachingTip x:Name="DeployUnsignedXMLButtonTeachingTip"
+                            Target="{x:Bind DeployUnsignedXMLButton}"
+                            Title="No File was selected"
+                            Subtitle="You need to select unsigned XML files to deploy first.">
+                        </TeachingTip>
+
+                    </controls:WrapPanel>
 
                 </controls:SettingsCard>
 
-                <controls:SettingsCard x:Name="BrowseForCIPBinaryFilesSettingsCard"
-Description="Browse for CIP Binary file(s) to deploy on the system"
-Header="Select CIP Binary file(s)"
-HeaderIcon="{ui:FontIcon Glyph=&#xE8E5;}" IsClickEnabled="True" IsActionIconVisible="False" Click="BrowseForCIPBinaryFilesSettingsCard_Click" >
+                <controls:SettingsCard 
+                    Description="Browse for CIP Binary file(s) to deploy on the system"
+                    Header="Select CIP Binary file(s)"
+                    HeaderIcon="{ui:FontIcon Glyph=&#xE8E5;}" IsClickEnabled="False" IsActionIconVisible="False" >
 
-                    <Button Content="Browse" x:Name="BrowseForCIPBinaryFilesButton" Click="BrowseForCIPBinaryFilesButton_Click" />
+                    <controls:WrapPanel HorizontalSpacing="15" VerticalSpacing="15">
+
+                        <Button x:Name="BrowseForCIPBinaryFilesButton" Content="Browse" Click="BrowseForCIPBinaryFilesButton_Click">
+
+                            <Button.Flyout>
+                                <Flyout x:Name="BrowseForCIPBinaryFilesButton_Flyout">
+
+                                    <controls:WrapPanel Orientation="Vertical" HorizontalSpacing="15" VerticalSpacing="15">
+
+                                        <Button Content="Clear" Click="BrowseForCIPBinaryFilesButton_Flyout_Clear_Click" />
+
+                                        <TextBlock Text="View the CIP files you selected." TextWrapping="WrapWholeWords" />
+
+                                        <TextBox x:Name="BrowseForCIPBinaryFilesButton_SelectedFilesTextBox"
+                                            TextWrapping="Wrap" AcceptsReturn="True" IsSpellCheckEnabled="False"
+                                            SelectionHighlightColor="Pink" MinWidth="400" IsReadOnly="True" />
+
+                                    </controls:WrapPanel>
+
+                                </Flyout>
+                            </Button.Flyout>
+
+                        </Button>
+
+
+                        <Button HorizontalAlignment="Center" x:Name="DeployCIPButton"
+                            HorizontalContentAlignment="Center" Click="DeployCIPButton_Click">
+                            <Button.Content>
+                                <StackPanel Orientation="Horizontal">
+
+                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Center">
+                                        <FontIcon Glyph="&#xE8B6;" Margin="0,0,8,0" />
+                                        <TextBlock Text="Deploy"/>
+                                    </StackPanel>
+
+                                </StackPanel>
+                            </Button.Content>
+
+                        </Button>
+
+                        <TeachingTip x:Name="DeployCIPButtonTeachingTip"
+                            Target="{x:Bind DeployCIPButton}"
+                            Title="No File was selected"
+                            Subtitle="You need to select CIP files to deploy first.">
+                        </TeachingTip>
+
+                    </controls:WrapPanel>
 
                 </controls:SettingsCard>
 

--- a/AppControl Manager/Pages/Deployment.xaml.cs
+++ b/AppControl Manager/Pages/Deployment.xaml.cs
@@ -10,12 +10,11 @@ using Microsoft.UI.Xaml.Navigation;
 
 namespace AppControlManager.Pages;
 
-
-public sealed partial class Deployment : Page
+public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 {
-	// Lists to store user input selected files
-	private readonly List<string> XMLFiles = [];
-	private readonly List<string> CIPFiles = [];
+	// HashSets to store user input selected files
+	private readonly HashSet<string> XMLFiles = [];
+	private readonly HashSet<string> CIPFiles = [];
 
 	public Deployment()
 	{
@@ -24,36 +23,92 @@ public sealed partial class Deployment : Page
 		this.NavigationCacheMode = NavigationCacheMode.Enabled;
 	}
 
+
+
+	#region Augmentation Interface
+
+	private string? unsignedBasePolicyPathFromSidebar;
+
+	// Implement the SetVisibility method required by IAnimatedIconsManager
+	public void SetVisibility(Visibility visibility, string? unsignedBasePolicyPath, Button button1, Button button2)
+	{
+		// Light up the local page's button icons
+		UnsignedXMLFilesLightAnimatedIcon.Visibility = visibility;
+
+		// Light up the sidebar buttons' icons
+		button1.Visibility = visibility;
+
+		// Set the incoming text which is from sidebar for unsigned policy path to a local private variable
+		unsignedBasePolicyPathFromSidebar = unsignedBasePolicyPath;
+
+		if (visibility is Visibility.Visible)
+		{
+			// Assign sidebar buttons' content texts
+			button1.Content = "Deploy Unsigned Policy";
+
+			// Assign a local event handler to the sidebar button
+			button1.Click += LightUp1;
+			// Save a reference to the event handler we just set for tracking
+			Sidebar.EventHandlersTracking.SidebarUnsignedBasePolicyConnect1EventHandler = LightUp1;
+
+		}
+	}
+
 	/// <summary>
-	/// Deploy button event handler
+	/// Local event handlers that are assigned to the sidebar button
 	/// </summary>
 	/// <param name="sender"></param>
 	/// <param name="e"></param>
-	private async void DeployButton_Click(object sender, RoutedEventArgs e)
+	private void LightUp1(object sender, RoutedEventArgs e)
 	{
-		if (XMLFiles.Count == 0 && CIPFiles.Count == 0)
+
+		if (!string.IsNullOrWhiteSpace(unsignedBasePolicyPathFromSidebar))
 		{
-			DeployButtonTeachingTip.IsOpen = true;
+			if (XMLFiles.Add(unsignedBasePolicyPathFromSidebar))
+			{
+				// Append the new file to the TextBox, followed by a newline
+				BrowseForXMLPolicyFilesButton_SelectedFilesTextBox.Text += unsignedBasePolicyPathFromSidebar + Environment.NewLine;
+			}
+		}
+
+		BrowseForXMLPolicyFilesButton_Flyout.ShowAt(BrowseForXMLPolicyFilesButton);
+	}
+
+	#endregion
+
+
+
+
+	/// <summary>
+	/// Deploy unsigned XML files button
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="e"></param>
+	private async void DeployUnsignedXMLButton_Click(object sender, RoutedEventArgs e)
+	{
+		if (XMLFiles.Count is 0)
+		{
+			DeployUnsignedXMLButtonTeachingTip.IsOpen = true;
 			return;
 		}
+
+		DeployUnsignedXMLButtonTeachingTip.IsOpen = false;
 
 		bool errorsOccurred = false;
 
 		try
 		{
-			DeployButton.IsEnabled = false;
-			BrowseForXMLPolicyFilesSettingsCard.IsEnabled = false;
-			BrowseForCIPBinaryFilesSettingsCard.IsEnabled = false;
-			BrowseForXMLPolicyFilesButton.IsEnabled = false;
-			BrowseForCIPBinaryFilesButton.IsEnabled = false;
+			// Disable all the deployment buttons during main operation
+			DeployUnsignedXMLButton.IsEnabled = false;
+			DeployCIPButton.IsEnabled = false;
 
 			StatusInfoBar.Visibility = Visibility.Visible;
 			StatusInfoBar.IsOpen = true;
-			StatusInfoBar.Message = $"Deploying {XMLFiles.Count} XML files and {CIPFiles.Count} CIP binary files.";
+			StatusInfoBar.Message = $"Deploying {XMLFiles.Count} unsigned XML files.";
 			StatusInfoBar.Severity = InfoBarSeverity.Informational;
 			StatusInfoBar.IsClosable = false;
 
-			ProgressRing.Visibility = Visibility.Visible;
+			MainProgressRing.Visibility = Visibility.Visible;
 
 			// Deploy the selected files
 			await Task.Run(() =>
@@ -62,71 +117,54 @@ public sealed partial class Deployment : Page
 				DirectoryInfo stagingArea = StagingArea.NewStagingArea("Deployments");
 
 				// Convert and then deploy each XML file
-				if (XMLFiles.Count > 0)
+				foreach (string file in XMLFiles)
 				{
-					foreach (string file in XMLFiles)
+
+					// Instantiate the policy
+					CodeIntegrityPolicy codeIntegrityPolicy = new(file, null);
+
+					// Get all of the policy rule option nodes
+					XmlNodeList? policyRuleOptionNodes = codeIntegrityPolicy.SiPolicyNode.SelectNodes("ns:Rules/ns:Rule", codeIntegrityPolicy.NamespaceManager);
+
+					if (policyRuleOptionNodes is not null)
 					{
+
+						List<string> policyRuleOptions = [];
+
+						foreach (XmlNode item in policyRuleOptionNodes)
 						{
-							// Instantiate the policy
-							CodeIntegrityPolicy codeIntegrityPolicy = new(file, null);
+							policyRuleOptions.Add(item.InnerText);
+						}
 
-							// Get all of the policy rule option nodes
-							XmlNodeList? policyRuleOptionNodes = codeIntegrityPolicy.SiPolicyNode.SelectNodes("ns:Rules/ns:Rule", codeIntegrityPolicy.NamespaceManager);
+						bool isUnsigned = policyRuleOptions.Any(p => string.Equals(p, "Enabled:Unsigned System Integrity Policy", StringComparison.OrdinalIgnoreCase));
 
-							if (policyRuleOptionNodes is not null)
-							{
-
-								List<string> policyRuleOptions = [];
-
-								foreach (XmlNode item in policyRuleOptionNodes)
-								{
-									policyRuleOptions.Add(item.InnerText);
-								}
-
-								bool isUnsigned = policyRuleOptions.Any(p => string.Equals(p, "Enabled:Unsigned System Integrity Policy", StringComparison.OrdinalIgnoreCase));
-
-								if (!isUnsigned)
-								{
-									throw new InvalidOperationException($"The XML file '{file}' is a signed policy!");
-								}
-							}
-
-
-							string randomString = SiPolicyIntel.GUIDGenerator.GenerateUniqueGUID();
-
-							string xmlFileName = Path.GetFileName(file);
-
-							string CIPFilePath = Path.Combine(stagingArea.FullName, $"{xmlFileName}-{randomString}.cip");
-
-							_ = DispatcherQueue.TryEnqueue(() =>
-							{
-								StatusInfoBar.Message = $"Currently Deploying XML file: '{file}'";
-							});
-
-							// Convert the XML file to CIP
-							PolicyToCIPConverter.Convert(file, CIPFilePath);
-
-							// Deploy the CIP file
-							CiToolHelper.UpdatePolicy(CIPFilePath);
-
-							// Delete the CIP file after deployment
-							File.Delete(CIPFilePath);
+						if (!isUnsigned)
+						{
+							throw new InvalidOperationException($"The XML file '{file}' is a signed policy, use the signed policy deployment section instead!");
 						}
 					}
 
-					// Deploy each CIP file
-					if (CIPFiles.Count > 0)
-					{
-						foreach (string file in CIPFiles)
-						{
-							_ = DispatcherQueue.TryEnqueue(() =>
-							{
-								StatusInfoBar.Message = $"Currently Deploying CIP file: '{file}'";
-							});
 
-							CiToolHelper.UpdatePolicy(file);
-						}
-					}
+					string randomString = SiPolicyIntel.GUIDGenerator.GenerateUniqueGUID();
+
+					string xmlFileName = Path.GetFileName(file);
+
+					string CIPFilePath = Path.Combine(stagingArea.FullName, $"{xmlFileName}-{randomString}.cip");
+
+					_ = DispatcherQueue.TryEnqueue(() =>
+					{
+						StatusInfoBar.Message = $"Currently Deploying XML file: '{file}'";
+					});
+
+					// Convert the XML file to CIP
+					PolicyToCIPConverter.Convert(file, CIPFilePath);
+
+					// Deploy the CIP file
+					CiToolHelper.UpdatePolicy(CIPFilePath);
+
+					// Delete the CIP file after deployment
+					File.Delete(CIPFilePath);
+
 				}
 			});
 		}
@@ -136,7 +174,7 @@ public sealed partial class Deployment : Page
 			errorsOccurred = true;
 
 			StatusInfoBar.Severity = InfoBarSeverity.Error;
-			StatusInfoBar.Message = "There was an error deploying the selected files";
+			StatusInfoBar.Message = "There was an error deploying the selected XML files";
 
 			throw;
 		}
@@ -145,25 +183,114 @@ public sealed partial class Deployment : Page
 			if (!errorsOccurred)
 			{
 				StatusInfoBar.Severity = InfoBarSeverity.Success;
-				StatusInfoBar.Message = "Successfully deployed all of the selected files";
+				StatusInfoBar.Message = "Successfully deployed all of the selected XML files";
+
+				// Clear the lists at the end if no errors occurred
+				XMLFiles.Clear();
+
+				BrowseForXMLPolicyFilesButton_SelectedFilesTextBox.Text = null;
 			}
 
-			DeployButton.IsEnabled = true;
-			BrowseForXMLPolicyFilesSettingsCard.IsEnabled = true;
-			BrowseForCIPBinaryFilesSettingsCard.IsEnabled = true;
-			BrowseForXMLPolicyFilesButton.IsEnabled = true;
-			BrowseForCIPBinaryFilesButton.IsEnabled = true;
+			// Re-enable all the deploy buttons
+			DeployUnsignedXMLButton.IsEnabled = true;
+			DeployCIPButton.IsEnabled = true;
 
-			ProgressRing.Visibility = Visibility.Collapsed;
+			MainProgressRing.Visibility = Visibility.Collapsed;
 			StatusInfoBar.IsClosable = true;
-
-			// Clear the lists at the end
-			XMLFiles.Clear();
-			CIPFiles.Clear();
-
 		}
 	}
 
+
+
+
+
+
+
+
+	/// <summary>
+	/// Deploy CIP files button
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="e"></param>
+	private async void DeployCIPButton_Click(object sender, RoutedEventArgs e)
+	{
+		if (CIPFiles.Count is 0)
+		{
+			DeployCIPButtonTeachingTip.IsOpen = true;
+			return;
+		}
+
+		DeployCIPButtonTeachingTip.IsOpen = false;
+
+		bool errorsOccurred = false;
+
+		try
+		{
+			DeployUnsignedXMLButton.IsEnabled = false;
+			DeployCIPButton.IsEnabled = false;
+
+			StatusInfoBar.Visibility = Visibility.Visible;
+			StatusInfoBar.IsOpen = true;
+			StatusInfoBar.Message = $"Deploying {CIPFiles.Count} CIP binary files.";
+			StatusInfoBar.Severity = InfoBarSeverity.Informational;
+			StatusInfoBar.IsClosable = false;
+
+			MainProgressRing.Visibility = Visibility.Visible;
+
+			// Deploy the selected CIP files
+			await Task.Run(() =>
+			{
+				foreach (string file in CIPFiles)
+				{
+					_ = DispatcherQueue.TryEnqueue(() =>
+					{
+						StatusInfoBar.Message = $"Currently Deploying CIP file: '{file}'";
+					});
+
+					CiToolHelper.UpdatePolicy(file);
+				}
+			});
+		}
+
+		catch
+		{
+			errorsOccurred = true;
+
+			StatusInfoBar.Severity = InfoBarSeverity.Error;
+			StatusInfoBar.Message = "There was an error deploying the selected CIP files";
+
+			throw;
+		}
+		finally
+		{
+			if (!errorsOccurred)
+			{
+				StatusInfoBar.Severity = InfoBarSeverity.Success;
+				StatusInfoBar.Message = "Successfully deployed all of the selected CIP files";
+
+				// Clear the list at the end if no errors occurred
+				CIPFiles.Clear();
+
+				BrowseForCIPBinaryFilesButton_SelectedFilesTextBox.Text = null;
+			}
+
+			DeployUnsignedXMLButton.IsEnabled = true;
+			DeployCIPButton.IsEnabled = true;
+
+			MainProgressRing.Visibility = Visibility.Collapsed;
+			StatusInfoBar.IsClosable = true;
+		}
+	}
+
+
+
+
+
+	/// <summary>
+	/// Event handler for browse button - Unsigned XML files
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="e"></param>
 	private void BrowseForXMLPolicyFilesButton_Click(object sender, RoutedEventArgs e)
 	{
 		string filter = "XML file|*.xml";
@@ -174,26 +301,21 @@ public sealed partial class Deployment : Page
 		{
 			foreach (string file in selectedFiles)
 			{
-				XMLFiles.Add(file);
+				if (XMLFiles.Add(file))
+				{
+					// Append the new file to the TextBox, followed by a newline
+					BrowseForXMLPolicyFilesButton_SelectedFilesTextBox.Text += file + Environment.NewLine;
+				}
 			}
 		}
 	}
 
-	private void BrowseForXMLPolicyFilesSettingsCard_Click(object sender, RoutedEventArgs e)
-	{
-		string filter = "XML file|*.xml";
 
-		List<string>? selectedFiles = FileDialogHelper.ShowMultipleFilePickerDialog(filter);
-
-		if (selectedFiles is { Count: > 0 })
-		{
-			foreach (string file in selectedFiles)
-			{
-				XMLFiles.Add(file);
-			}
-		}
-	}
-
+	/// <summary>
+	/// Event handler for Browser button - CIP files
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="e"></param>
 	private void BrowseForCIPBinaryFilesButton_Click(object sender, RoutedEventArgs e)
 	{
 		string filter = "CIP file|*.cip";
@@ -204,24 +326,36 @@ public sealed partial class Deployment : Page
 		{
 			foreach (string file in selectedFiles)
 			{
-				CIPFiles.Add(file);
+				if (CIPFiles.Add(file))
+				{
+					// Append the new file to the TextBox, followed by a newline
+					BrowseForCIPBinaryFilesButton_SelectedFilesTextBox.Text += file + Environment.NewLine;
+				}
 			}
 		}
 	}
 
-	private void BrowseForCIPBinaryFilesSettingsCard_Click(object sender, RoutedEventArgs e)
+
+	/// <summary>
+	/// Clear button for the CIP files deployment button flyout
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="e"></param>
+	private void BrowseForCIPBinaryFilesButton_Flyout_Clear_Click(object sender, RoutedEventArgs e)
 	{
-		string filter = "CIP file|*.cip";
-
-		List<string>? selectedFiles = FileDialogHelper.ShowMultipleFilePickerDialog(filter);
-
-		if (selectedFiles is { Count: > 0 })
-		{
-			foreach (string file in selectedFiles)
-			{
-				CIPFiles.Add(file);
-			}
-		}
+		BrowseForCIPBinaryFilesButton_SelectedFilesTextBox.Text = null;
+		CIPFiles.Clear();
 	}
 
+
+	/// <summary>
+	/// Clear button for the unsigned files deployment button flyout
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="e"></param>
+	private void BrowseForXMLPolicyFilesButton_Flyout_Clear_Click(object sender, RoutedEventArgs e)
+	{
+		BrowseForXMLPolicyFilesButton_SelectedFilesTextBox.Text = null;
+		XMLFiles.Clear();
+	}
 }

--- a/AppControl Manager/Pages/Deployment.xaml.cs
+++ b/AppControl Manager/Pages/Deployment.xaml.cs
@@ -3,7 +3,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Xml;
+using AppControlManager.CustomUIElements;
+using AppControlManager.Logging;
+using AppControlManager.SiPolicy;
+using AppControlManager.SiPolicyIntel;
+using AppControlManager.XMLOps;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
@@ -14,6 +18,7 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 {
 	// HashSets to store user input selected files
 	private readonly HashSet<string> XMLFiles = [];
+	private readonly HashSet<string> SignedXMLFiles = [];
 	private readonly HashSet<string> CIPFiles = [];
 
 	public Deployment()
@@ -21,8 +26,13 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 		this.InitializeComponent();
 
 		this.NavigationCacheMode = NavigationCacheMode.Enabled;
-	}
 
+		if (GlobalVars.CurrentOSVersion < GlobalVars.VersionFor24H2)
+		{
+			DeploySignedXMLButton.IsEnabled = false;
+			DeploySignedXMLButtonContentTextBlock.Text = "Requires Windows 11 24H2 or later";
+		};
+	}
 
 
 	#region Augmentation Interface
@@ -34,9 +44,11 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 	{
 		// Light up the local page's button icons
 		UnsignedXMLFilesLightAnimatedIcon.Visibility = visibility;
+		SignedXMLFilesLightAnimatedIcon.Visibility = visibility;
 
 		// Light up the sidebar buttons' icons
 		button1.Visibility = visibility;
+		button2.Visibility = visibility;
 
 		// Set the incoming text which is from sidebar for unsigned policy path to a local private variable
 		unsignedBasePolicyPathFromSidebar = unsignedBasePolicyPath;
@@ -45,12 +57,15 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 		{
 			// Assign sidebar buttons' content texts
 			button1.Content = "Deploy Unsigned Policy";
+			button2.Content = "Deploy Signed Policy";
 
 			// Assign a local event handler to the sidebar button
 			button1.Click += LightUp1;
+			button2.Click += LightUp2;
+
 			// Save a reference to the event handler we just set for tracking
 			Sidebar.EventHandlersTracking.SidebarUnsignedBasePolicyConnect1EventHandler = LightUp1;
-
+			Sidebar.EventHandlersTracking.SidebarUnsignedBasePolicyConnect1EventHandler = LightUp2;
 		}
 	}
 
@@ -72,6 +87,21 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 		}
 
 		BrowseForXMLPolicyFilesButton_Flyout.ShowAt(BrowseForXMLPolicyFilesButton);
+	}
+
+	private void LightUp2(object sender, RoutedEventArgs e)
+	{
+
+		if (!string.IsNullOrWhiteSpace(unsignedBasePolicyPathFromSidebar))
+		{
+			if (SignedXMLFiles.Add(unsignedBasePolicyPathFromSidebar))
+			{
+				// Append the new file to the TextBox, followed by a newline
+				BrowseForSignedXMLPolicyFilesButton_SelectedFilesTextBox.Text += unsignedBasePolicyPathFromSidebar + Environment.NewLine;
+			}
+		}
+
+		BrowseForSignedXMLPolicyFilesButton_Flyout.ShowAt(BrowseForSignedXMLPolicyFilesButton);
 	}
 
 	#endregion
@@ -101,6 +131,7 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 			// Disable all the deployment buttons during main operation
 			DeployUnsignedXMLButton.IsEnabled = false;
 			DeployCIPButton.IsEnabled = false;
+			DeploySignedXMLButton.IsEnabled = false;
 
 			StatusInfoBar.Visibility = Visibility.Visible;
 			StatusInfoBar.IsOpen = true;
@@ -114,38 +145,21 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 			await Task.Run(() =>
 			{
 
-				DirectoryInfo stagingArea = StagingArea.NewStagingArea("Deployments");
+				DirectoryInfo stagingArea = StagingArea.NewStagingArea("UnsignedDeployments");
 
 				// Convert and then deploy each XML file
 				foreach (string file in XMLFiles)
 				{
 
 					// Instantiate the policy
-					CodeIntegrityPolicy codeIntegrityPolicy = new(file, null);
+					SiPolicy.SiPolicy policyObject = Management.Initialize(file);
 
-					// Get all of the policy rule option nodes
-					XmlNodeList? policyRuleOptionNodes = codeIntegrityPolicy.SiPolicyNode.SelectNodes("ns:Rules/ns:Rule", codeIntegrityPolicy.NamespaceManager);
-
-					if (policyRuleOptionNodes is not null)
+					if (policyObject.Rules is null || !policyObject.Rules.Any(rule => rule.Item is OptionType.EnabledUnsignedSystemIntegrityPolicy))
 					{
-
-						List<string> policyRuleOptions = [];
-
-						foreach (XmlNode item in policyRuleOptionNodes)
-						{
-							policyRuleOptions.Add(item.InnerText);
-						}
-
-						bool isUnsigned = policyRuleOptions.Any(p => string.Equals(p, "Enabled:Unsigned System Integrity Policy", StringComparison.OrdinalIgnoreCase));
-
-						if (!isUnsigned)
-						{
-							throw new InvalidOperationException($"The XML file '{file}' is a signed policy, use the signed policy deployment section instead!");
-						}
+						throw new InvalidOperationException($"The XML file '{file}' is a signed policy, use the signed policy deployment section instead!");
 					}
 
-
-					string randomString = SiPolicyIntel.GUIDGenerator.GenerateUniqueGUID();
+					string randomString = GUIDGenerator.GenerateUniqueGUID();
 
 					string xmlFileName = Path.GetFileName(file);
 
@@ -165,6 +179,22 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 					// Delete the CIP file after deployment
 					File.Delete(CIPFilePath);
 
+					// Don't need to deploy it for the recommended block rules since they are only explicit Deny mode policies
+					if (!string.Equals(policyObject.FriendlyName, "Microsoft Windows Recommended User Mode BlockList", StringComparison.OrdinalIgnoreCase))
+					{
+						if (!string.Equals(policyObject.FriendlyName, "Microsoft Windows Driver Policy", StringComparison.OrdinalIgnoreCase))
+						{
+							// Make sure the policy is a base policy and it doesn't have allow all rule
+							if (policyObject.PolicyType is PolicyType.BasePolicy)
+							{
+								if (!CheckForAllowAll.Check(file))
+								{
+									// Deploy the AppControlManager supplemental policy
+									SupplementalForSelf.Deploy(stagingArea.FullName, policyObject.PolicyID);
+								}
+							}
+						}
+					}
 				}
 			});
 		}
@@ -194,6 +224,7 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 			// Re-enable all the deploy buttons
 			DeployUnsignedXMLButton.IsEnabled = true;
 			DeployCIPButton.IsEnabled = true;
+			DeploySignedXMLButton.IsEnabled = true;
 
 			MainProgressRing.Visibility = Visibility.Collapsed;
 			StatusInfoBar.IsClosable = true;
@@ -201,6 +232,175 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 	}
 
 
+
+
+
+	/// <summary>
+	/// Deploy Signed XML files button
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="e"></param>
+	private async void DeploySignedXMLButton_Click(object sender, RoutedEventArgs e)
+	{
+
+		if (SignedXMLFiles.Count is 0)
+		{
+			DeploySignedXMLButtonTeachingTip.IsOpen = true;
+			return;
+		}
+
+		DeploySignedXMLButtonTeachingTip.IsOpen = false;
+
+
+		#region Signing Details acquisition
+
+		string CertCN;
+		string CertPath;
+		string SignToolPath;
+
+		// Instantiate the Content Dialog
+		SigningDetailsDialog customDialog = new();
+
+		// Show the dialog and await its result
+		ContentDialogResult result = await customDialog.ShowAsync();
+
+		// Ensure primary button was selected
+		if (result is ContentDialogResult.Primary)
+		{
+			SignToolPath = customDialog.SignToolPath!;
+			CertPath = customDialog.CertificatePath!;
+			CertCN = customDialog.CertificateCommonName!;
+		}
+		else
+		{
+			return;
+		}
+
+		#endregion
+
+
+		bool errorsOccurred = false;
+
+		try
+		{
+			// Disable all the deployment buttons during main operation
+			DeployUnsignedXMLButton.IsEnabled = false;
+			DeployCIPButton.IsEnabled = false;
+			DeploySignedXMLButton.IsEnabled = false;
+
+			StatusInfoBar.Visibility = Visibility.Visible;
+			StatusInfoBar.IsOpen = true;
+			StatusInfoBar.Message = $"Deploying {SignedXMLFiles.Count} Signed XML files.";
+			StatusInfoBar.Severity = InfoBarSeverity.Informational;
+			StatusInfoBar.IsClosable = false;
+
+			MainProgressRing.Visibility = Visibility.Visible;
+
+			// Deploy the selected files
+			await Task.Run(() =>
+			{
+
+				DirectoryInfo stagingArea = StagingArea.NewStagingArea("SignedDeployments");
+
+				// Convert and then deploy each XML file
+				foreach (string file in SignedXMLFiles)
+				{
+
+					_ = DispatcherQueue.TryEnqueue(() =>
+					{
+						StatusInfoBar.Message = $"Currently Deploying XML file: '{file}'";
+					});
+
+
+					// Add certificate's details to the policy
+					SiPolicy.SiPolicy policyObject = AddSigningDetails.Add(file, CertPath);
+
+					// Remove the unsigned policy rule option from the policy
+					CiRuleOptions.Set(filePath: file, rulesToRemove: [CiRuleOptions.PolicyRuleOptions.EnabledUnsignedSystemIntegrityPolicy]);
+
+					// Define the path for the CIP file
+					string randomString = GUIDGenerator.GenerateUniqueGUID();
+					string xmlFileName = Path.GetFileName(file);
+					string CIPFilePath = Path.Combine(stagingArea.FullName, $"{xmlFileName}-{randomString}.cip");
+
+					string CIPp7SignedFilePath = Path.Combine(stagingArea.FullName, $"{xmlFileName}-{randomString}.cip.p7");
+
+					// Convert the XML file to CIP, overwriting the unsigned one
+					PolicyToCIPConverter.Convert(file, CIPFilePath);
+
+					// Sign the CIP
+					SignToolHelper.Sign(new FileInfo(CIPFilePath), new FileInfo(SignToolPath), CertCN);
+
+					// Rename the .p7 signed file to .cip 
+					File.Move(CIPp7SignedFilePath, CIPFilePath, true);
+
+					// Get all of the deployed base and supplemental policies on the system
+					List<CiPolicyInfo> policies = CiToolHelper.GetPolicies(false, true, true);
+
+					CiPolicyInfo? possibleAlreadyDeployedUnsignedVersion = policies.
+					FirstOrDefault(x => string.Equals(policyObject.PolicyID.Trim('{', '}'), x.PolicyID, StringComparison.OrdinalIgnoreCase));
+
+					if (possibleAlreadyDeployedUnsignedVersion is not null)
+					{
+						Logger.Write($"A policy with the same PolicyID {possibleAlreadyDeployedUnsignedVersion.PolicyID} is already deployed on the system in Unsigned version. Removing it before deployed the signed version to prevent boot failures.");
+
+						CiToolHelper.RemovePolicy(possibleAlreadyDeployedUnsignedVersion.PolicyID!);
+					}
+
+					// Don't need to deploy it for the recommended block rules since they are only explicit Deny mode policies
+					if (!string.Equals(policyObject.FriendlyName, "Microsoft Windows Recommended User Mode BlockList", StringComparison.OrdinalIgnoreCase))
+					{
+						if (!string.Equals(policyObject.FriendlyName, "Microsoft Windows Driver Policy", StringComparison.OrdinalIgnoreCase))
+						{
+							// Make sure the policy is a base policy and it doesn't have allow all rule
+							if (policyObject.PolicyType is PolicyType.BasePolicy)
+							{
+								if (!CheckForAllowAll.Check(file))
+								{
+									// Sign and deploy the required AppControlManager supplemental policy
+									SupplementalForSelf.DeploySigned(policyObject.PolicyID, CertPath, SignToolPath, CertCN);
+								}
+							}
+						}
+					}
+
+					// Deploy the signed CIP file
+					CiToolHelper.UpdatePolicy(CIPFilePath);
+				}
+			});
+		}
+
+		catch
+		{
+			errorsOccurred = true;
+
+			StatusInfoBar.Severity = InfoBarSeverity.Error;
+			StatusInfoBar.Message = "There was an error deploying the selected XML files";
+
+			throw;
+		}
+		finally
+		{
+			if (!errorsOccurred)
+			{
+				StatusInfoBar.Severity = InfoBarSeverity.Success;
+				StatusInfoBar.Message = "Successfully deployed all of the selected XML files as Signed policies";
+
+				// Clear the lists at the end if no errors occurred
+				SignedXMLFiles.Clear();
+
+				BrowseForSignedXMLPolicyFilesButton_SelectedFilesTextBox.Text = null;
+			}
+
+			// Re-enable all the deploy buttons
+			DeployUnsignedXMLButton.IsEnabled = true;
+			DeployCIPButton.IsEnabled = true;
+			DeploySignedXMLButton.IsEnabled = true;
+
+			MainProgressRing.Visibility = Visibility.Collapsed;
+			StatusInfoBar.IsClosable = true;
+		}
+	}
 
 
 
@@ -228,6 +428,7 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 		{
 			DeployUnsignedXMLButton.IsEnabled = false;
 			DeployCIPButton.IsEnabled = false;
+			DeploySignedXMLButton.IsEnabled = false;
 
 			StatusInfoBar.Visibility = Visibility.Visible;
 			StatusInfoBar.IsOpen = true;
@@ -276,6 +477,7 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 
 			DeployUnsignedXMLButton.IsEnabled = true;
 			DeployCIPButton.IsEnabled = true;
+			DeploySignedXMLButton.IsEnabled = true;
 
 			MainProgressRing.Visibility = Visibility.Collapsed;
 			StatusInfoBar.IsClosable = true;
@@ -293,9 +495,8 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 	/// <param name="e"></param>
 	private void BrowseForXMLPolicyFilesButton_Click(object sender, RoutedEventArgs e)
 	{
-		string filter = "XML file|*.xml";
 
-		List<string>? selectedFiles = FileDialogHelper.ShowMultipleFilePickerDialog(filter);
+		List<string>? selectedFiles = FileDialogHelper.ShowMultipleFilePickerDialog(GlobalVars.XMLFilePickerFilter);
 
 		if (selectedFiles is { Count: > 0 })
 		{
@@ -358,4 +559,43 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 		BrowseForXMLPolicyFilesButton_SelectedFilesTextBox.Text = null;
 		XMLFiles.Clear();
 	}
+
+
+	/// <summary>
+	/// Clear button for the Signed files deployment button flyout
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="e"></param>
+	private void BrowseForSignedXMLPolicyFilesButton_Flyout_Clear_Click(object sender, RoutedEventArgs e)
+	{
+		BrowseForSignedXMLPolicyFilesButton_SelectedFilesTextBox.Text = null;
+		SignedXMLFiles.Clear();
+	}
+
+
+	/// <summary>
+	/// Event handler for browse button - Signed XML files
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="e"></param>
+	private void BrowseForSignedXMLPolicyFilesButton_Click(object sender, RoutedEventArgs e)
+	{
+
+		List<string>? selectedFiles = FileDialogHelper.ShowMultipleFilePickerDialog(GlobalVars.XMLFilePickerFilter);
+
+		if (selectedFiles is { Count: > 0 })
+		{
+			foreach (string file in selectedFiles)
+			{
+				if (SignedXMLFiles.Add(file))
+				{
+					// Append the new file to the TextBox, followed by a newline
+					BrowseForSignedXMLPolicyFilesButton_SelectedFilesTextBox.Text += file + Environment.NewLine;
+				}
+			}
+		}
+	}
+
+
+
 }

--- a/AppControl Manager/Pages/EventLogsPolicyCreation.xaml.cs
+++ b/AppControl Manager/Pages/EventLogsPolicyCreation.xaml.cs
@@ -679,9 +679,7 @@ public sealed partial class EventLogsPolicyCreation : Page
 	private void AddToPolicyButton_Click(object sender, RoutedEventArgs e)
 	{
 
-		string filter = "XML file|*.xml";
-
-		string? selectedFile = FileDialogHelper.ShowFilePickerDialog(filter);
+		string? selectedFile = FileDialogHelper.ShowFilePickerDialog(GlobalVars.XMLFilePickerFilter);
 
 		if (!string.IsNullOrEmpty(selectedFile))
 		{
@@ -704,9 +702,7 @@ public sealed partial class EventLogsPolicyCreation : Page
 	private void BasePolicyFileButton_Click(object sender, RoutedEventArgs e)
 	{
 
-		string filter = "XML file|*.xml";
-
-		string? selectedFile = FileDialogHelper.ShowFilePickerDialog(filter);
+		string? selectedFile = FileDialogHelper.ShowFilePickerDialog(GlobalVars.XMLFilePickerFilter);
 
 		if (!string.IsNullOrEmpty(selectedFile))
 		{

--- a/AppControl Manager/Pages/MDEAHPolicyCreation.xaml.cs
+++ b/AppControl Manager/Pages/MDEAHPolicyCreation.xaml.cs
@@ -690,9 +690,7 @@ public sealed partial class MDEAHPolicyCreation : Page
 	private void AddToPolicyButton_Click(object sender, RoutedEventArgs e)
 	{
 
-		string filter = "XML file|*.xml";
-
-		string? selectedFile = FileDialogHelper.ShowFilePickerDialog(filter);
+		string? selectedFile = FileDialogHelper.ShowFilePickerDialog(GlobalVars.XMLFilePickerFilter);
 
 		if (!string.IsNullOrEmpty(selectedFile))
 		{
@@ -715,9 +713,7 @@ public sealed partial class MDEAHPolicyCreation : Page
 	private void BasePolicyFileButton_Click(object sender, RoutedEventArgs e)
 	{
 
-		string filter = "XML file|*.xml";
-
-		string? selectedFile = FileDialogHelper.ShowFilePickerDialog(filter);
+		string? selectedFile = FileDialogHelper.ShowFilePickerDialog(GlobalVars.XMLFilePickerFilter);
 
 		if (!string.IsNullOrEmpty(selectedFile))
 		{

--- a/AppControl Manager/Pages/MergePolicies.xaml.cs
+++ b/AppControl Manager/Pages/MergePolicies.xaml.cs
@@ -123,9 +123,8 @@ public sealed partial class MergePolicies : Page
 
 	private void MainPolicyBrowseButton_Click(object sender, RoutedEventArgs e)
 	{
-		string filter = "XML file|*.xml";
 
-		string? selectedFile = FileDialogHelper.ShowFilePickerDialog(filter);
+		string? selectedFile = FileDialogHelper.ShowFilePickerDialog(GlobalVars.XMLFilePickerFilter);
 
 		if (!string.IsNullOrEmpty(selectedFile))
 		{
@@ -139,9 +138,8 @@ public sealed partial class MergePolicies : Page
 
 	private void MainPolicySettingsCard_Click(object sender, RoutedEventArgs e)
 	{
-		string filter = "XML file|*.xml";
 
-		string? selectedFile = FileDialogHelper.ShowFilePickerDialog(filter);
+		string? selectedFile = FileDialogHelper.ShowFilePickerDialog(GlobalVars.XMLFilePickerFilter);
 
 		if (!string.IsNullOrEmpty(selectedFile))
 		{
@@ -159,9 +157,8 @@ public sealed partial class MergePolicies : Page
 
 	private void OtherPoliciesBrowseButton_Click(object sender, RoutedEventArgs e)
 	{
-		string filter = "XML file|*.xml";
 
-		List<string>? selectedFiles = FileDialogHelper.ShowMultipleFilePickerDialog(filter);
+		List<string>? selectedFiles = FileDialogHelper.ShowMultipleFilePickerDialog(GlobalVars.XMLFilePickerFilter);
 
 		if (selectedFiles is { Count: > 0 })
 		{
@@ -179,9 +176,8 @@ public sealed partial class MergePolicies : Page
 
 	private void OtherPoliciesSettingsCard_Click(object sender, RoutedEventArgs e)
 	{
-		string filter = "XML file|*.xml";
 
-		List<string>? selectedFiles = FileDialogHelper.ShowMultipleFilePickerDialog(filter);
+		List<string>? selectedFiles = FileDialogHelper.ShowMultipleFilePickerDialog(GlobalVars.XMLFilePickerFilter);
 
 		if (selectedFiles is { Count: > 0 })
 		{

--- a/AppControl Manager/Pages/Settings.xaml.cs
+++ b/AppControl Manager/Pages/Settings.xaml.cs
@@ -444,10 +444,10 @@ public sealed partial class Settings : Page
 		switch (fieldName)
 		{
 			case "SignedPolicyPath":
-				SignedPolicyPathTextBox.Text = FileDialogHelper.ShowFilePickerDialog("XML file|*.xml");
+				SignedPolicyPathTextBox.Text = FileDialogHelper.ShowFilePickerDialog(GlobalVars.XMLFilePickerFilter);
 				break;
 			case "UnsignedPolicyPath":
-				UnsignedPolicyPathTextBox.Text = FileDialogHelper.ShowFilePickerDialog("XML file|*.xml");
+				UnsignedPolicyPathTextBox.Text = FileDialogHelper.ShowFilePickerDialog(GlobalVars.XMLFilePickerFilter);
 				break;
 			case "SignToolCustomPath":
 				SignToolCustomPathTextBox.Text = FileDialogHelper.ShowFilePickerDialog("EXE file|*.exe");

--- a/AppControl Manager/Pages/Simulation.xaml.cs
+++ b/AppControl Manager/Pages/Simulation.xaml.cs
@@ -147,9 +147,7 @@ public sealed partial class Simulation : Page
 	private void SelectXmlFileButton_Click(object sender, RoutedEventArgs e)
 	{
 
-		string filter = "XML file|*.xml";
-
-		string? selectedFile = FileDialogHelper.ShowFilePickerDialog(filter);
+		string? selectedFile = FileDialogHelper.ShowFilePickerDialog(GlobalVars.XMLFilePickerFilter);
 
 		if (!string.IsNullOrEmpty(selectedFile))
 		{

--- a/AppControl Manager/Pages/SystemInformation/SystemInformation.xaml
+++ b/AppControl Manager/Pages/SystemInformation/SystemInformation.xaml
@@ -17,7 +17,7 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,10,6,10">
+        <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Horizontal" Margin="5,0,0,5">
 
             <TextBlock
 TextWrapping="WrapWholeWords"
@@ -31,7 +31,7 @@ Style="{StaticResource BodyTextBlockStyle}">
 </Span>
             </TextBlock>
 
-            <HyperlinkButton Content="Guide" NavigateUri="https://github.com/HotCakeX/Harden-Windows-Security/wiki/System-Information" />
+            <HyperlinkButton Margin="0,-6,0,0" Content="Guide" NavigateUri="https://github.com/HotCakeX/Harden-Windows-Security/wiki/System-Information" />
 
         </controls:WrapPanel>
 
@@ -65,7 +65,7 @@ Style="{StaticResource BodyTextBlockStyle}">
             </NavigationView.MenuItems>
 
             <!-- Global margin settings for every page -->
-            <Frame x:Name="ContentFrame" Margin="15,15,15,10"/>
+            <Frame x:Name="ContentFrame" Margin="15,5,15,10"/>
         </NavigationView>
 
     </Grid>

--- a/AppControl Manager/Pages/SystemInformation/ViewCurrentPolicies.xaml
+++ b/AppControl Manager/Pages/SystemInformation/ViewCurrentPolicies.xaml
@@ -31,7 +31,7 @@
             </Style>
         </Grid.Resources>
 
-        <Border Grid.Row="0" Margin="0,0,0,15" Style="{StaticResource GridCardStyle}" Padding="10">
+        <Border Grid.Row="0" Margin="0,0,0,5" Style="{StaticResource GridCardStyle}" Padding="10">
 
             <controls:WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" HorizontalSpacing="12" VerticalSpacing="12">
 
@@ -91,11 +91,11 @@
 
                 <TextBlock Name="PoliciesCountTextBlock" Text="Number of Policies: 0" VerticalAlignment="Center" HorizontalAlignment="Center" ToolTipService.ToolTip="The count of all of the displayed policies"/>
 
-                <Button x:Name="RemoveUnsignedOrSupplementalPolicyButton" Click="RemoveUnsignedOrSupplementalPolicy_Click" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTipService.ToolTip="Unsigned Base policies as well as any Supplemental policy can be removed with this button">
+                <Button x:Name="RemovePolicyButton" Click="RemovePolicy_Click" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTipService.ToolTip="Remove any non-system policy from the system">
                     <Button.Content>
                         <StackPanel Orientation="Horizontal">
                             <FontIcon Glyph="&#xE74D;" />
-                            <TextBlock Text="Remove Unsigned/Supplemental Policy" Margin="5,0,0,0" />
+                            <TextBlock Text="Remove Policy" Margin="5,0,0,0" />
                         </StackPanel>
                     </Button.Content>
                 </Button>

--- a/AppControl Manager/SiPolicy/Merger.Aggregate.cs
+++ b/AppControl Manager/SiPolicy/Merger.Aggregate.cs
@@ -23,8 +23,14 @@ internal static class Factory
 
 			// Index FileRules by their ID for quick lookup
 			// ID will be key and AllowRule itself will be the value
-			Dictionary<string, Allow> fileRuleDictionary = siPolicy.FileRules.OfType<Allow>()
+			Dictionary<string, Allow>? fileRuleDictionary = siPolicy.FileRules?.OfType<Allow>()
 				.ToDictionary(fileRule => fileRule.ID, fileRule => fileRule);
+
+			// Skip if the policy doesn't have <FileRules> node
+			if (fileRuleDictionary is null)
+			{
+				continue;
+			}
 
 			// Find all FileRuleRefs in SigningScenarios and map them to AllowRules
 			foreach (SigningScenario signingScenario in siPolicy.SigningScenarios)
@@ -79,8 +85,14 @@ internal static class Factory
 		{
 			// Index FileRules by their ID for quick lookup
 			// ID will be key and DenyRule itself will be the value
-			Dictionary<string, Deny> fileRuleDictionary = siPolicy.FileRules.OfType<Deny>()
+			Dictionary<string, Deny>? fileRuleDictionary = siPolicy.FileRules?.OfType<Deny>()
 				.ToDictionary(fileRule => fileRule.ID, fileRule => fileRule);
+
+			// Skip if the policy doesn't have <FileRules> node
+			if (fileRuleDictionary is null)
+			{
+				continue;
+			}
 
 			// Find all FileRuleRefs in SigningScenarios and map them to DenyRules
 			foreach (SigningScenario signingScenario in siPolicy.SigningScenarios)
@@ -140,7 +152,7 @@ internal static class Factory
 		{
 
 			// Index elements for efficient lookup
-			Dictionary<string, FileAttrib> fileAttribDictionary = siPolicy.FileRules.OfType<FileAttrib>()
+			Dictionary<string, FileAttrib>? fileAttribDictionary = siPolicy.FileRules?.OfType<FileAttrib>()
 				.ToDictionary(fileAttrib => fileAttrib.ID, fileAttrib => fileAttrib);
 
 			// Get all of the <Signer> elements from the policy
@@ -249,7 +261,7 @@ internal static class Factory
 	AllowedSigner? allowedSigner,
 	DeniedSigner? deniedSigner,
 	HashSet<string> ciSignerSet,
-	Dictionary<string, FileAttrib> fileAttribDictionary,
+	Dictionary<string, FileAttrib>? fileAttribDictionary,
 	HashSet<FilePublisherSignerRule> filePublisherSigners,
 	HashSet<SignerRule> signerRules,
 	HashSet<WHQLPublisher> WHQLPublishers,
@@ -264,7 +276,7 @@ internal static class Factory
 
 		// Gather all associated FileAttribs
 		List<FileAttrib> associatedFileAttribs = signer.FileAttribRef?
-			.Select(fileAttribRef => fileAttribDictionary.GetValueOrDefault(fileAttribRef.RuleID))
+			.Select(fileAttribRef => fileAttribDictionary?.GetValueOrDefault(fileAttribRef.RuleID))
 			.Where(fileAttrib => fileAttrib is not null) // Ensure no nulls
 			.Cast<FileAttrib>()                         // Safe cast to non-nullable type
 			.ToList() ?? [];

--- a/AppControl Manager/SiPolicyIntel/AddSigningDetails.cs
+++ b/AppControl Manager/SiPolicyIntel/AddSigningDetails.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using AppControlManager.SiPolicy;
+
+namespace AppControlManager.SiPolicyIntel;
+
+internal static class AddSigningDetails
+{
+	/// <summary>
+	/// Adds the details of a certificate to an App Control policy in order to prepare it for signing.
+	/// Regardless of how many chains a certificate contains, only the leaf certificate will be used.
+	/// It will also remove the unsigned policy rule option.
+	/// </summary>
+	/// <param name="xmlPolicyFile"></param>
+	/// <param name="certificateFile"></param>
+	internal static SiPolicy.SiPolicy Add(string xmlPolicyFile, string certificateFile)
+	{
+		// Create a certificate object from the .cer file
+		X509Certificate2 CertObject = X509CertificateLoader.LoadCertificateFromFile(certificateFile);
+
+		// Get the TBS of the certificate
+		string CertTBS = CertificateHelper.GetTBSCertificate(CertObject);
+
+		// Get the Common Name of the certificate
+		string CertCommonName = CryptoAPI.GetNameString(CertObject.Handle, CryptoAPI.CERT_NAME_SIMPLE_DISPLAY_TYPE, null, false);
+
+		SiPolicy.SiPolicy policyObject = Management.Initialize(xmlPolicyFile);
+
+		// Create a Cert root object that will be used by signers
+		CertRoot certRoot = new()
+		{
+			Type = CertEnumType.TBS,
+
+			// Parses the hexadecimal string (CertTBS) into a byte array by processing 2 characters at a time
+			Value = [.. Enumerable.Range(0, CertTBS.Length / 2).Select(x => Convert.ToByte(CertTBS.Substring(x * 2, 2), 16))]
+		};
+
+		Signer supplementalPolicySigner = new()
+		{
+			ID = $"ID_SIGNER_S_{GUIDGenerator.GenerateUniqueGUIDToUpper()}",
+			Name = CertCommonName,
+			CertRoot = certRoot
+		};
+
+		Signer updatePolicySigner = new()
+		{
+			ID = $"ID_SIGNER_S_{GUIDGenerator.GenerateUniqueGUIDToUpper()}",
+			Name = CertCommonName,
+			CertRoot = certRoot
+		};
+
+		SupplementalPolicySigner supplementalPolicySigner1 = new()
+		{
+			SignerId = supplementalPolicySigner.ID
+		};
+
+		UpdatePolicySigner updatePolicySigner1 = new()
+		{
+			SignerId = updatePolicySigner.ID
+		};
+
+
+
+
+		// If the policy has <Signers> node
+		if (policyObject.Signers is not null)
+		{
+			// Convert the signers array to list for easy manipulation
+			List<Signer> currentSignersList = [.. policyObject.Signers];
+
+
+			currentSignersList.Add(updatePolicySigner);
+
+			// Only add the SupplementalPolicySigner if the policy is not a SupplementalPolicy
+			// Because only Base policies can have that
+			if (policyObject.PolicyType is not PolicyType.SupplementalPolicy)
+			{
+				currentSignersList.Add(supplementalPolicySigner);
+			}
+
+			// Converting to IEnumerable is required to assign it properly to the Signers nodes
+			IEnumerable<Signer> currentSignersEnumerable = [.. currentSignersList];
+
+			policyObject.Signers = [.. currentSignersEnumerable];
+		}
+		else
+		{
+			IEnumerable<Signer> signersList = policyObject.PolicyType is not PolicyType.SupplementalPolicy ?
+				[updatePolicySigner, supplementalPolicySigner] : [updatePolicySigner];
+
+			policyObject.Signers = [.. signersList];
+		}
+
+
+		if (policyObject.PolicyType is not PolicyType.SupplementalPolicy)
+		{
+			if (policyObject.SupplementalPolicySigners is not null)
+			{
+				List<SupplementalPolicySigner> currentSupplementalPolicySignersList = [.. policyObject.SupplementalPolicySigners];
+				currentSupplementalPolicySignersList.Add(supplementalPolicySigner1);
+				policyObject.SupplementalPolicySigners = [.. currentSupplementalPolicySignersList];
+			}
+			else
+			{
+				policyObject.SupplementalPolicySigners = [supplementalPolicySigner1];
+			}
+		}
+
+
+		if (policyObject.UpdatePolicySigners is not null)
+		{
+			List<UpdatePolicySigner> currentUpdatePolicySignersList = [.. policyObject.UpdatePolicySigners];
+			currentUpdatePolicySignersList.Add(updatePolicySigner1);
+			policyObject.UpdatePolicySigners = [.. currentUpdatePolicySignersList];
+		}
+		else
+		{
+			policyObject.UpdatePolicySigners = [updatePolicySigner1];
+		}
+
+		Management.SavePolicyToFile(policyObject, xmlPolicyFile);
+
+
+		return policyObject;
+	}
+
+}

--- a/AppControl Manager/XMLOps/CheckForAllowAll.cs
+++ b/AppControl Manager/XMLOps/CheckForAllowAll.cs
@@ -1,0 +1,26 @@
+﻿using System.IO;
+using System.Text.RegularExpressions;
+
+namespace AppControlManager.XMLOps;
+
+internal static partial class CheckForAllowAll
+{
+	/// <summary>
+	/// Takes a XML file path and checks whether it has an allow all rule
+	/// </summary>
+	/// <param name="xmlFilePath"></param>
+	/// <returns></returns>
+	internal static bool Check(string xmlFilePath)
+	{
+		// Read the content of the XML file into a string
+		string xmlContent = File.ReadAllText(xmlFilePath);
+
+		Regex allowAllRegex = MyRegex();
+
+		// Check if the pattern matches the XML content
+		return allowAllRegex.IsMatch(xmlContent);
+	}
+
+	[GeneratedRegex(@"<Allow ID=""ID_ALLOW_.*"" FriendlyName="".*"" FileName=""\*"".*/>", RegexOptions.Compiled)]
+	private static partial Regex MyRegex();
+}


### PR DESCRIPTION
* Improved the deployment page by adding flyouts to the browse buttons to display the files you select. The page is also augmented with the [Sidebar](https://github.com/HotCakeX/Harden-Windows-Security/wiki/Sidebar) so it supports quick policy file assignment.

* You can now deploy signed policies in the deployment page.

* [The system information page](https://github.com/HotCakeX/Harden-Windows-Security/wiki/System-Information) now allows the removal of all non-system policies. Whenever you select a policy, it will automatically detect the type of it and will take the appropriate action.

* Many guardrails have been put in place to guide the user during policy signing and signed policy removal in order to prevent accidents or boot failures.

* Reduced the empty spaces at the top of certain pages.

* Made the remaining regex expressions throughout the code source generated and compiled for improved performance.
