### PR TITLE
Adding support for hashing very large file

### DIFF
--- a/AppControl Manager/Pages/GetCIHashes.xaml
+++ b/AppControl Manager/Pages/GetCIHashes.xaml
@@ -21,40 +21,95 @@
             <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,10,6,10">
 
                 <TextBlock
-TextWrapping="WrapWholeWords"
-Style="{StaticResource BodyTextBlockStyle}">
+                    TextWrapping="WrapWholeWords"
+                    Style="{StaticResource BodyTextBlockStyle}">
 
-<Span>
-    Calculate the <Italic>Code Integrity</Italic>
-        <Run Foreground="{ThemeResource SystemAccentColor}">hashes</Run>
-    of files.</Span>
+                    <Span>
+                        Calculate the <Italic>Code Integrity</Italic>
+                            <Run Foreground="{ThemeResource SystemAccentColor}">hashes</Run>
+                        of files.</Span>
                 </TextBlock>
 
                 <HyperlinkButton Content="Guide" NavigateUri="https://github.com/HotCakeX/Harden-Windows-Security/wiki/Get-Code-Integrity-Hashes" />
 
             </controls:WrapPanel>
 
-
             <controls:WrapPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalSpacing="10" VerticalSpacing="15" Margin="15,0,15,0" Grid.Row="1">
 
                 <!-- Button to trigger file picker -->
                 <Button x:Name="PickFileButton" Content="Browse for a file" Click="PickFile_Click"
             HorizontalAlignment="Center"
-           ToolTipService.ToolTip="Click/Tap to choose a file from your device." Style="{StaticResource AccentButtonStyle}"/>
+            ToolTipService.ToolTip="Click/Tap to choose a file from your device." 
+            Style="{StaticResource AccentButtonStyle}"/>
 
-                <!-- TextBlocks to display the returned hash values -->
-                <TextBox Header="SHA1 Page" x:Name="Sha1PageTextBox" IsReadOnly="True" MinWidth="300"/>
+                <!-- Grid for SHA1 Page -->
+                <Grid HorizontalAlignment="Stretch">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <!-- Takes all available space -->
+                        <ColumnDefinition Width="Auto"/>
+                        <!-- Takes space for ProgressRing -->
+                    </Grid.ColumnDefinitions>
 
-                <TextBox Header="SHA256 Page" x:Name="Sha256PageTextBox" IsReadOnly="True" MinWidth="300"/>
+                    <TextBox Header="SHA1 Page" x:Name="Sha1PageTextBox" IsReadOnly="True" HorizontalAlignment="Stretch" MinWidth="300" Margin="0,0,12,0"/>
+                    <ProgressRing x:Name="Sha1PageProgressRing" Visibility="Collapsed" Grid.Column="1" Margin="0,27,0,0"/>
+                </Grid>
 
-                <TextBox Header="SHA1 Authenticode" x:Name="Sha1AuthenticodeTextBox" IsReadOnly="True" MinWidth="300"/>
+                <!-- Grid for SHA256 Page -->
+                <Grid HorizontalAlignment="Stretch">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
 
-                <TextBox Header="SHA256 Authenticode" x:Name="Sha256AuthenticodeTextBox" IsReadOnly="True" MinWidth="300"/>
+                    <TextBox Header="SHA256 Page" x:Name="Sha256PageTextBox" IsReadOnly="True" HorizontalAlignment="Stretch" MinWidth="300" Margin="0,0,12,0"/>
+                    <ProgressRing x:Name="Sha256PageProgressRing" Visibility="Collapsed" Grid.Column="1" Margin="0,27,0,0"/>
+                </Grid>
 
