### PR TITLE
Minor improvements before AppControl Manager v.0.1.8.4 release

### DIFF
--- a/AppControl Manager/AppControl Manager.csproj
+++ b/AppControl Manager/AppControl Manager.csproj
@@ -113,7 +113,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.XmlSerializer.Generator" Version="9.0.0" />
+    <DotNetCliToolReference Include="Microsoft.XmlSerializer.Generator" Version="9.0.1" />
   </ItemGroup>
 
   <!--

--- a/AppControl Manager/Pages/CreatePolicy.xaml.cs
+++ b/AppControl Manager/Pages/CreatePolicy.xaml.cs
@@ -811,16 +811,6 @@ public sealed partial class CreatePolicy : Page
 				// Set policy name and reset the policy ID
 				string policyID = SetCiPolicyInfo.Set(policyPath, true, null, null, null);
 
-				// Save the policyID and time of deployment of the audit mode policy in user configs
-				if (useNoFlightRoots)
-				{
-					_ = UserConfiguration.Set(StrictKernelNoFlightRootsPolicyGUID: Guid.Parse(policyID), StrictKernelModePolicyTimeOfDeployment: DateTime.UtcNow);
-				}
-				else
-				{
-					_ = UserConfiguration.Set(StrictKernelPolicyGUID: Guid.Parse(policyID), StrictKernelModePolicyTimeOfDeployment: DateTime.UtcNow);
-				}
-
 				// Copy the policy to the user configurations directory
 				File.Copy(policyPath, finalPolicyPath, true);
 

--- a/AppControl Manager/Pages/CreateSupplementalPolicy.xaml.cs
+++ b/AppControl Manager/Pages/CreateSupplementalPolicy.xaml.cs
@@ -1335,7 +1335,7 @@ public sealed partial class CreateSupplementalPolicy : Page, Sidebar.IAnimatedIc
 				StrictKernelModeInfoBar.Message = "Successfully scanned the system for events";
 			}
 
-
+			StrictKernelModeInfoBar.IsClosable = true;
 
 		}
 	}
@@ -1494,6 +1494,7 @@ public sealed partial class CreateSupplementalPolicy : Page, Sidebar.IAnimatedIc
 			StrictKernelModeScanButton.IsEnabled = true;
 			StrictKernelModeScanSinceLastRebootButton.IsEnabled = true;
 			StrictKernelModeBrowseForBasePolicyButton.IsEnabled = true;
+			StrictKernelModeInfoBar.IsClosable = true;
 
 		}
 
@@ -1530,7 +1531,6 @@ public sealed partial class CreateSupplementalPolicy : Page, Sidebar.IAnimatedIc
 			StrictKernelModeInfoBar.Severity = InfoBarSeverity.Informational;
 			StrictKernelModeInfoBar.Message = "Scanning the system for drivers";
 			StrictKernelModeSection.IsExpanded = true;
-
 
 			List<FileInfo> kernelModeDriversList = [];
 
@@ -1591,7 +1591,8 @@ public sealed partial class CreateSupplementalPolicy : Page, Sidebar.IAnimatedIc
 				HashSet<FileIdentity> LocalFilesResults = LocalFilesScan.Scan(kernelModeDriversList, 2, null, null);
 
 				// Add the results to the DataGrid
-				foreach (FileIdentity item in LocalFilesResults.Where(fileIdentity => fileIdentity.SISigningScenario is 0)) // && fileIdentity.SignatureStatus is SignatureStatus.IsSigned
+				// Only signed kernel-mode files
+				foreach (FileIdentity item in LocalFilesResults.Where(fileIdentity => fileIdentity.SISigningScenario is 0 && fileIdentity.SignatureStatus is SignatureStatus.IsSigned))
 				{
 					_ = DispatcherQueue.TryEnqueue(() =>
 					{
@@ -1629,6 +1630,8 @@ public sealed partial class CreateSupplementalPolicy : Page, Sidebar.IAnimatedIc
 			StrictKernelModeScanSinceLastRebootButton.IsEnabled = true;
 			StrictKernelModeAutoDetectAllDriversSettingsCard.IsClickEnabled = true;
 			StrictKernelModeCreateButton.IsEnabled = true;
+
+			StrictKernelModeInfoBar.IsClosable = true;
 		}
 	}
 

--- a/AppControl Manager/Pages/Settings.xaml
+++ b/AppControl Manager/Pages/Settings.xaml
@@ -117,14 +117,6 @@ Style="{StaticResource BodyTextBlockStyle}">
                                         <AppBarButton Icon="Folder" Label="Browse" Click="BrowseButton_Click" Tag="CertificatePath"/>
                                     </CommandBar>
                                 </controls:WrapPanel>
-                                <!-- Strict Kernel Mode Policy Time of Deployment -->
-                                <controls:WrapPanel Orientation="Horizontal" Margin="0,0,0,10">
-                                    <TextBox Header="Strict Kernel Mode Policy Time of Deployment (YYYY-MM-DD):" x:Name="StrictKernelModePolicyTimeTextBox" MinWidth="300" Margin="0,0,10,0" VerticalAlignment="Center"/>
-                                    <CommandBar Background="Transparent" IsOpen="False" DefaultLabelPosition="Right" VerticalAlignment="Center" Margin="0,25,0,0">
-                                        <AppBarButton Icon="Save" Label="Save" Click="EditButton_Click" Tag="StrictKernelModePolicyTime"/>
-                                        <AppBarButton Icon="Clear" Label="Clear" Click="ClearButton_Click" Tag="StrictKernelModePolicyTime"/>
-                                    </CommandBar>
-                                </controls:WrapPanel>
                             </StackPanel>
                         </controls:SettingsCard>
                     </controls:SettingsExpander.Items>

--- a/AppControl Manager/Pages/Settings.xaml.cs
+++ b/AppControl Manager/Pages/Settings.xaml.cs
@@ -301,7 +301,6 @@ public sealed partial class Settings : Page
 		SignToolCustomPathTextBox.Text = userConfig.SignToolCustomPath ?? string.Empty;
 		CertificateCommonNameAutoSuggestBox.Text = userConfig.CertificateCommonName ?? string.Empty;
 		CertificatePathTextBox.Text = userConfig.CertificatePath ?? string.Empty;
-		StrictKernelModePolicyTimeTextBox.Text = userConfig.StrictKernelModePolicyTimeOfDeployment?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) ?? string.Empty;
 	}
 
 	// When the edit button of any field is pressed
