### PR TITLE
AppControl Manager v.1.8.3.0

### DIFF
--- a/AppControl Manager/AppControl Manager.csproj
+++ b/AppControl Manager/AppControl Manager.csproj
@@ -91,7 +91,7 @@
     <AssemblyName>AppControlManager</AssemblyName>
     <PublishAot>False</PublishAot>
     <ErrorReport>send</ErrorReport>
-    <FileVersion>1.8.2.0</FileVersion>
+    <FileVersion>1.8.3.0</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/AppControl Manager/Logic/CertificateCreator.cs
+++ b/AppControl Manager/Logic/CertificateCreator.cs
@@ -12,7 +12,6 @@ internal static class CertificateGenerator
 
 	/// <summary>
 	/// Build a self-signed on-device certificate for the purpose of App Control policy signing
-	/// Use certutil -dump -v '.\codesign.cer' to view the certificate properties, such as encoding of the certificate fields like the subject
 	/// </summary>
 	/// <param name="CommonName"></param>
 	/// <param name="Password"></param>

--- a/AppControl Manager/Logic/Main/BasePolicyCreator.cs
+++ b/AppControl Manager/Logic/Main/BasePolicyCreator.cs
@@ -281,7 +281,7 @@ internal static partial class BasePolicyCreator
 		}
 
 		// Download the zip file
