### PR TITLE
Improved dependency compatibility in the Harden Windows Security Module

### DIFF
--- a/Harden-Windows-Security Module/Main files/C#/GUI/Confirm/View.cs
+++ b/Harden-Windows-Security Module/Main files/C#/GUI/Confirm/View.cs
@@ -389,7 +389,7 @@ public partial class GUIMain
 			}
 
 			// Display a notification if it's allowed to do so, and ShowNotification is set to true
-			if (GlobalVars.UseNewNotificationsExp && ShowNotification)
+			if (ShowNotification)
 			{
 				ToastNotification.Show(ToastNotification.Type.EndOfConfirmation, CompliantItemsCount, NonCompliantItemsCount, null, null);
 			}

--- a/Harden-Windows-Security Module/Main files/C#/GUI/Protection/EventHandlers.cs
+++ b/Harden-Windows-Security Module/Main files/C#/GUI/Protection/EventHandlers.cs
@@ -723,10 +723,7 @@ public static partial class GUIProtectWinSecurity
 							   }
 						   }
 
-						   if (GlobalVars.UseNewNotificationsExp)
-						   {
-							   ToastNotification.Show(ToastNotification.Type.EndOfProtection, null, null, null, null);
-						   }
+						   ToastNotification.Show(ToastNotification.Type.EndOfProtection, null, null, null, null);
 					   }
 					   else
 					   {

--- a/Harden-Windows-Security Module/Main files/C#/Others/DialogMsgHelper.cs
+++ b/Harden-Windows-Security Module/Main files/C#/Others/DialogMsgHelper.cs
@@ -22,7 +22,7 @@ internal static class DialogMsgHelper
 			{
 				Title = Title,
 				Width = 450,
-				Height = 300,
+				Height = 350,
 				WindowStartupLocation = WindowStartupLocation.CenterScreen,
 				ResizeMode = ResizeMode.NoResize
 

--- a/Harden-Windows-Security Module/Main files/C#/Others/GlobalVars.cs
+++ b/Harden-Windows-Security Module/Main files/C#/Others/GlobalVars.cs
@@ -65,11 +65,6 @@ public static class GlobalVars
 	// The path to the LGPO.exe utility
 	internal static string? LGPOExe;
 
-	// A flag to determine whether the new notifications experience should be used or not
-	// It won't be used if there is an interferences detected with DLL load due to other addons being loaded in the PowerShell session
-	// Such as PowerToys' CommandNotFound or WinGet's PowerShell module
-	public static bool UseNewNotificationsExp = true;
-
 	// Initialize the RegistryCSVItems list so that the HardeningRegistryKeys.ReadCsv() method can write to it
 	internal static readonly List<HardeningRegistryKeys.CsvRecord> RegistryCSVItems = [];
 

--- a/Harden-Windows-Security Module/Main files/C#/Others/ToastNotification.cs
+++ b/Harden-Windows-Security Module/Main files/C#/Others/ToastNotification.cs
@@ -20,9 +20,6 @@ public static class ToastNotification
 
 	/// <summary>
 	/// Displays modern toast notification on Windows
-	/// The caller must check for GlobalVars.UseNewNotificationsExp and if it's true then use this method
-	/// So that it will only display the notifications if the required DLLs have been loaded in the PowerShell session via Add-Type
-	/// That is different than the DLLs being made available to the Add-Type during C# code compilation
 	/// </summary>
 	/// <param name="Type">The type of the toast notification to use</param>
 	public static void Show(Type Type, string? TotalCompliantValues, string? TotalNonCompliantValues, string? UnprotectCategory, string? BitLockerEncryptionTab)

--- a/Harden-Windows-Security Module/Main files/Core/Confirm-SystemCompliance.psm1
+++ b/Harden-Windows-Security Module/Main files/Core/Confirm-SystemCompliance.psm1
@@ -41,8 +41,8 @@ function Confirm-SystemCompliance {
         if (-NOT ([HardenWindowsSecurity.UserPrivCheck]::IsAdmin())) {
             Throw [System.Security.AccessControl.PrivilegeNotHeldException] 'Administrator'
         }
+        try { LoadHardenWindowsSecurityNecessaryDLLsInternal }  catch { Write-Verbose $global:ReRunText; ReRunTheModuleAgain $MyInvocation.Statement }
         [HardenWindowsSecurity.Initializer]::Initialize($VerbosePreference)
-
         if (-NOT $Offline) {
             [HardenWindowsSecurity.Logger]::LogMessage('Checking for updates...', [HardenWindowsSecurity.LogTypeIntel]::Information)
             Update-HardenWindowsSecurity -InvocationStatement $MyInvocation.Statement

--- a/Harden-Windows-Security Module/Main files/Core/Protect-WindowsSecurity.psm1
+++ b/Harden-Windows-Security Module/Main files/Core/Protect-WindowsSecurity.psm1
@@ -271,6 +271,7 @@ Function Protect-WindowsSecurity {
         }
     }
     begin {
+        try { LoadHardenWindowsSecurityNecessaryDLLsInternal }  catch { Write-Verbose $global:ReRunText; ReRunTheModuleAgain -C $MyInvocation.Statement }
         $script:ErrorActionPreference = 'Stop'
         [HardenWindowsSecurity.Initializer]::Initialize($VerbosePreference)
         [System.Boolean]$ErrorsOccurred = $false

--- a/Harden-Windows-Security Module/Main files/Core/Unprotect-WindowsSecurity.psm1
+++ b/Harden-Windows-Security Module/Main files/Core/Unprotect-WindowsSecurity.psm1
@@ -23,6 +23,7 @@ Function Unprotect-WindowsSecurity {
         if (-NOT ([HardenWindowsSecurity.UserPrivCheck]::IsAdmin())) {
             Throw [System.Security.AccessControl.PrivilegeNotHeldException] 'Administrator'
         }
+        try { LoadHardenWindowsSecurityNecessaryDLLsInternal }  catch { Write-Verbose $global:ReRunText; ReRunTheModuleAgain $MyInvocation.Statement }
         $script:ErrorActionPreference = 'Stop'
         [HardenWindowsSecurity.Initializer]::Initialize($VerbosePreference)
         [HardenWindowsSecurity.Logger]::LogMessage('Checking for updates...', [HardenWindowsSecurity.LogTypeIntel]::Information)

--- a/Harden-Windows-Security Module/Main files/Harden-Windows-Security-Module.psd1
+++ b/Harden-Windows-Security Module/Main files/Harden-Windows-Security-Module.psd1
@@ -12,7 +12,7 @@
   PowerShellVersion    = '7.4.5'
   RequiredAssemblies   = @()
   NestedModules        = @('Core\Confirm-SystemCompliance.psm1', 'Core\Protect-WindowsSecurity.psm1', 'Core\Unprotect-WindowsSecurity.psm1')
-  FunctionsToExport    = @('Confirm-SystemCompliance', 'Protect-WindowsSecurity', 'Unprotect-WindowsSecurity', 'Update-HardenWindowsSecurity')
+  FunctionsToExport    = @('Confirm-SystemCompliance', 'Protect-WindowsSecurity', 'Unprotect-WindowsSecurity', 'Update-HardenWindowsSecurity', 'LoadHardenWindowsSecurityNecessaryDLLsInternal', 'ReRunTheModuleAgain')
   CmdletsToExport      = @()
   VariablesToExport    = '*'
   AliasesToExport      = @()

--- a/Harden-Windows-Security Module/Main files/Resources/XAML/AppControlManager.xaml
+++ b/Harden-Windows-Security Module/Main files/Resources/XAML/AppControlManager.xaml
@@ -10,7 +10,7 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <TextBlock Grid.Row="0" Text="Use this page to install the AppControl Manager. Since AppControl Manager uses on-device generated self-signed certificate, the 'Only Elevate Signed' policy and Smart App Control must not be enabled. Smart App Control must be off either way if you intend to take full control of Applicaton Control in your system using the AppControl Manager."
+        <TextBlock Grid.Row="0" Text="Use this page to install the AppControl Manager. Since it uses certificate generated on your device, Smart App Control might not let it run. Smart App Control must be off either way if you intend to take full control of Applicaton Control in your system using the AppControl Manager."
             Foreground="Black"
             FontSize="14"
             Margin="20,10,20,15"


### PR DESCRIPTION
The module will not detect if there was a problem loading its dlls and if it was, reloads PowerShell with -NoProfile switch to fix it.

Also a new message will be shown when installing the AppControl Manager and there is an incompatible policy on the system.
