### PR TITLE
Improved Merge operation

### DIFF
--- a/AppControl Manager/Pages/MergePolicies.xaml.cs
+++ b/AppControl Manager/Pages/MergePolicies.xaml.cs
@@ -24,6 +24,12 @@ public sealed partial class MergePolicies : Page
 		this.NavigationCacheMode = NavigationCacheMode.Enabled;
 	}
 
+
+	/// <summary>
+	/// Event handler for the main Merge button
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="e"></param>
 	private async void MergeButton_Click(object sender, RoutedEventArgs e)
 	{
 
@@ -52,6 +58,8 @@ public sealed partial class MergePolicies : Page
 
 		try
 		{
+
+			MergeButton.IsEnabled = false;
 
 			PolicyMergerInfoBar.IsOpen = true;
 
@@ -113,6 +121,9 @@ public sealed partial class MergePolicies : Page
 			PolicyMergerInfoBar.IsClosable = true;
 
 			MergeProgressRing.Visibility = Visibility.Collapsed;
+
+
+			MergeButton.IsEnabled = true;
 		}
 	}
 
@@ -132,7 +143,7 @@ public sealed partial class MergePolicies : Page
 			mainPolicy = selectedFile;
 
 			// Add the selected main XML policy file path to the flyout's TextBox
-			MainPolicy_Flyout_TextBox.Text += selectedFile;
+			MainPolicy_Flyout_TextBox.Text = selectedFile;
 		}
 	}
 
@@ -147,7 +158,7 @@ public sealed partial class MergePolicies : Page
 			mainPolicy = selectedFile;
 
 			// Add the selected main XML policy file path to the flyout's TextBox
-			MainPolicy_Flyout_TextBox.Text += selectedFile;
+			MainPolicy_Flyout_TextBox.Text = selectedFile;
 		}
 
 		// Manually display the Flyout since user clicked/tapped on the Settings card and not the button itself

--- a/AppControl Manager/SiPolicy/Merger.cs
+++ b/AppControl Manager/SiPolicy/Merger.cs
@@ -87,7 +87,9 @@ internal static partial class Merger
 		IEnumerable<Signer> signers = signerCollection.FilePublisherSigners.Select(x => x.SignerElement).
 			Concat(signerCollection.WHQLFilePublishers.Select(x => x.SignerElement)).
 			Concat(signerCollection.WHQLPublishers.Select(x => x.SignerElement)).
-			Concat(signerCollection.SignerRules.Select(x => x.SignerElement));
+			Concat(signerCollection.SignerRules.Select(x => x.SignerElement)).
+			Concat(signerCollection.SupplementalPolicySigners.Select(x => x.SignerElement)).
+			Concat(signerCollection.UpdatePolicySigners.Select(x => x.SignerElement));
 
 		// Get all CiSigners
 		IEnumerable<CiSigner> ciSigners = signerCollection.WHQLPublishers.Where(x => x.SigningScenario is SSType.UserMode).Select(x => x.CiSignerElement!).
@@ -128,6 +130,11 @@ internal static partial class Merger
 			Concat(signerCollection.WHQLFilePublishers.Where(x => x.SigningScenario is SSType.KernelMode && x.Auth is Authorization.Deny).Select(x => x.DeniedSignerElement)).
 			Concat(signerCollection.SignerRules.Where(x => x.SigningScenario is SSType.KernelMode && x.Auth is Authorization.Deny).Select(x => x.DeniedSignerElement)).
 			Concat(signerCollection.FilePublisherSigners.Where(x => x.SigningScenario is SSType.KernelMode && x.Auth is Authorization.Deny).Select(x => x.DeniedSignerElement))!;
+
+
+		IEnumerable<SupplementalPolicySigner> supplementalPolicySignersCol = signerCollection.SupplementalPolicySigners.Where(x => x is not null).Select(x => x.SupplementalPolicySigner);
+
+		IEnumerable<UpdatePolicySigner> updatePolicySignersCol = signerCollection.UpdatePolicySigners.Where(x => x is not null).Select(x => x.UpdatePolicySigner);
 
 
 		// Construct the User Mode Signing Scenario