-		using (HttpClient client = new SecHttpClient())
+		using (HttpClient client = new())
 		{
 			// Download the file synchronously
 			byte[] fileBytes = client.GetByteArrayAsync(DriversBlockListZipDownloadLink).GetAwaiter().GetResult();

--- a/AppControl Manager/Logic/SignToolHelper.cs
+++ b/AppControl Manager/Logic/SignToolHelper.cs
@@ -7,7 +7,6 @@ using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using AppControlManager.Logging;
-using AppControlManager.Logic;
 
 namespace AppControlManager;
 
@@ -77,7 +76,7 @@ internal static class SignToolHelper
 	{
 		DirectoryInfo stagingArea = StagingArea.NewStagingArea("GetSignTool");
 
-		using HttpClient client = new SecHttpClient();
+		using HttpClient client = new();
 
 		string packageName = "microsoft.windows.sdk.buildtools"; // Important that this stays all lower case
 
@@ -109,7 +108,7 @@ internal static class SignToolHelper
 
 		// Extract the .nupkg file
 		string extractPath = Path.Combine(stagingArea.FullName, "extracted");
-		ZipFile.ExtractToDirectory(filePath, extractPath);
+		ZipFile.ExtractToDirectory(filePath, extractPath, true);
 
 		Logger.Write($"Extracted package to {extractPath}");
 

--- a/AppControl Manager/Package.appxmanifest
+++ b/AppControl Manager/Package.appxmanifest
@@ -11,7 +11,7 @@
   <Identity
     Name="AppControlManager"
     Publisher="CN=SelfSignedCertForAppControlManager"
-    Version="1.8.2.0" />
+    Version="1.8.3.0" />
 
   <mp:PhoneIdentity PhoneProductId="199a23ec-7cb6-4ab5-ab50-8baca348bc79" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/AppControl Manager/Pages/BuildNewCertificate.xaml.cs
+++ b/AppControl Manager/Pages/BuildNewCertificate.xaml.cs
@@ -18,7 +18,7 @@ public sealed partial class BuildNewCertificate : Page
 	{
 		this.InitializeComponent();
 
-		this.NavigationCacheMode = NavigationCacheMode.Enabled;
+		this.NavigationCacheMode = NavigationCacheMode.Required;
 
 		CheckFieldContents();
 	}

--- a/AppControl Manager/Pages/CreateDenyPolicy.xaml.cs
+++ b/AppControl Manager/Pages/CreateDenyPolicy.xaml.cs
@@ -25,7 +25,7 @@ public sealed partial class CreateDenyPolicy : Page
 	{
 		this.InitializeComponent();
 
-		this.NavigationCacheMode = NavigationCacheMode.Enabled;
+		this.NavigationCacheMode = NavigationCacheMode.Required;
 
 		// Assign this instance to the static field
 		_instance = this;

--- a/AppControl Manager/Pages/CreatePolicy.xaml.cs
+++ b/AppControl Manager/Pages/CreatePolicy.xaml.cs
@@ -27,7 +27,7 @@ public sealed partial class CreatePolicy : Page
 		SignedAndReputableLogSizeInput.IsEnabled = false;
 
 		// Make sure navigating to/from this page maintains its state
-		this.NavigationCacheMode = NavigationCacheMode.Enabled;
+		this.NavigationCacheMode = NavigationCacheMode.Required;
 
 	}
 

--- a/AppControl Manager/Pages/CreateSupplementalPolicy.xaml.cs
+++ b/AppControl Manager/Pages/CreateSupplementalPolicy.xaml.cs
@@ -28,7 +28,7 @@ public sealed partial class CreateSupplementalPolicy : Page, Sidebar.IAnimatedIc
 		this.InitializeComponent();
 
 		// Make sure navigating to/from this page maintains its state
-		this.NavigationCacheMode = NavigationCacheMode.Enabled;
+		this.NavigationCacheMode = NavigationCacheMode.Required;
 
 		// Assign this instance to the static field
 		_instance = this;

--- a/AppControl Manager/Pages/Deployment.xaml.cs
+++ b/AppControl Manager/Pages/Deployment.xaml.cs
@@ -25,7 +25,7 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 	{
 		this.InitializeComponent();
 
-		this.NavigationCacheMode = NavigationCacheMode.Enabled;
+		this.NavigationCacheMode = NavigationCacheMode.Required;
 
 		if (GlobalVars.IsOlderThan24H2)
 		{

--- a/AppControl Manager/Pages/GetCIHashes.xaml.cs
+++ b/AppControl Manager/Pages/GetCIHashes.xaml.cs
@@ -17,7 +17,7 @@ public sealed partial class GetCIHashes : Page
 	public GetCIHashes()
 	{
 		this.InitializeComponent();
-		this.NavigationCacheMode = NavigationCacheMode.Enabled;
+		this.NavigationCacheMode = NavigationCacheMode.Required;
 	}
 
 	/// <summary>

--- a/AppControl Manager/Pages/MDEAHPolicyCreation.xaml.cs
+++ b/AppControl Manager/Pages/MDEAHPolicyCreation.xaml.cs
@@ -44,7 +44,7 @@ public sealed partial class MDEAHPolicyCreation : Page
 		this.InitializeComponent();
 
 		// Make sure navigating to/from this page maintains its state
-		this.NavigationCacheMode = NavigationCacheMode.Enabled;
+		this.NavigationCacheMode = NavigationCacheMode.Required;
 
 		// Initialize the lists
 		FileIdentities = [];

--- a/AppControl Manager/Pages/MergePolicies.xaml.cs
+++ b/AppControl Manager/Pages/MergePolicies.xaml.cs
@@ -21,7 +21,7 @@ public sealed partial class MergePolicies : Page
 		this.InitializeComponent();
 
 		// Make sure navigating to/from this page maintains its state
-		this.NavigationCacheMode = NavigationCacheMode.Enabled;
+		this.NavigationCacheMode = NavigationCacheMode.Required;
 	}
 
 

--- a/AppControl Manager/Pages/Simulation.xaml.cs
+++ b/AppControl Manager/Pages/Simulation.xaml.cs
@@ -28,7 +28,7 @@ public sealed partial class Simulation : Page
 	public Simulation()
 	{
 		this.InitializeComponent();
-		this.NavigationCacheMode = NavigationCacheMode.Enabled;
+		this.NavigationCacheMode = NavigationCacheMode.Required;
 
 		SimulationOutputs = [];
 		AllSimulationOutputs = [];

--- a/AppControl Manager/app.manifest
+++ b/AppControl Manager/app.manifest
@@ -2,7 +2,7 @@
 <!-- INFO: https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests -->
 <!-- INFO (for legacy UWP but its info can be used for better understanding): https://learn.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/root-elements -->
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.8.2.0" name="AppControlManager"/>
+  <assemblyIdentity version="1.8.3.0" name="AppControlManager"/>
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>


### PR DESCRIPTION
* Improved the update mechanism, it will remove any related previous ASR rule exclusions instead of only those for the previous app version. The same improvement was previously implemented in the [bootstrapper script](https://github.com/HotCakeX/Harden-Windows-Security/pull/509) and the Harden Windows Security module as well.

* Improved page behaviors, their states will now be preserved at all times even if you navigate away from them for any amount of time.

* Fixed NuGet connection (e.g., for downloading the SignTool.exe), it isn't always compatible with HTTP v.2

<br>
