### PR TITLE
Added support for catalog signed files in local file scans in the AppControl Manager

### DIFF
--- a/AppControl Manager/IntelGathering/LocalFilesScan.cs
+++ b/AppControl Manager/IntelGathering/LocalFilesScan.cs
@@ -152,11 +152,25 @@ internal static class LocalFilesScan
 						// If the file doesn't have certificates in itself, check for catalog signers
 						else if (AllSecurityCatalogHashes.TryGetValue(fileHashes.SHa1Authenticode!, out string? CurrentFilePathHashSHA1CatResult))
 						{
-							FileSignatureResults = AllCertificatesGrabber.GetAllFileSigners(CurrentFilePathHashSHA1CatResult);
+							try
+							{
+								FileSignatureResults = AllCertificatesGrabber.GetAllFileSigners(CurrentFilePathHashSHA1CatResult);
+							}
+							catch (HashMismatchInCertificateException)
+							{
+								Logger.Write($"The file '{file.FullName}' has hash mismatch.");
+							}
 						}
 						else if (AllSecurityCatalogHashes.TryGetValue(fileHashes.SHA256Authenticode!, out string? CurrentFilePathHashSHA256CatResult))
 						{
-							FileSignatureResults = AllCertificatesGrabber.GetAllFileSigners(CurrentFilePathHashSHA256CatResult);
+							try
+							{
+								FileSignatureResults = AllCertificatesGrabber.GetAllFileSigners(CurrentFilePathHashSHA256CatResult);
+							}
+							catch (HashMismatchInCertificateException)
+							{
+								Logger.Write($"The file '{file.FullName}' has hash mismatch.");
+							}
 						}
 
 						// Check the signatures again

--- a/AppControl Manager/MyRoots.xml
+++ b/AppControl Manager/MyRoots.xml
@@ -1,10 +1,3 @@
 ﻿<linker>
-  <assembly fullname="CommunityToolkit.WinUI.Extensions" preserve="all" />
-  <assembly fullname="CommunityToolkit.WinUI.UI.Controls.DataGrid" preserve="all" />
-  <assembly fullname="Microsoft.Web.WebView2.Core.Projection" preserve="all" />
-  <assembly fullname="Microsoft.Windows.SDK.NET" preserve="all" />
-  <assembly fullname="Microsoft.Xaml.Interactions" preserve="all" />
-  <assembly fullname="System.CodeDom" preserve="all" />
-  <assembly fullname="System.Management" preserve="all" />
-  <assembly fullname="WinRT.Runtime" preserve="all" />
+  <assembly fullname="CommunityToolkit.WinUI.UI.Controls.DataGrid" preserve="all"/>
 </linker>

--- a/AppControl Manager/Others/MeowOpener.cs
+++ b/AppControl Manager/Others/MeowOpener.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Xml;
 
 namespace AppControlManager.Others;
 
@@ -55,13 +54,6 @@ internal static partial class MeowParser
 		// Initializes a new HashSet to store the hashes.
 		HashSet<string> OutputHashSet = [];
 
-		// Creates a new XmlDocument instance.
-		XmlDocument PurrfectCatalogXMLDoc = new()
-		{
-			// Disables the XML resolver for security reasons.
-			XmlResolver = null
-		};
-
 		IntPtr MainCryptProviderHandle = IntPtr.Zero; // Initializes the handle to zero.
 		IntPtr MeowLogHandle = IntPtr.Zero; // Initializes the catalog context handle to zero.
 		IntPtr KittyPointer = IntPtr.Zero; // Pointer to iterate through catalog members, initialized to zero.
@@ -86,12 +78,6 @@ internal static partial class MeowParser
 				int lastWin32Error = Marshal.GetLastWin32Error();
 				Logger.Write($"CryptCATOpen failed with error code: {lastWin32Error}");
 			}
-
-			// Creates an XML element to represent the catalog file.
-			XmlElement catalogElement = PurrfectCatalogXMLDoc.CreateElement("MeowFile");
-
-			// Appends the element to the XML document.
-			_ = PurrfectCatalogXMLDoc.AppendChild(catalogElement);
 
 			// Iterates through the catalog members.
 			while ((KittyPointer = WinTrust.CryptCATEnumerateMember(MeowLogHandle, KittyPointer)) != IntPtr.Zero)

--- a/AppControl Manager/Pages/CreateSupplementalPolicy.xaml
+++ b/AppControl Manager/Pages/CreateSupplementalPolicy.xaml
@@ -509,25 +509,25 @@ Style="{StaticResource AccentButtonStyle}" Margin="0,0,15,0" Click="StrictKernel
 
 
                         <controls:SettingsCard x:Name="StrictKernelModeAutoDetectAllDriversSettingsCard" Description="Automatically detect and list all of the drivers on the system"
-          Header="Auto Driver Detection"
-          IsClickEnabled="True" IsActionIconVisible="False" Click="StrictKernelModeAutoDetectAllDriversSettingsCard_Click">
+                             Header="Auto Driver Detection"
+                             IsClickEnabled="True" IsActionIconVisible="False" Click="StrictKernelModeAutoDetectAllDriversSettingsCard_Click">
 
                             <Button x:Name="StrictKernelModeAutoDetectAllDriversButton" Content="Begin" Click="StrictKernelModeAutoDetectAllDriversButton_Click" />
 
                         </controls:SettingsCard>
 
                         <controls:SettingsCard x:Name="StrictKernelModeScanButtonSettingsCard" Description="Scan the event logs for Kernel-mode files only"