@@ -207,27 +214,27 @@ internal static partial class Merger
 		// Create the final policy data, it will replace the content in the main XML file
 		SiPolicy output = new()
 		{
-			VersionEx = mainXML.VersionEx,  // Main policy takes priority
-			PolicyTypeID = mainXML.PolicyTypeID,  // Main policy takes priority
-			PlatformID = mainXML.PlatformID,  // Main policy takes priority
-			PolicyID = mainXML.PolicyID,  // Main policy takes priority
-			BasePolicyID = mainXML.BasePolicyID,  // Main policy takes priority
-			Rules = mainXML.Rules,  // Main policy takes priority
+			VersionEx = mainXML.VersionEx, // Main policy takes priority
+			PolicyTypeID = mainXML.PolicyTypeID, // Main policy takes priority
+			PlatformID = mainXML.PlatformID, // Main policy takes priority
+			PolicyID = mainXML.PolicyID, // Main policy takes priority
+			BasePolicyID = mainXML.BasePolicyID, // Main policy takes priority
+			Rules = mainXML.Rules, // Main policy takes priority
 			EKUs = [.. ekusToUse], // Aggregated data
 			FileRules = [.. fileRules], // Aggregated data
-			Signers = [.. signers],  // Aggregated data
+			Signers = [.. signers], // Aggregated data
 			SigningScenarios = [UMCISigningScenario, KMCISigningScenario], // Aggregated data
-			UpdatePolicySigners = mainXML.UpdatePolicySigners,  // Main policy takes priority
+			UpdatePolicySigners = [.. updatePolicySignersCol], // Aggregated data
 			CiSigners = [.. ciSigners], // Aggregated data
 			HvciOptions = 2, // Set to the secure state
 			HvciOptionsSpecified = true, // Set to the secure state
-			Settings = mainXML.Settings,  // Main policy takes priority
-			Macros = mainXML.Macros,  // Main policy takes priority
-			SupplementalPolicySigners = mainXML.SupplementalPolicySigners,  // Main policy takes priority
-			AppSettings = mainXML.AppSettings,  // Main policy takes priority
-			FriendlyName = mainXML.FriendlyName,  // Main policy takes priority
-			PolicyType = mainXML.PolicyType,  // Main policy takes priority
-			PolicyTypeSpecified = mainXML.PolicyTypeSpecified  // Main policy takes priority
+			Settings = mainXML.Settings, // Main policy takes priority
+			Macros = mainXML.Macros, // Main policy takes priority
+			SupplementalPolicySigners = [.. supplementalPolicySignersCol], // Aggregated data
+			AppSettings = mainXML.AppSettings, // Main policy takes priority
+			FriendlyName = mainXML.FriendlyName, // Main policy takes priority
+			PolicyType = mainXML.PolicyType, // Main policy takes priority
+			PolicyTypeSpecified = mainXML.PolicyTypeSpecified // Main policy takes priority
 		};
 
 

--- a/AppControl Manager/SiPolicyIntel/AllowRuleComparer.cs
+++ b/AppControl Manager/SiPolicyIntel/AllowRuleComparer.cs
@@ -13,6 +13,12 @@ internal sealed class AllowRuleComparer : IEqualityComparer<AllowRule>
 			return false;
 		}
 
+		// Check SSType
+		if (x.SigningScenario != y.SigningScenario)
+		{
+			return false;
+		}
+
 		Allow allowX = x.AllowElement;
 		Allow allowY = y.AllowElement;
 
@@ -34,6 +40,12 @@ internal sealed class AllowRuleComparer : IEqualityComparer<AllowRule>
 		if (!string.IsNullOrWhiteSpace(allowX.FilePath) &&
 			!string.IsNullOrWhiteSpace(allowY.FilePath) &&
 			string.Equals(allowX.FilePath, allowY.FilePath, StringComparison.OrdinalIgnoreCase))
+		{
+			return true;
+		}
+
+		// Rule special case: Check if FileName is "*" in both and are equal
+		if (string.Equals(allowX.FileName, "*", StringComparison.OrdinalIgnoreCase) && string.Equals(allowY.FileName, "*", StringComparison.OrdinalIgnoreCase))
 		{
 			return true;
 		}

--- a/AppControl Manager/SiPolicyIntel/DenyRuleComparer.cs
+++ b/AppControl Manager/SiPolicyIntel/DenyRuleComparer.cs
@@ -13,6 +13,12 @@ internal sealed class DenyRuleComparer : IEqualityComparer<DenyRule>
 			return false;
 		}
 
+		// Check SSType
+		if (x.SigningScenario != y.SigningScenario)
+		{
+			return false;
+		}
+
 		Deny denyX = x.DenyElement;
 		Deny denyY = y.DenyElement;
 
