### PR TITLE
Set minimum HTTP version to 2.0

### DIFF
--- a/AppControl Manager/.editorconfig
+++ b/AppControl Manager/.editorconfig
@@ -1093,3 +1093,6 @@ csharp_style_namespace_declarations = file_scoped:error
 
 # CA1002: Do not expose generic lists
 dotnet_diagnostic.CA1002.severity = error
+
+# CA1034: Nested types should not be visible
+dotnet_diagnostic.CA1034.severity = error

--- a/AppControl Manager/Logic/AppUpdate.cs
+++ b/AppControl Manager/Logic/AppUpdate.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Http;
+using AppControlManager.Logic;
 
 namespace AppControlManager;
 
@@ -33,7 +34,7 @@ internal sealed class AppUpdate
 	/// </summary>
 	internal UpdateCheckResponse Check()
 	{
-		using HttpClient client = new();
+		using HttpClient client = new SecHttpClient();
 
 		string versionsResponse = client.GetStringAsync(GlobalVars.AppVersionLinkURL).GetAwaiter().GetResult();
 

--- a/AppControl Manager/Logic/FileCertificateInfoCol.cs
+++ b/AppControl Manager/Logic/FileCertificateInfoCol.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace AppControlManager;
+
+// a class that represents each certificate in a chain
+// Used by the DataGrid in the View File Certificates page
+public sealed class FileCertificateInfoCol
+{
+	public int SignerNumber { get; set; }
+	public CertificateType Type { get; set; }
+	public string? SubjectCN { get; set; }
+	public string? IssuerCN { get; set; }
+	public DateTime NotBefore { get; set; }
+	public DateTime NotAfter { get; set; }
+	public string? HashingAlgorithm { get; set; }
+	public string? SerialNumber { get; set; }
+	public string? Thumbprint { get; set; }
+	public string? TBSHash { get; set; }
+	public string? OIDs { get; set; }
+}

--- a/AppControl Manager/Logic/GetOpusData.cs
+++ b/AppControl Manager/Logic/GetOpusData.cs
@@ -6,6 +6,17 @@ using System.Security.Cryptography.Pkcs;
 
 namespace AppControlManager;
 
+// https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-oshared/91755632-4b0d-44ca-89a9-9699afbbd268
+// Rust implementation: https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Security/WinTrust/struct.SPC_SP_OPUS_INFO.html
+public struct OpusInfoObj
+{
+	// Declaring a public field CertOemID of type string with LPWStr marshaling
+	[MarshalAs(UnmanagedType.LPWStr)]
+	public string CertOemID;
+	public IntPtr PublisherInfo;
+	public IntPtr MoreInfo; // not always present
+}
+
 public static partial class Opus
 {
 	internal static partial class Crypt32
@@ -30,17 +41,6 @@ public static partial class Opus
 	public const uint SPC_SP_OPUS_INFO_STRUCT = 2007;
 	// for the SpcSpOpusInfo structure
 	public const string SPC_SP_OPUS_INFO_OBJID = "1.3.6.1.4.1.311.2.1.12";
-
-	// https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-oshared/91755632-4b0d-44ca-89a9-9699afbbd268
-	// Rust implementation: https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Security/WinTrust/struct.SPC_SP_OPUS_INFO.html
-	public struct OpusInfoObj
-	{
-		// Declaring a public field CertOemID of type string with LPWStr marshaling
-		[MarshalAs(UnmanagedType.LPWStr)]
-		public string CertOemID;
-		public IntPtr PublisherInfo;
-		public IntPtr MoreInfo; // not always present
-	}
 
 	// Declaring a public static method GetOpusData that returns a List of OpusInfoObj, taking a SignedCms parameter
 	// https://learn.microsoft.com/en-us/windows/win32/seccrypto/example-c-program--verifying-the-signature-of-a-pe-file

--- a/AppControl Manager/Logic/Main/BasePolicyCreator.cs
+++ b/AppControl Manager/Logic/Main/BasePolicyCreator.cs
@@ -10,6 +10,7 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Xml;
 using AppControlManager.Logging;
+using AppControlManager.Logic;
 using AppControlManager.XMLOps;
 
 namespace AppControlManager;
@@ -190,7 +191,7 @@ internal static partial class BasePolicyCreator
 
 			Uri apiUrl = new($"https://api.github.com/repos/{owner}/{repo}/commits?path={path}");
 
-			using HttpClient httpClient = new();
+			using HttpClient httpClient = new SecHttpClient();
 			httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36");
 
 			// Call GitHub API to get commit details
@@ -280,7 +281,7 @@ internal static partial class BasePolicyCreator
 		}
 
 		// Download the zip file
-		using (HttpClient client = new())
+		using (HttpClient client = new SecHttpClient())
 		{
 			// Download the file synchronously
 			byte[] fileBytes = client.GetByteArrayAsync(DriversBlockListZipDownloadLink).GetAwaiter().GetResult();
@@ -323,7 +324,7 @@ internal static partial class BasePolicyCreator
 
 		// Download the markdown page from GitHub containing the latest Microsoft recommended driver block rules
 		string msftDriverBlockRulesAsString;
-		using (HttpClient client = new())
+		using (HttpClient client = new SecHttpClient())
 		{
 			msftDriverBlockRulesAsString = client.GetStringAsync(GlobalVars.MSFTRecommendedDriverBlockRulesURL).GetAwaiter().GetResult();
 		}
@@ -545,7 +546,7 @@ internal static partial class BasePolicyCreator
 
 		// Download the markdown page from GitHub containing the latest Microsoft recommended block rules (User Mode)
 		string msftUserModeBlockRulesAsString;
-		using (HttpClient client = new())
+		using (HttpClient client = new SecHttpClient())
 		{
 			msftUserModeBlockRulesAsString = client.GetStringAsync(GlobalVars.MSFTRecommendedBlockRulesURL).GetAwaiter().GetResult();
 		}

--- a/AppControl Manager/Logic/SecHttpClient.cs
+++ b/AppControl Manager/Logic/SecHttpClient.cs
@@ -1,0 +1,16 @@
+﻿using System.Net;
+using System.Net.Http;
+
+namespace AppControlManager.Logic;
+
+/// <summary>
+/// This class enforces minimum HTTP version of 2.0 and is future proof since it tries the highest available HTTP version by default
+/// </summary>
+internal sealed partial class SecHttpClient : HttpClient
+{
+	internal SecHttpClient() : base()
+	{
+		DefaultRequestVersion = HttpVersion.Version20;
+		DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
+	}
+}

--- a/AppControl Manager/Logic/SignToolHelper.cs
+++ b/AppControl Manager/Logic/SignToolHelper.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using AppControlManager.Logging;
+using AppControlManager.Logic;
 
 namespace AppControlManager;
 
@@ -76,7 +77,7 @@ internal static class SignToolHelper
 	{
 		DirectoryInfo stagingArea = StagingArea.NewStagingArea("GetSignTool");
 
-		using HttpClient client = new();
+		using HttpClient client = new SecHttpClient();
 
 		string packageName = "microsoft.windows.sdk.buildtools"; // Important that this stays all lower case
 

--- a/AppControl Manager/Pages/Update.xaml.cs
+++ b/AppControl Manager/Pages/Update.xaml.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using AppControlManager.Logging;
+using AppControlManager.Logic;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
@@ -54,7 +55,7 @@ public sealed partial class Update : Page
 		_instance = this;
 
 		// Cache the page in the memory so that when the user navigates back to this page, it does not go through the entire initialization process again, which improves performance.
-		this.NavigationCacheMode = NavigationCacheMode.Enabled;
+		this.NavigationCacheMode = NavigationCacheMode.Required;
 	}
 
 
@@ -121,7 +122,7 @@ public sealed partial class Update : Page
 				if (!useCustomMSIXPath)
 				{
 
-					using (HttpClient client = new())
+					using (HttpClient client = new SecHttpClient())
 					{
 						// Store the download link to the latest available version
 						onlineDownloadURL = new Uri(await client.GetStringAsync(GlobalVars.AppUpdateDownloadLinkURL));
@@ -135,7 +136,7 @@ public sealed partial class Update : Page
 					UpdateStatusInfoBar.Message = "Downloading the AppControl Manager MSIX package...";
 
 
-					using (HttpClient client = new())
+					using (HttpClient client = new SecHttpClient())
 					{
 						// Send an Async get request to the url and specify to stop reading after headers are received for better efficiently
 						using (HttpResponseMessage response = await client.GetAsync(onlineDownloadURL, HttpCompletionOption.ResponseHeadersRead))

--- a/AppControl Manager/Pages/ViewFileCertificates.xaml.cs
+++ b/AppControl Manager/Pages/ViewFileCertificates.xaml.cs
@@ -24,22 +24,6 @@ public sealed partial class ViewFileCertificates : Page
 		this.NavigationCacheMode = NavigationCacheMode.Enabled;
 	}
 
-	// a class that represents each certificate in a chain
-	public sealed class FileCertificateInfoCol
-	{
-		public int SignerNumber { get; set; }
-		public CertificateType Type { get; set; }
-		public string? SubjectCN { get; set; }
-		public string? IssuerCN { get; set; }
-		public DateTime NotBefore { get; set; }
-		public DateTime NotAfter { get; set; }
-		public string? HashingAlgorithm { get; set; }
-		public string? SerialNumber { get; set; }
-		public string? Thumbprint { get; set; }
-		public string? TBSHash { get; set; }
-		public string? OIDs { get; set; }
-	}
-
 	// Main collection assigned to the DataGrid
 	private readonly ObservableCollection<FileCertificateInfoCol> FileCertificates = [];
 


### PR DESCRIPTION
* Set the minimum HTTP version to 2.0 so it no longer uses 1.1 as fallback and by default it tries the highest available version which is 3.0 at the moment.
* Enabled a new code analyzer: nested types should not be visible.
* Changed the update page's cache mode from enabled to required.

<br>