-                 Header="Scan Event Logs"
-                 IsClickEnabled="False" IsActionIconVisible="False" >
+                             Header="Scan Event Logs"
+                             IsClickEnabled="False" IsActionIconVisible="False" >
 
                             <controls:WrapPanel Orientation="Vertical" HorizontalSpacing="10" VerticalSpacing="10">
 
                                 <Button x:Name="StrictKernelModeScanButton" Click="StrictKernelModeScanButton_Click" HorizontalAlignment="Center" Content="Scan for All Kernel-mode Logs" />
 
                                 <Button x:Name="StrictKernelModeScanSinceLastRebootButton" Click="StrictKernelModeScanSinceLastRebootButton_Click" HorizontalAlignment="Center" Content="Scan for Kernel-mode Logs Since Last Reboot" />
-                           
+
                             </controls:WrapPanel>
-                       
+
                         </controls:SettingsCard>
 
 

--- a/AppControl Manager/Pages/CreateSupplementalPolicy.xaml.cs
+++ b/AppControl Manager/Pages/CreateSupplementalPolicy.xaml.cs
@@ -1383,7 +1383,7 @@ public sealed partial class CreateSupplementalPolicy : Page, Sidebar.IAnimatedIc
 		{
 			StrictKernelModeCreateButton.IsEnabled = false;
 			StrictKernelModeDeployToggleButton.IsEnabled = false;
-			StrictKernelModeAutoDetectAllDriversSettingsCard.IsEnabled = false;
+			StrictKernelModeAutoDetectAllDriversSettingsCard.IsClickEnabled = false;
 			StrictKernelModeAutoDetectAllDriversButton.IsEnabled = false;
 			StrictKernelModeScanButton.IsEnabled = false;
 			StrictKernelModeScanSinceLastRebootButton.IsEnabled = false;
@@ -1489,7 +1489,7 @@ public sealed partial class CreateSupplementalPolicy : Page, Sidebar.IAnimatedIc
 
 			StrictKernelModeCreateButton.IsEnabled = true;
 			StrictKernelModeDeployToggleButton.IsEnabled = true;
-			StrictKernelModeAutoDetectAllDriversSettingsCard.IsEnabled = true;
+			StrictKernelModeAutoDetectAllDriversSettingsCard.IsClickEnabled = true;
 			StrictKernelModeAutoDetectAllDriversButton.IsEnabled = true;
 			StrictKernelModeScanButton.IsEnabled = true;
 			StrictKernelModeScanSinceLastRebootButton.IsEnabled = true;
@@ -1522,6 +1522,8 @@ public sealed partial class CreateSupplementalPolicy : Page, Sidebar.IAnimatedIc
 			StrictKernelModeAutoDetectAllDriversButton.IsEnabled = false;
 			StrictKernelModeScanButton.IsEnabled = false;
 			StrictKernelModeScanSinceLastRebootButton.IsEnabled = false;
+			StrictKernelModeAutoDetectAllDriversSettingsCard.IsClickEnabled = false;
+			StrictKernelModeCreateButton.IsEnabled = false;
 
 			StrictKernelModeInfoBar.IsClosable = false;
 			StrictKernelModeInfoBar.IsOpen = true;
@@ -1625,6 +1627,8 @@ public sealed partial class CreateSupplementalPolicy : Page, Sidebar.IAnimatedIc
 			StrictKernelModeAutoDetectAllDriversButton.IsEnabled = true;
 			StrictKernelModeScanButton.IsEnabled = true;
 			StrictKernelModeScanSinceLastRebootButton.IsEnabled = true;
+			StrictKernelModeAutoDetectAllDriversSettingsCard.IsClickEnabled = true;
+			StrictKernelModeCreateButton.IsEnabled = true;
 		}
 	}
 

--- a/AppControl Manager/Pages/ViewFileCertificates.xaml
+++ b/AppControl Manager/Pages/ViewFileCertificates.xaml
@@ -79,6 +79,14 @@
 
             </controls:SettingsCard>
 
+            <controls:SettingsCard Description="Many files are signed using Security Catalogs. Enabling this option ensures accurate results. Security Catalogs are processed only once and reused in subsequent checks, enhancing performance."
+                          x:Name="IncludeSecurityCatalogsSettingsCard"
+       Header="Include Catalog Signers" Click="IncludeSecurityCatalogsSettingsCard_Click" IsClickEnabled="True" IsActionIconVisible="False">
+
+                <ToggleSwitch x:Name="IncludeSecurityCatalogsToggleSwitch" IsOn="True" />
+
+            </controls:SettingsCard>
+
         </StackPanel>
 
 

--- a/AppControl Manager/global.json
+++ b/AppControl Manager/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "9.0.101",
+        "version": "9.0.1",
         "rollForward": "latestMajor",
         "allowPrerelease": true
     }


### PR DESCRIPTION
* Added support for catalog signed files in local file scans. This is a prerequisite for a successful local driver scans since the majority of them are catalog signed. This also improves the overall accuracy of all file scans in the AppControl Manager.

* Added support for catalog signed files to the [View File Certificates page](https://github.com/HotCakeX/Harden-Windows-Security/wiki/View-File-Certificates).

<br>