-                <TextBox Header="SHA3 384 Flat" x:Name="SHA3384FlatHash" IsReadOnly="True" MinWidth="300"/>
-                
-                <TextBox Header="SHA3 512 Flat" x:Name="SHA3512FlatHash" IsReadOnly="True" MinWidth="300"/>                
-            
+                <!-- Grid for SHA1 Authenticode -->
+                <Grid HorizontalAlignment="Stretch">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+
+                    <TextBox Header="SHA1 Authenticode" x:Name="Sha1AuthenticodeTextBox" IsReadOnly="True" HorizontalAlignment="Stretch" MinWidth="300" Margin="0,0,12,0"/>
+                    <ProgressRing x:Name="Sha1AuthenticodeProgressRing" Visibility="Collapsed" Grid.Column="1" Margin="0,27,0,0"/>
+                </Grid>
+
+                <!-- Grid for SHA256 Authenticode -->
+                <Grid HorizontalAlignment="Stretch">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+
+                    <TextBox Header="SHA256 Authenticode" x:Name="Sha256AuthenticodeTextBox" IsReadOnly="True" HorizontalAlignment="Stretch" MinWidth="300" Margin="0,0,12,0"/>
+                    <ProgressRing x:Name="Sha256AuthenticodeProgressRing" Visibility="Collapsed" Grid.Column="1" Margin="0,27,0,0"/>
+                </Grid>
+
+                <!-- Grid for SHA3 384 Flat -->
+                <Grid HorizontalAlignment="Stretch">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+
+                    <TextBox Header="SHA3 384 Flat" x:Name="SHA3384FlatHash" IsReadOnly="True" HorizontalAlignment="Stretch" MinWidth="300" Margin="0,0,12,0"/>
+                    <ProgressRing x:Name="SHA3384FlatHashProgressRing" Visibility="Collapsed" Grid.Column="1" Margin="0,27,0,0"/>
+                </Grid>
+
+                <!-- Grid for SHA3 512 Flat -->
+                <Grid HorizontalAlignment="Stretch">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+
+                    <TextBox Header="SHA3 512 Flat" x:Name="SHA3512FlatHash" IsReadOnly="True" HorizontalAlignment="Stretch" MinWidth="300" Margin="0,0,12,0"/>
+                    <ProgressRing x:Name="SHA3512FlatHashProgressRing" Visibility="Collapsed" Grid.Column="1" Margin="0,27,0,0"/>
+                </Grid>
+
             </controls:WrapPanel>
 
         </Grid>

--- a/AppControl Manager/Pages/GetCIHashes.xaml.cs
+++ b/AppControl Manager/Pages/GetCIHashes.xaml.cs
@@ -67,9 +67,6 @@ public sealed partial class GetCIHashes : Page
 			string? SHA3_512Hash = null;
 			string? SHA3_384Hash = null;
 
-			SHA3384FlatHashProgressRing.Visibility = Visibility.Visible;
-			SHA3512FlatHashProgressRing.Visibility = Visibility.Visible;
-
 			if (GlobalVars.IsOlderThan24H2)
 			{
 				SHA3_512Hash = "Requires Windows 11 24H2 or later";
@@ -77,6 +74,9 @@ public sealed partial class GetCIHashes : Page
 			}
 			else
 			{
+
+				SHA3384FlatHashProgressRing.Visibility = Visibility.Visible;
+				SHA3512FlatHashProgressRing.Visibility = Visibility.Visible;
 
 				await Task.Run(() =>
 				{
@@ -123,14 +123,15 @@ public sealed partial class GetCIHashes : Page
 					}
 
 				});
+
+				SHA3384FlatHashProgressRing.Visibility = Visibility.Collapsed;
+				SHA3512FlatHashProgressRing.Visibility = Visibility.Collapsed;
 			}
 
 			// Display the rest of the hashes in the UI
 			SHA3384FlatHash.Text = SHA3_384Hash ?? "N/A";
 			SHA3512FlatHash.Text = SHA3_512Hash ?? "N/A";
 
-			SHA3384FlatHashProgressRing.Visibility = Visibility.Collapsed;
-			SHA3512FlatHashProgressRing.Visibility = Visibility.Collapsed;
 		}
 		finally
 		{

--- a/AppControl Manager/Pages/GetCIHashes.xaml.cs
+++ b/AppControl Manager/Pages/GetCIHashes.xaml.cs
@@ -38,10 +38,37 @@ public sealed partial class GetCIHashes : Page
 				return;
 			}
 
+			// Clear the UI text boxes
+			Sha1PageTextBox.Text = null;
+			Sha256PageTextBox.Text = null;
+			Sha1AuthenticodeTextBox.Text = null;
+			Sha256AuthenticodeTextBox.Text = null;
+			SHA3384FlatHash.Text = null;
+			SHA3512FlatHash.Text = null;
+
+			Sha1PageProgressRing.Visibility = Visibility.Visible;
+			Sha256PageProgressRing.Visibility = Visibility.Visible;
+			Sha1AuthenticodeProgressRing.Visibility = Visibility.Visible;
+			Sha256AuthenticodeProgressRing.Visibility = Visibility.Visible;
+
 			CodeIntegrityHashes hashes = await Task.Run(() => CiFileHash.GetCiFileHashes(selectedFile));
+
+			// Display the hashes in the UI
+			Sha1PageTextBox.Text = hashes.SHA1Page ?? "N/A";
+			Sha256PageTextBox.Text = hashes.SHA256Page ?? "N/A";
+			Sha1AuthenticodeTextBox.Text = hashes.SHa1Authenticode ?? "N/A";
+			Sha256AuthenticodeTextBox.Text = hashes.SHA256Authenticode ?? "N/A";
+
+			Sha1PageProgressRing.Visibility = Visibility.Collapsed;
+			Sha256PageProgressRing.Visibility = Visibility.Collapsed;
+			Sha1AuthenticodeProgressRing.Visibility = Visibility.Collapsed;
+			Sha256AuthenticodeProgressRing.Visibility = Visibility.Collapsed;
 
 			string? SHA3_512Hash = null;
 			string? SHA3_384Hash = null;