@@ -34,6 +40,12 @@ internal sealed class DenyRuleComparer : IEqualityComparer<DenyRule>
 		if (!string.IsNullOrWhiteSpace(denyX.FilePath) &&
 			!string.IsNullOrWhiteSpace(denyY.FilePath) &&
 			string.Equals(denyX.FilePath, denyY.FilePath, StringComparison.OrdinalIgnoreCase))
+		{
+			return true;
+		}
+
+		// Rule special case: Check if FileName is "*" in both and are equal
+		if (string.Equals(denyX.FileName, "*", StringComparison.OrdinalIgnoreCase) && string.Equals(denyX.FileName, "*", StringComparison.OrdinalIgnoreCase))
 		{
 			return true;
 		}

--- a/AppControl Manager/SiPolicyIntel/SignerCollection.cs
+++ b/AppControl Manager/SiPolicyIntel/SignerCollection.cs
@@ -11,4 +11,6 @@ internal sealed class SignerCollection
 	internal required HashSet<SignerRule> SignerRules { get; set; }
 	internal required HashSet<WHQLPublisher> WHQLPublishers { get; set; }
 	internal required HashSet<WHQLFilePublisher> WHQLFilePublishers { get; set; }
+	internal required HashSet<UpdatePolicySignerRule> UpdatePolicySigners { get; set; }
+	internal required HashSet<SupplementalPolicySignerRule> SupplementalPolicySigners { get; set; }
 }

--- a/AppControl Manager/SiPolicyIntel/SupplementalPolicySignerRule.cs
+++ b/AppControl Manager/SiPolicyIntel/SupplementalPolicySignerRule.cs
@@ -1,0 +1,9 @@
+﻿using AppControlManager.SiPolicy;
+
+namespace AppControlManager.SiPolicyIntel;
+
+internal sealed class SupplementalPolicySignerRule
+{
+	internal required Signer SignerElement { get; set; }
+	internal required SupplementalPolicySigner SupplementalPolicySigner { get; set; }
+}

--- a/AppControl Manager/SiPolicyIntel/SupplementalPolicySignerRuleComparer.cs
+++ b/AppControl Manager/SiPolicyIntel/SupplementalPolicySignerRuleComparer.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using AppControlManager.SiPolicy;
+
+namespace AppControlManager.SiPolicyIntel;
+
+/// <summary>
+/// Provides comparison logic for SupplementalPolicySignerRule objects based on their SignerElement.
+/// This comparer supports two matching rules to determine equality.
+/// </summary>
+internal sealed class SupplementalPolicySignerRuleComparer : IEqualityComparer<SupplementalPolicySignerRule>
+{
+	/// <summary>
+	/// Determines whether two SupplementalPolicySignerRule objects are equal based on their SignerElement.
+	/// </summary>
+	/// <param name="x">First SupplementalPolicySignerRule object.</param>
+	/// <param name="y">Second SupplementalPolicySignerRule object.</param>
+	/// <returns>True if the objects are considered equal, otherwise false.</returns>
+	public bool Equals(SupplementalPolicySignerRule? x, SupplementalPolicySignerRule? y)
+	{
+		// Null checks
+		if (x is null || y is null)
+		{
+			return false;
+		}
+
+		// Extract signer elements for comparison
+		Signer signerX = x.SignerElement;
+		Signer signerY = y.SignerElement;
+
+		// Rule 1: Check if Name, CertRoot.Value, and CertPublisher.Value are equal
+		if (IsSignerRule1Match(signerX, signerY))
+		{
+			return true;
+		}
+
+		// Rule 2: Check if Name and CertRoot.Value are equal
+		if (IsSignerRule2Match(signerX, signerY))
+		{
+			return true;
+		}
+
+		// If none of the rules match, return false
+		return false;
+	}
+
+	/// <summary>
+	/// Generates a hash code for a SupplementalPolicySignerRule based on its SignerElement.
+	/// </summary>
+	/// <param name="obj">The SupplementalPolicySignerRule object.</param>
+	/// <returns>A hash code for the object.</returns>
+	public int GetHashCode(SupplementalPolicySignerRule obj)
+	{
+		ArgumentNullException.ThrowIfNull(obj);
+
+		Signer signer = obj.SignerElement;
+		long hash = 17;  // Initial hash value
+		const long modulus = 0x7FFFFFFF; // Maximum positive integer
+
+		// Include Name in hash calculation if present
+		if (!string.IsNullOrWhiteSpace(signer.Name))
+		{
+			hash = (hash * 31 + signer.Name.GetHashCode(StringComparison.OrdinalIgnoreCase)) % modulus;
+		}
+
+		// Include CertRoot.Value in hash calculation if present
+		if (signer.CertRoot?.Value != null)
+		{
+			hash = (hash * 31 + CustomMethods.GetByteArrayHashCode(signer.CertRoot.Value)) % modulus;
+		}
+
+		// Include CertPublisher.Value in hash calculation if present
+		if (!string.IsNullOrWhiteSpace(signer.CertPublisher?.Value))
+		{
+			hash = (hash * 31 + signer.CertPublisher.Value.GetHashCode(StringComparison.OrdinalIgnoreCase)) % modulus;
+		}
+
+		return (int)(hash & 0x7FFFFFFF); // Ensure non-negative hash
+	}
+
+	/// <summary>
+	/// Rule 1: Name, CertRoot.Value, and CertPublisher.Value must match.
+	/// </summary>
+	private static bool IsSignerRule1Match(Signer signerX, Signer signerY)
+	{
+		return !string.IsNullOrWhiteSpace(signerX.Name) &&
+			   !string.IsNullOrWhiteSpace(signerY.Name) &&
+			   string.Equals(signerX.Name, signerY.Name, StringComparison.OrdinalIgnoreCase) &&
+			   BytesArrayComparer.AreByteArraysEqual(signerX.CertRoot?.Value, signerY.CertRoot?.Value) &&
+			   string.Equals(signerX.CertPublisher?.Value, signerY.CertPublisher?.Value, StringComparison.OrdinalIgnoreCase);
+	}
+
+	/// <summary>
+	/// Rule 2: Name and CertRoot.Value must match.
+	/// </summary>
+	private static bool IsSignerRule2Match(Signer signerX, Signer signerY)
+	{
+		return !string.IsNullOrWhiteSpace(signerX.Name) &&
+			   !string.IsNullOrWhiteSpace(signerY.Name) &&
+			   string.Equals(signerX.Name, signerY.Name, StringComparison.OrdinalIgnoreCase) &&
+			   BytesArrayComparer.AreByteArraysEqual(signerX.CertRoot?.Value, signerY.CertRoot?.Value);
+	}
+}