@@ -329,9 +328,6 @@ public sealed partial class Settings : Page
 			case "CertificatePath":
 				newValue = CertificatePathTextBox.Text;
 				break;
-			case "StrictKernelModePolicyTime":
-				newValue = StrictKernelModePolicyTimeTextBox.Text;
-				break;
 			default:
 				break;
 		}
@@ -341,8 +337,7 @@ public sealed partial class Settings : Page
 			UnsignedPolicyPath: string.Equals(fieldName, "UnsignedPolicyPath", StringComparison.OrdinalIgnoreCase) ? newValue : null,
 			SignToolCustomPath: string.Equals(fieldName, "SignToolCustomPath", StringComparison.OrdinalIgnoreCase) ? newValue : null,
 			CertificateCommonName: string.Equals(fieldName, "CertificateCommonName", StringComparison.OrdinalIgnoreCase) ? newValue : null,
-			CertificatePath: string.Equals(fieldName, "CertificatePath", StringComparison.OrdinalIgnoreCase) ? newValue : null,
-			StrictKernelModePolicyTimeOfDeployment: string.Equals(fieldName, "StrictKernelModePolicyTime", StringComparison.OrdinalIgnoreCase) ? TryParseDateTime(newValue) : null
+			CertificatePath: string.Equals(fieldName, "CertificatePath", StringComparison.OrdinalIgnoreCase) ? newValue : null
 		);
 
 		Logger.Write($"Edited {fieldName} to {newValue}");
@@ -355,14 +350,11 @@ public sealed partial class Settings : Page
 		string? fieldName = button!.Tag.ToString();
 
 		UserConfiguration.Remove(
-			string.Equals(fieldName, "SignedPolicyPath", StringComparison.OrdinalIgnoreCase),
-			string.Equals(fieldName, "UnsignedPolicyPath", StringComparison.OrdinalIgnoreCase),
-			string.Equals(fieldName, "SignToolCustomPath", StringComparison.OrdinalIgnoreCase),
-			string.Equals(fieldName, "CertificateCommonName", StringComparison.OrdinalIgnoreCase),
-			string.Equals(fieldName, "CertificatePath", StringComparison.OrdinalIgnoreCase),
-			string.Equals(fieldName, "StrictKernelPolicyGUID", StringComparison.OrdinalIgnoreCase),
-			string.Equals(fieldName, "StrictKernelNoFlightRootsPolicyGUID", StringComparison.OrdinalIgnoreCase),
-			string.Equals(fieldName, "StrictKernelModePolicyTime", StringComparison.OrdinalIgnoreCase)
+			SignedPolicyPath: string.Equals(fieldName, "SignedPolicyPath", StringComparison.OrdinalIgnoreCase),
+			UnsignedPolicyPath: string.Equals(fieldName, "UnsignedPolicyPath", StringComparison.OrdinalIgnoreCase),
+			SignToolCustomPath: string.Equals(fieldName, "SignToolCustomPath", StringComparison.OrdinalIgnoreCase),
+			CertificateCommonName: string.Equals(fieldName, "CertificateCommonName", StringComparison.OrdinalIgnoreCase),
+			CertificatePath: string.Equals(fieldName, "CertificatePath", StringComparison.OrdinalIgnoreCase)
 		);
 
 		switch (fieldName)
@@ -381,9 +373,6 @@ public sealed partial class Settings : Page
 				break;
 			case "CertificatePath":
 				CertificatePathTextBox.Text = string.Empty;
-				break;
-			case "StrictKernelModePolicyTime":
-				StrictKernelModePolicyTimeTextBox.Text = string.Empty;
 				break;
 			default:
 				break;

--- a/AppControl Manager/Pages/StrictKernelPolicyScanResults.xaml
+++ b/AppControl Manager/Pages/StrictKernelPolicyScanResults.xaml
@@ -37,7 +37,7 @@
             <TextBlock
                 TextWrapping="WrapWholeWords"
                 Style="{StaticResource BodyTextBlockStyle}">
-                
+
                 <Span>
                     View the detected Kernel-mode files that will be used to create the <Run Foreground="{ThemeResource SystemAccentColor}">enforced mode</Run> policy. Remove items you don't want to be included in the final Strict Kernel-mode policy from the list.
                 </Span>


### PR DESCRIPTION
* Tidied up the settings page for user configurations.

* Adjusted XML Serializer version

* Removed unnecessary user configurations assignments for strict kernel-mode policy

* Adjusted Infobar states during runtime.
