### PR TITLE
Implemented another protection when removing signed policies in AppControl Manager

### DIFF
--- a/AppControl Manager/Logic/Main/UserConfiguration.cs
+++ b/AppControl Manager/Logic/Main/UserConfiguration.cs
@@ -265,7 +265,7 @@ public sealed partial class UserConfiguration(
 			Logger.Write($"Error reading or parsing the user configuration file: {ex.Message} A new configuration with default values will be created.");
 
 			// Create a new configuration with default values and write it to the file
-			UserConfiguration defaultConfig = new(null, null, null, null, null, null, null, null, null, null);
+			UserConfiguration defaultConfig = new(null, null, null, null, null, null, null, null, null, null, null);
 			WriteUserConfiguration(defaultConfig);
 
 			return defaultConfig;
@@ -382,7 +382,7 @@ public sealed partial class UserConfiguration(
 	/// </summary>
 	/// <param name="key">The key to add.</param>
 	/// <param name="value">The value to associate with the key.</param>
-	internal static void Add(string key, DateTime value)
+	internal static void AddSignedPolicyStage1RemovalTime(string key, DateTime value)
 	{
 		// Get the current user configuration
 		UserConfiguration currentConfig = ReadUserConfiguration();
@@ -406,7 +406,7 @@ public sealed partial class UserConfiguration(
 	/// </summary>
 	/// <param name="key">The key to query.</param>
 	/// <returns>The value associated with the key, or null if the key does not exist.</returns>
-	internal static DateTime? Query(string key)
+	internal static DateTime? QuerySignedPolicyStage1RemovalTime(string key)
 	{
 		// Get the current user configuration
 		UserConfiguration currentConfig = ReadUserConfiguration();
@@ -428,7 +428,7 @@ public sealed partial class UserConfiguration(
 	/// </summary>
 	/// <param name="key">The key to remove.</param>
 	/// <returns>True if the key was successfully removed; false if the key was not found.</returns>
-	internal static void RemoveKey(string key)
+	internal static void RemoveSignedPolicyStage1RemovalTime(string key)
 	{
 		// Get the current user configuration
 		UserConfiguration currentConfig = ReadUserConfiguration();

--- a/AppControl Manager/Pages/SystemInformation/ViewCurrentPolicies.xaml.cs
+++ b/AppControl Manager/Pages/SystemInformation/ViewCurrentPolicies.xaml.cs
@@ -345,14 +345,14 @@ public sealed partial class ViewCurrentPolicies : Page
 									CiToolHelper.RemovePolicy(policy.PolicyID!);
 
 									// Remove the PolicyID from the SignedPolicyStage1RemovalTimes dictionary
-									UserConfiguration.RemoveKey(policy.PolicyID!);
+									UserConfiguration.RemoveSignedPolicyStage1RemovalTime(policy.PolicyID!);
 								}
 								else
 								{
 									// Create and display a ContentDialog
 									ContentDialog dialog = new()
 									{
-										Title = "WARNING",
+										Title = "Warning",
 										Content = $"Before you can safely remove the signed policy named '{policy.FriendlyName}' with the ID '{policy.PolicyID}', you must restart your system.",
 										PrimaryButtonText = "I Understand",
 										BorderBrush = Application.Current.Resources["AccentFillColorDefaultBrush"] as Brush ?? new SolidColorBrush(Colors.Transparent),
@@ -367,6 +367,8 @@ public sealed partial class ViewCurrentPolicies : Page
 									return;
 								}
 							}
+
+							// Treat it as a new signed policy removal
 							else
 							{
 
@@ -433,7 +435,7 @@ public sealed partial class ViewCurrentPolicies : Page
 								// The time of first stage of the signed policy removal
 								// Since policy object has the full ID, in upper case with curly brackets,
 								// We need to normalize them to match what the CiPolicyInfo class uses
-								UserConfiguration.Add(policyObj.PolicyID.Trim('{', '}').ToLowerInvariant(), DateTime.UtcNow);
+								UserConfiguration.AddSignedPolicyStage1RemovalTime(policyObj.PolicyID.Trim('{', '}').ToLowerInvariant(), DateTime.UtcNow);
 							}
 						}
 					}
@@ -710,11 +712,11 @@ public sealed partial class ViewCurrentPolicies : Page
 		Logger.Write($"System's last reboot was {lastRebootTimeUtc} (UTC)");
 
 		// When the policy's 1st stage was completed
-		DateTime? stage1RemovalTime = UserConfiguration.Query(policyID);
+		DateTime? stage1RemovalTime = UserConfiguration.QuerySignedPolicyStage1RemovalTime(policyID);
 
 		if (stage1RemovalTime is not null)
 		{
-			Logger.Write($"Signed policy with the ID '{policyID}' completed its 1st state at {stage1RemovalTime} (UTC)");
+			Logger.Write($"Signed policy with the ID '{policyID}' completed its 1st stage at {stage1RemovalTime} (UTC)");
 
 			if (stage1RemovalTime < lastRebootTimeUtc)
 			{

--- a/AppControl Manager/Pages/SystemInformation/ViewCurrentPolicies.xaml.cs
+++ b/AppControl Manager/Pages/SystemInformation/ViewCurrentPolicies.xaml.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using AppControlManager.CustomUIElements;
+using AppControlManager.Logging;
 using AppControlManager.SiPolicyIntel;
 using CommunityToolkit.WinUI.UI.Controls;
 using Microsoft.UI;
@@ -322,14 +323,8 @@ public sealed partial class ViewCurrentPolicies : Page
 
 					foreach (CiPolicyInfo policy in policiesToRemove)
 					{
-						// Remove the policy directly from the system if it's unsigned
-						if (!policy.IsSignedPolicy ||
-							// or supplemental
-							!string.Equals(policy.PolicyID, policy.BasePolicyID, StringComparison.OrdinalIgnoreCase) ||
-							// or signed base policy with the EnabledUnsignedSystemIntegrityPolicy policy rule option
-							(policy.IsSignedPolicy && string.Equals(policy.PolicyID, policy.BasePolicyID, StringComparison.OrdinalIgnoreCase) &&
-							 policy.PolicyOptions is not null && policy.PolicyOptionsDisplay.Contains("Enabled:Unsigned System Integrity Policy", StringComparison.OrdinalIgnoreCase)
-							))
+						// Remove the policy directly from the system if it's unsigned or supplemental
+						if (!policy.IsSignedPolicy || !string.Equals(policy.PolicyID, policy.BasePolicyID, StringComparison.OrdinalIgnoreCase))
 						{
 							await Task.Run(() =>
 							{
@@ -337,78 +332,120 @@ public sealed partial class ViewCurrentPolicies : Page
 							});
 						}
 
-						// If the policy is base and signed
+						// At this point the policy is definitely a Signed Base policy
 						else
 						{
-							#region Signing Details acquisition
-
-							string CertCN;
-							string CertPath;
-							string SignToolPath;
-							string XMLPolicyPath;
-
-							// Instantiate the Content Dialog
-							SigningDetailsDialogForRemoval customDialog = new(currentlyDeployedBasePolicyIDs, policy.PolicyID!);
-
-							// Show the dialog and await its result
-							ContentDialogResult result = await customDialog.ShowAsync();
-
-							// Ensure primary button was selected
-							if (result is ContentDialogResult.Primary)
+							// If the EnabledUnsignedSystemIntegrityPolicy policy rule option exists
+							// Which means 1st stage already happened
+							if (policy.PolicyOptions is not null && policy.PolicyOptionsDisplay.Contains("Enabled:Unsigned System Integrity Policy", StringComparison.OrdinalIgnoreCase))
 							{
-								SignToolPath = customDialog.SignToolPath!;
-								CertPath = customDialog.CertificatePath!;
-								CertCN = customDialog.CertificateCommonName!;
-								XMLPolicyPath = customDialog.XMLPolicyPath!;
+								// And if system was rebooted once after performing the 1st removal stage
+								if (VerifyRemovalEligibility(policy.PolicyID!))
+								{
+									CiToolHelper.RemovePolicy(policy.PolicyID!);
 
-								// Sometimes the content dialog lingers on or re-appears so making sure it hides
-								customDialog.Hide();
+									// Remove the PolicyID from the SignedPolicyStage1RemovalTimes dictionary
+									UserConfiguration.RemoveKey(policy.PolicyID!);
+								}
+								else
+								{
+									// Create and display a ContentDialog
+									ContentDialog dialog = new()
+									{
+										Title = "WARNING",
+										Content = $"Before you can safely remove the signed policy named '{policy.FriendlyName}' with the ID '{policy.PolicyID}', you must restart your system.",
+										PrimaryButtonText = "I Understand",
+										BorderBrush = Application.Current.Resources["AccentFillColorDefaultBrush"] as Brush ?? new SolidColorBrush(Colors.Transparent),
+										BorderThickness = new Thickness(1),
+										XamlRoot = this.XamlRoot // Set XamlRoot to the current page's XamlRoot
+									};
 
+									// Show the dialog and wait for user response
+									_ = await dialog.ShowAsync();
+
+									// Exit the method, nothing more can be done about the selected policy
+									return;
+								}
 							}
 							else
 							{
-								return;
+
+
+								#region Signing Details acquisition
+
+								string CertCN;
+								string CertPath;
+								string SignToolPath;
+								string XMLPolicyPath;
+
+								// Instantiate the Content Dialog
+								SigningDetailsDialogForRemoval customDialog = new(currentlyDeployedBasePolicyIDs, policy.PolicyID!);
+
+								// Show the dialog and await its result
+								ContentDialogResult result = await customDialog.ShowAsync();
+
+								// Ensure primary button was selected
+								if (result is ContentDialogResult.Primary)
+								{
+									SignToolPath = customDialog.SignToolPath!;
+									CertPath = customDialog.CertificatePath!;
+									CertCN = customDialog.CertificateCommonName!;
+									XMLPolicyPath = customDialog.XMLPolicyPath!;
+
+									// Sometimes the content dialog lingers on or re-appears so making sure it hides
+									customDialog.Hide();
+
+								}
+								else
+								{
+									return;
+								}
+
+								#endregion
+
+								// Add the unsigned policy rule option to the policy
+								CiRuleOptions.Set(filePath: XMLPolicyPath, rulesToAdd: [CiRuleOptions.PolicyRuleOptions.EnabledUnsignedSystemIntegrityPolicy]);
+
+								// Making sure SupplementalPolicySigners do not exist in the XML policy
+								CiPolicyHandler.RemoveSupplementalSigners(XMLPolicyPath);
+
+								// Define the path for the CIP file
+								string randomString = GUIDGenerator.GenerateUniqueGUID();
+								string xmlFileName = Path.GetFileName(XMLPolicyPath);
+								string CIPFilePath = Path.Combine(stagingArea.FullName, $"{xmlFileName}-{randomString}.cip");
+
+								string CIPp7SignedFilePath = Path.Combine(stagingArea.FullName, $"{xmlFileName}-{randomString}.cip.p7");
+
+								// Convert the XML file to CIP, overwriting the unsigned one
+								PolicyToCIPConverter.Convert(XMLPolicyPath, CIPFilePath);
+
+								// Sign the CIP
+								SignToolHelper.Sign(new FileInfo(CIPFilePath), new FileInfo(SignToolPath), CertCN);
+
+								// Rename the .p7 signed file to .cip
+								File.Move(CIPp7SignedFilePath, CIPFilePath, true);
+
+								// Deploy the signed CIP file
+								CiToolHelper.UpdatePolicy(CIPFilePath);
+
+								SiPolicy.SiPolicy policyObj = SiPolicy.Management.Initialize(XMLPolicyPath);
+
+								// The time of first stage of the signed policy removal
+								// Since policy object has the full ID, in upper case with curly brackets,
+								// We need to normalize them to match what the CiPolicyInfo class uses
+								UserConfiguration.Add(policyObj.PolicyID.Trim('{', '}').ToLowerInvariant(), DateTime.UtcNow);
 							}
-
-							#endregion
-
-							// Add the unsigned policy rule option to the policy
-							CiRuleOptions.Set(filePath: XMLPolicyPath, rulesToAdd: [CiRuleOptions.PolicyRuleOptions.EnabledUnsignedSystemIntegrityPolicy]);
-
-							// Making sure SupplementalPolicySigners do not exist in the XML policy
-							CiPolicyHandler.RemoveSupplementalSigners(XMLPolicyPath);
-
-							// Define the path for the CIP file
-							string randomString = GUIDGenerator.GenerateUniqueGUID();
-							string xmlFileName = Path.GetFileName(XMLPolicyPath);
-							string CIPFilePath = Path.Combine(stagingArea.FullName, $"{xmlFileName}-{randomString}.cip");
-
-							string CIPp7SignedFilePath = Path.Combine(stagingArea.FullName, $"{xmlFileName}-{randomString}.cip.p7");
-
-							// Convert the XML file to CIP, overwriting the unsigned one
-							PolicyToCIPConverter.Convert(XMLPolicyPath, CIPFilePath);
-
-							// Sign the CIP
-							SignToolHelper.Sign(new FileInfo(CIPFilePath), new FileInfo(SignToolPath), CertCN);
-
-							// Rename the .p7 signed file to .cip
-							File.Move(CIPp7SignedFilePath, CIPFilePath, true);
-
-							// Deploy the signed CIP file
-							CiToolHelper.UpdatePolicy(CIPFilePath);
-
 						}
 					}
-
-
-					// Refresh the DataGrid's policies and their count
-					RetrievePolicies();
 				}
 			}
 		}
 
 		finally
 		{
+			// Refresh the DataGrid's policies and their count
+			RetrievePolicies();
+
 			DeployedPolicies.IsHitTestVisible = true;
 			RetrievePoliciesButton.IsEnabled = true;
 			SearchBox.IsEnabled = true;
@@ -658,5 +695,37 @@ public sealed partial class ViewCurrentPolicies : Page
 	}
 
 #pragma warning restore CA1822
+
+
+	/// <summary>
+	/// If returns true, the signed policy can be removed
+	/// </summary>
+	/// <param name="policyID"></param>
+	/// <returns></returns>
+	private static bool VerifyRemovalEligibility(string policyID)
+	{
+		// When system was last reboot
+		DateTime lastRebootTimeUtc = DateTime.UtcNow - TimeSpan.FromMilliseconds(Environment.TickCount64);
+
+		Logger.Write($"System's last reboot was {lastRebootTimeUtc} (UTC)");
+
+		// When the policy's 1st stage was completed
+		DateTime? stage1RemovalTime = UserConfiguration.Query(policyID);
+
+		if (stage1RemovalTime is not null)
+		{
+			Logger.Write($"Signed policy with the ID '{policyID}' completed its 1st state at {stage1RemovalTime} (UTC)");
+
+			if (stage1RemovalTime < lastRebootTimeUtc)
+			{
+				Logger.Write("Signed policy is safe to be removed because system was restarted after 1st stage");
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 
 }


### PR DESCRIPTION
This new protection mechanism ensures the safe removal of signed policies. To complete the process securely, a system reboot is required after the first stage. The newly implemented protection verifies that the reboot has been performed before allowing the process to proceed to the final stage.

If the user forgets to reboot or is unsure whether it’s necessary, a prompt will appear to guide them through the process. This safeguard prevents accidental errors that could lead to boot failures, making the AppControl Manager even safer and more reliable when managing Signed App Control policies.

Wonder why Signed policies are important? [Check out this article](https://github.com/HotCakeX/Harden-Windows-Security/wiki/The-Strength-of-Signed-App-Control-Policies)

<br>