--- a/AppControl Manager/SiPolicyIntel/UpdatePolicySignerRule.cs
+++ b/AppControl Manager/SiPolicyIntel/UpdatePolicySignerRule.cs
@@ -1,0 +1,9 @@
+﻿using AppControlManager.SiPolicy;
+
+namespace AppControlManager.SiPolicyIntel;
+
+internal sealed class UpdatePolicySignerRule
+{
+	internal required Signer SignerElement { get; set; }
+	internal required UpdatePolicySigner UpdatePolicySigner { get; set; }
+}

--- a/AppControl Manager/SiPolicyIntel/UpdatePolicySignerRuleComparer.cs
+++ b/AppControl Manager/SiPolicyIntel/UpdatePolicySignerRuleComparer.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using AppControlManager.SiPolicy;
+
+namespace AppControlManager.SiPolicyIntel;
+
+/// <summary>
+/// Provides comparison logic for UpdatePolicySignerRule objects based on their SignerElement.
+/// This comparer supports two matching rules to determine equality.
+/// </summary>
+internal sealed class UpdatePolicySignerRuleComparer : IEqualityComparer<UpdatePolicySignerRule>
+{
+	/// <summary>
+	/// Determines whether two UpdatePolicySignerRule objects are equal based on their SignerElement.
+	/// </summary>
+	/// <param name="x">First UpdatePolicySignerRule object.</param>
+	/// <param name="y">Second UpdatePolicySignerRule object.</param>
+	/// <returns>True if the objects are considered equal, otherwise false.</returns>
+	public bool Equals(UpdatePolicySignerRule? x, UpdatePolicySignerRule? y)
+	{
+		// Null checks
+		if (x is null || y is null)
+		{
+			return false;
+		}
+
+		// Extract signer elements for comparison
+		Signer signerX = x.SignerElement;
+		Signer signerY = y.SignerElement;
+
+		// Rule 1: Check if Name, CertRoot.Value, and CertPublisher.Value are equal
+		if (IsSignerRule1Match(signerX, signerY))
+		{
+			return true;
+		}
+
+		// Rule 2: Check if Name and CertRoot.Value are equal
+		if (IsSignerRule2Match(signerX, signerY))
+		{
+			return true;
+		}
+
+		// If none of the rules match, return false
+		return false;
+	}
+
+	/// <summary>
+	/// Generates a hash code for an UpdatePolicySignerRule based on its SignerElement.
+	/// </summary>
+	/// <param name="obj">The UpdatePolicySignerRule object.</param>
+	/// <returns>A hash code for the object.</returns>
+	public int GetHashCode(UpdatePolicySignerRule obj)
+	{
+		ArgumentNullException.ThrowIfNull(obj);
+
+		Signer signer = obj.SignerElement;
+		long hash = 17;  // Initial hash value
+		const long modulus = 0x7FFFFFFF; // Maximum positive integer
+
+		// Include Name in hash calculation if present
+		if (!string.IsNullOrWhiteSpace(signer.Name))
+		{
+			hash = (hash * 31 + signer.Name.GetHashCode(StringComparison.OrdinalIgnoreCase)) % modulus;
+		}
+
+		// Include CertRoot.Value in hash calculation if present
+		if (signer.CertRoot?.Value != null)
+		{
+			hash = (hash * 31 + CustomMethods.GetByteArrayHashCode(signer.CertRoot.Value)) % modulus;
+		}
+
+		// Include CertPublisher.Value in hash calculation if present
+		if (!string.IsNullOrWhiteSpace(signer.CertPublisher?.Value))
+		{
+			hash = (hash * 31 + signer.CertPublisher.Value.GetHashCode(StringComparison.OrdinalIgnoreCase)) % modulus;
+		}
+
+		return (int)(hash & 0x7FFFFFFF); // Ensure non-negative hash
+	}
+
+	/// <summary>
+	/// Rule 1: Name, CertRoot.Value, and CertPublisher.Value must match.
+	/// </summary>
+	private static bool IsSignerRule1Match(Signer signerX, Signer signerY)
+	{
+		return !string.IsNullOrWhiteSpace(signerX.Name) &&
+			   !string.IsNullOrWhiteSpace(signerY.Name) &&
+			   string.Equals(signerX.Name, signerY.Name, StringComparison.OrdinalIgnoreCase) &&
+			   BytesArrayComparer.AreByteArraysEqual(signerX.CertRoot?.Value, signerY.CertRoot?.Value) &&
+			   string.Equals(signerX.CertPublisher?.Value, signerY.CertPublisher?.Value, StringComparison.OrdinalIgnoreCase);
+	}
+
+	/// <summary>
+	/// Rule 2: Name and CertRoot.Value must match.
+	/// </summary>
+	private static bool IsSignerRule2Match(Signer signerX, Signer signerY)
+	{
+		return !string.IsNullOrWhiteSpace(signerX.Name) &&
+			   !string.IsNullOrWhiteSpace(signerY.Name) &&
+			   string.Equals(signerX.Name, signerY.Name, StringComparison.OrdinalIgnoreCase) &&
+			   BytesArrayComparer.AreByteArraysEqual(signerX.CertRoot?.Value, signerY.CertRoot?.Value);
+	}
+}