+
+			SHA3384FlatHashProgressRing.Visibility = Visibility.Visible;
+			SHA3512FlatHashProgressRing.Visibility = Visibility.Visible;
 
 			if (GlobalVars.IsOlderThan24H2)
 			{
@@ -54,33 +81,56 @@ public sealed partial class GetCIHashes : Page
 				await Task.Run(() =>
 				{
 
-					// Read the file as a byte array - This way we can get hashes of a file in use by another process
-					byte[] Bytes = File.ReadAllBytes(selectedFile);
+					// Initializing the hash algorithms for SHA3-512 and SHA3-384
+					using SHA3_512 sha3_512 = SHA3_512.Create();
+					using SHA3_384 sha3_384 = SHA3_384.Create();
 
-					// Compute the hash of the byte array
-					Byte[] SHA3_512HashBytes = SHA3_512.HashData(Bytes);
+					// Opening the file as a stream to read it in chunks, this way we can handle large files
+					using (FileStream fs = new(selectedFile, FileMode.Open, FileAccess.Read))
+					{
+						// Defining a buffer size of 4MB to read the file in manageable chunks
+						byte[] buffer = new byte[4 * 1024 * 1024];
 
-					// Convert the hash bytes to a hexadecimal string to make it look like the output of the Get-FileHash which produces hexadecimals (0-9 and A-F)
-					// If System.Convert.ToBase64String was used, it'd return the hash in base64 format, which uses 64 symbols (A-Z, a-z, 0-9, + and /) to represent each byte
-					String HashString_SHA3_512 = BitConverter.ToString(SHA3_512HashBytes);
+						int bytesRead;
 
-					// Remove the dashes from the hexadecimal string
-					SHA3_512Hash = HashString_SHA3_512.Replace("-", "", StringComparison.OrdinalIgnoreCase);
+						// Read the file in chunks and update the hash algorithms with the chunk data
+						while ((bytesRead = fs.Read(buffer, 0, buffer.Length)) > 0)
+						{
+							// Update SHA3-512 hash with the current chunk
+							_ = sha3_512.TransformBlock(buffer, 0, bytesRead, null, 0);
 
+							// Update SHA3-384 hash with the current chunk
+							_ = sha3_384.TransformBlock(buffer, 0, bytesRead, null, 0);
+						}
 
-					Byte[] SHA3_384HashBytes = SHA3_384.HashData(Bytes);
-					String HashString_SHA3_384 = BitConverter.ToString(SHA3_384HashBytes);
-					SHA3_384Hash = HashString_SHA3_384.Replace("-", "", StringComparison.OrdinalIgnoreCase);
+						// Finalize the SHA3-512 hash computation
+						_ = sha3_512.TransformFinalBlock([], 0, 0);
+
+						// Finalize the SHA3-384 hash computation
+						_ = sha3_384.TransformFinalBlock([], 0, 0);
+					}
+
+					if (sha3_512.Hash is not null)
+
+					{   // Convert the SHA3-512 hash bytes to a hexadecimal string
+						SHA3_512Hash = Convert.ToHexString(sha3_512.Hash);
+					}
+
+					if (sha3_384.Hash is not null)
+					{
+						// Convert the SHA3-384 hash bytes to a hexadecimal string
+						SHA3_384Hash = Convert.ToHexString(sha3_384.Hash);
+					}
+
 				});
 			}
 
-			// Display the hashes in the UI
-			Sha1PageTextBox.Text = hashes.SHA1Page ?? "N/A";
-			Sha256PageTextBox.Text = hashes.SHA256Page ?? "N/A";
-			Sha1AuthenticodeTextBox.Text = hashes.SHa1Authenticode ?? "N/A";
-			Sha256AuthenticodeTextBox.Text = hashes.SHA256Authenticode ?? "N/A";
+			// Display the rest of the hashes in the UI
 			SHA3384FlatHash.Text = SHA3_384Hash ?? "N/A";
 			SHA3512FlatHash.Text = SHA3_512Hash ?? "N/A";
+
+			SHA3384FlatHashProgressRing.Visibility = Visibility.Collapsed;
+			SHA3512FlatHashProgressRing.Visibility = Visibility.Collapsed;
 		}
 		finally
 		{


### PR DESCRIPTION
* SHA3 hashes can now be calculated for very large files.
* Added progress rings for each hash type in the [Get Code Integrity Hashes](https://github.com/HotCakeX/Harden-Windows-Security/wiki/Get-Code-Integrity-Hashes) page to display their individual progress.

<br>