--- a/AppControl Manager/SiPolicyIntel/WHQLPublisherSignerRuleComparer.cs
+++ b/AppControl Manager/SiPolicyIntel/WHQLPublisherSignerRuleComparer.cs
@@ -31,7 +31,7 @@ internal sealed class WHQLPublisherSignerRuleComparer : IEqualityComparer<WHQLPu
 		// Rule 1: Check if Name, CertRoot.Value, and CertPublisher.Value are equal
 		// And CertEKUs match
 		// For intermediate certificate type that uses full proper chain in signer
-		if (IsSignerRule1Match(signerX, signerY) && DoCertEKUsMatch(signerX, signerY))
+		if (IsSignerRule1Match(signerX, signerY) && DoEKUsMatch(x.Ekus, y.Ekus))
 		{
 			return true;
 		}
@@ -39,7 +39,7 @@ internal sealed class WHQLPublisherSignerRuleComparer : IEqualityComparer<WHQLPu
 		// Rule 2: Check if Name and CertRoot.Value are equal
 		// And CertEKUs match
 		// For WHQL but PCA/Root/Leaf certificate signer types
-		if (IsSignerRule2Match(signerX, signerY) && DoCertEKUsMatch(signerX, signerY))
+		if (IsSignerRule2Match(signerX, signerY) && DoEKUsMatch(x.Ekus, y.Ekus))
 		{
 			return true;
 		}
@@ -49,6 +49,9 @@ internal sealed class WHQLPublisherSignerRuleComparer : IEqualityComparer<WHQLPu
 		return false;
 	}
 
+	/// <summary>
+	/// Generates a hash code for a WHQLPublisher object.
+	/// </summary>
 	public int GetHashCode(WHQLPublisher obj)
 	{
 		ArgumentNullException.ThrowIfNull(obj);
@@ -89,25 +92,23 @@ internal sealed class WHQLPublisherSignerRuleComparer : IEqualityComparer<WHQLPu
 			hash = (hash * 31 + CustomMethods.GetByteArrayHashCode(signer.CertRoot.Value)) % modulus;
 		}
 
-		// Rule 3: Include CertEKU IDs in the hash
-		foreach (CertEKU certEKU in signer.CertEKU ?? [])
+
+		// Rule 3: Include EKU Values
+		foreach (EKU eku in obj.Ekus)
 		{
-			if (!string.IsNullOrWhiteSpace(certEKU.ID))
+			if (eku.Value != null)
 			{
-				hash = (hash * 31 + certEKU.ID.GetHashCode(StringComparison.OrdinalIgnoreCase)) % modulus;
+				hash = (hash * 31 + CustomMethods.GetByteArrayHashCode(eku.Value)) % modulus;
 			}
 		}
 
-		return (int)(hash & 0x7FFFFFFF); // Ensure non-negative hash value
+		// Ensure non-negative hash value
+		return (int)(hash & 0x7FFFFFFF);
 	}
-
 
 	/// <summary>
 	/// Rule 1: Name, CertRoot.Value, CertPublisher.Value must match
 	/// </summary>
-	/// <param name="signerX"></param>
-	/// <param name="signerY"></param>
-	/// <returns></returns>
 	private static bool IsSignerRule1Match(Signer signerX, Signer signerY)
 	{
 		return !string.IsNullOrWhiteSpace(signerX.Name) &&
@@ -121,9 +122,6 @@ internal sealed class WHQLPublisherSignerRuleComparer : IEqualityComparer<WHQLPu
 	/// <summary>
 	/// Rule 2: Name and CertRoot.Value must match
 	/// </summary>
-	/// <param name="signerX"></param>
-	/// <param name="signerY"></param>
-	/// <returns></returns>
 	private static bool IsSignerRule2Match(Signer signerX, Signer signerY)
 	{
 		return !string.IsNullOrWhiteSpace(signerX.Name) &&
@@ -134,20 +132,21 @@ internal sealed class WHQLPublisherSignerRuleComparer : IEqualityComparer<WHQLPu
 
 
 	/// <summary>
-	/// Rule 3: CertEKU IDs must match
+	/// Rule 3: Compare EKU lists based on Value only (ignore IDs)
 	/// </summary>
-	/// <param name="signerX"></param>
-	/// <param name="signerY"></param>
-	/// <returns></returns>
-	private static bool DoCertEKUsMatch(Signer signerX, Signer signerY)
+	/// <param name="ekusX">EKU list for first signer</param>
+	/// <param name="ekusY">EKU list for second signer</param>
+	/// <returns>True if EKU values match</returns>
+	private static bool DoEKUsMatch(List<EKU> ekusX, List<EKU> ekusY)
 	{
-		HashSet<string> ekuIdsX = signerX.CertEKU?.Select(e => e.ID).Where(id => !string.IsNullOrWhiteSpace(id)).ToHashSet(StringComparer.OrdinalIgnoreCase)
-					  ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-		HashSet<string> ekuIdsY = signerY.CertEKU?.Select(e => e.ID).Where(id => !string.IsNullOrWhiteSpace(id)).ToHashSet(StringComparer.OrdinalIgnoreCase)
-					  ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		// Extract EKU values and ignore IDs
+		HashSet<int> ekuValuesX = [.. ekusX.Where(e => e.Value != null).Select(e => CustomMethods.GetByteArrayHashCode(e.Value))];
 
-		return ekuIdsX.SetEquals(ekuIdsY);
+		HashSet<int> ekuValuesY = [.. ekusY.Where(e => e.Value != null).Select(e => CustomMethods.GetByteArrayHashCode(e.Value))];
+
+		// Compare sets of EKU values
+		return ekuValuesX.SetEquals(ekuValuesY);
 	}
 
 


### PR DESCRIPTION
* After adding support for signed App Control policies to the AppControl Manager app, now adding support for Supplemental policy signers and Update policy signers to the merge functions.

* Improved the merge functions further to consider the signing scenario during deduplication of FileRules.

* Fixed a bug in Merge operation related to WHQLFilePublisher and WHQLPublisher level deduplication, their IDs were being considered instead of value.

* The Merge button now stays disabled while the merge operation is running.

* Added support for AllowAll/DenyAll FileRules in the merge functions.
