### PR TITLE
Added direct Intune cloud deployment to AppControl Manager

### DIFF
--- a/AppControl Manager/App.xaml.cs
+++ b/AppControl Manager/App.xaml.cs
@@ -45,7 +45,7 @@ public partial class App : Application
 	{
 		this.InitializeComponent();
 
-		Logger.Write("App Startup");
+		Logger.Write($"App Startup, .NET runtime version: {Environment.Version}");
 
 		// Give beautiful outline to the UI elements when using the tab key and keyboard for navigation
 		// https://learn.microsoft.com/en-us/windows/apps/design/style/reveal-focus

--- a/AppControl Manager/AppControl Manager.csproj
+++ b/AppControl Manager/AppControl Manager.csproj
@@ -144,6 +144,7 @@
     <PackageReference Include="CommunityToolkit.WinUI.Lottie" Version="8.1.240821" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.DataGrid" Version="7.1.2" />
     <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.3.1" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.67.2" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.106">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/AppControl Manager/Others/Intune.cs
+++ b/AppControl Manager/Others/Intune.cs
@@ -1,0 +1,472 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client;
+
+namespace AppControlManager.Others;
+
+internal static class Intune
+{
+
+	private const string ClientId = "14d82eec-204b-4c2f-b7e8-296a70dab67e";
+
+	// Scopes required to create and assign device configurations
+	private static readonly string[] Scopes = [
+		"Group.Read.All", // For Groups enumeration
+		"Group.ReadWrite.All",  // For Groups enumeration
+		"DeviceManagementConfiguration.ReadWrite.All",
+		"DeviceManagementConfiguration.Read.All" ,
+		"DeviceManagementManagedDevices.ReadWrite.All",
+		"DeviceManagementApps.ReadWrite.All"
+		];
+
+
+	private const string DeviceConfigurationsURL = "https://graph.microsoft.com/v1.0/deviceManagement/deviceConfigurations";
+
+	private static readonly JsonSerializerOptions JsonOpt = new()
+	{
+		DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+		WriteIndented = true
+	};
+
+	private static AuthenticationResult? authenticationResult;
+
+	// Initialize the Public Client Application
+	private static readonly IPublicClientApplication App = PublicClientApplicationBuilder.Create(ClientId)
+			.WithAuthority(AzureCloudInstance.AzurePublic, "common")
+			.WithRedirectUri("http://localhost")
+			.Build();
+
+
+	// Dictionary to store Group names as keys and Group IDs as values
+	private static readonly Dictionary<string, string> Groups = [];
+
+	private const string GroupsUrl = "https://graph.microsoft.com/v1.0/groups";
+
+
+	internal static async Task FetchGroups()
+	{
+		if (authenticationResult is null)
+		{
+			throw new InvalidOperationException("You need to authenticate first.");
+		}
+
+		using SecHttpClient httpClient = new();
+
+		// Set up the HTTP headers
+		httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", authenticationResult.AccessToken);
+		httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+		try
+		{
+			// Make the request to get all groups
+			HttpResponseMessage response = await httpClient.GetAsync(new Uri(GroupsUrl));
+
+			if (response.IsSuccessStatusCode)
+			{
+				string content = await response.Content.ReadAsStringAsync();
+				JsonElement groupsJson = JsonSerializer.Deserialize<JsonElement>(content);
+
+				if (groupsJson.TryGetProperty("value", out JsonElement groups))
+				{
+					Groups.Clear(); // Clear the dictionary before adding new entries
+
+					foreach (JsonElement group in groups.EnumerateArray())
+					{
+						string? groupName = group.GetProperty("displayName").GetString();
+						string? groupId = group.GetProperty("id").GetString();
+
+						if (!string.IsNullOrEmpty(groupName) && !string.IsNullOrEmpty(groupId))
+						{
+							Groups[groupName] = groupId;
+						}
+					}
+
+					Logger.Write($"Successfully fetched {Groups.Count} groups.");
+				}
+				else
+				{
+					Logger.Write("No groups found in the response.");
+				}
+			}
+			else
+			{
+				Logger.Write($"Failed to fetch groups. Status code: {response.StatusCode}");
+				string errorContent = await response.Content.ReadAsStringAsync();
+				Logger.Write($"Error details: {errorContent}");
+			}
+		}
+		catch (Exception ex)
+		{
+			Logger.Write($"An error occurred while fetching groups: {ex.Message}");
+		}
+	}
+
+	internal static Dictionary<string, string> GetGroups()
+	{
+		return new Dictionary<string, string>(Groups); // Return a copy of the groups dictionary
+	}
+
+	internal static async Task SignIn()
+	{
+
+		authenticationResult = null;
+
+		// Attempt silent authentication
+		IEnumerable<IAccount> accounts = await App.GetAccountsAsync();
+
+		try
+		{
+			authenticationResult = await App.AcquireTokenSilent(Scopes, accounts.FirstOrDefault())
+				.ExecuteAsync();
+		}
+		catch (MsalUiRequiredException)
+		{
+			// Fall back to interactive login if silent authentication fails
+			authenticationResult = await App.AcquireTokenInteractive(Scopes)
+				.WithPrompt(Prompt.SelectAccount)
+				.WithUseEmbeddedWebView(false)
+				.ExecuteAsync();
+		}
+	}
+
+
+	internal static async Task SignOut()
+	{
+		if (authenticationResult is null)
+		{
+			Logger.Write("No user is currently signed in.");
+			return;
+		}
+
+
+		// Get the cached accounts
+		IEnumerable<IAccount> accounts = await App.GetAccountsAsync();
+
+		try
+		{
+			foreach (IAccount account in accounts)
+			{
+				await App.RemoveAsync(account);
+				Logger.Write($"Signed out account: {account.Username}");
+			}
+
+			// Clear the current authentication result
+			authenticationResult = null;
+
+			Logger.Write("All accounts signed out successfully.");
+		}
+		catch (Exception ex)
+		{
+			Logger.Write($"An error occurred during sign-out: {ex.Message}");
+		}
+	}
+
+
+
+	/// <summary>
+	/// Grabs the path to a CIP file and upload it to Intune
+	/// </summary>
+	/// <param name="policyPath"></param>
+	internal static async Task UploadPolicyToIntune(string policyPath, string? groupName)
+	{
+
+		DirectoryInfo stagingArea = StagingArea.NewStagingArea("IntuneCIPUpload");
+
+		string tempPolicyPath = Path.Combine(stagingArea.FullName, "policy.bin");
+
+		File.Copy(policyPath, tempPolicyPath, true);
+
+		// https://learn.microsoft.com/en-us/windows/security/application-security/application-control/app-control-for-business/deployment/deploy-appcontrol-policies-using-intune#deploy-app-control-policies-with-custom-oma-uri
+		string base64String = ConvertBinFileToBase64(tempPolicyPath, 350000);
+
+		if (authenticationResult is null)
+		{
+			throw new InvalidOperationException("You need to authenticate first");
+		}
+
+		// Call Microsoft Graph API to create the custom policy
+		string? policyId = await CreateCustomPolicy(authenticationResult.AccessToken, base64String);
+
+		Logger.Write($"{policyId} is the ID of the policy that was created");
+
+
+		if (!string.IsNullOrWhiteSpace(groupName) && policyId is not null)
+		{
+			if (Groups.TryGetValue(groupName, out string? groupId))
+			{
+				await AssignPolicyToUsers(policyId, authenticationResult.AccessToken, groupId);
+			}
+		}
+
+
+		//		await GetPoliciesAndAssignments(result.AccessToken);
+	}
+
+
+
+
+
+	private static async Task AssignPolicyToUsers(string policyId, string accessToken, string groupID)
+	{
+		using SecHttpClient httpClient = new();
+
+		// Set up the HTTP headers
+		httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+		httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+		// Create the payload with a Dictionary to handle special characters like @odata.type
+		var assignmentPayload = new
+		{
+			target = new Dictionary<string, object>
+			{
+				{ "@odata.type", "#microsoft.graph.groupAssignmentTarget" },
+				{ "groupId", groupID }
+			}
+		};
+
+		// Serialize the assignment payload to JSON
+		string jsonPayload = JsonSerializer.Serialize(assignmentPayload, JsonOpt);
+
+		using StringContent content = new(jsonPayload, Encoding.UTF8, "application/json");
+
+		// Send the POST request to assign the policy to the group
+		HttpResponseMessage response = await httpClient.PostAsync(
+			new Uri($"{DeviceConfigurationsURL}/{policyId}/assignments"),
+			content
+		);
+
+		// Process the response
+		if (response.IsSuccessStatusCode)
+		{
+			string responseContent = await response.Content.ReadAsStringAsync();
+			Logger.Write("Policy assigned successfully:");
+			Logger.Write(responseContent);
+		}
+		else
+		{
+			Logger.Write($"Failed to assign policy. Status code: {response.StatusCode}");
+			string errorContent = await response.Content.ReadAsStringAsync();
+			Logger.Write($"Error details: {errorContent}");
+		}
+	}
+
+
+
+
+
+	/// <summary>
+	/// https://learn.microsoft.com/en-us/mem/intune/configuration/custom-settings-windows-10
+	/// </summary>
+	/// <param name="accessToken"></param>
+	/// <param name="policyData"></param>
+	/// <returns></returns>
+	private static async Task<string?> CreateCustomPolicy(string accessToken, string policyData)
+	{
+		// Create the policy object
+		Windows10CustomConfiguration customPolicy = new()
+		{
+			ODataType = "#microsoft.graph.windows10CustomConfiguration",
+			DisplayName = "Custom OMA-URI Policy",
+			Description = "Custom policy for Application Control",
+			OmaSettings =
+			[
+				new OmaSettingBase64
+				{
+					ODataType = "microsoft.graph.omaSettingBase64",
+					DisplayName = "Application Control Policy",
+					Description = "Configure application control policy using OMA-URI.",
+					OmaUri = "./Vendor/MSFT/ApplicationControl/Policies/d41d8cd9-8f00-b204-e980-0998ecf8427e/Policy",
+					FileName = "Policy.bin",
+					Value = policyData
+				}
+			],
+			Platforms = ["windows10AndLater"]
+		};
+
+		// Serialize the policy object to JSON
+		string jsonPayload = JsonSerializer.Serialize(customPolicy, JsonOpt);
+
+		using SecHttpClient httpClient = new();
+
+		// Set up the HTTP headers
+		httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+		httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+		using StringContent content = new(jsonPayload, Encoding.UTF8, "application/json");
+
+		// Send the POST request
+		HttpResponseMessage response = await httpClient.PostAsync(
+			new Uri(DeviceConfigurationsURL),
+			content
+		);
+
+		// Process the response
+		if (response.IsSuccessStatusCode)
+		{
+			string responseContent = await response.Content.ReadAsStringAsync();
+			Logger.Write("Custom policy created successfully:");
+			Logger.Write(responseContent);
+
+			// Extract the policy ID from the response
+			JsonElement responseJson = JsonSerializer.Deserialize<JsonElement>(responseContent);
+			return responseJson.GetProperty("id").GetString();
+		}
+		else
+		{
+			Logger.Write($"Failed to create custom policy. Status code: {response.StatusCode}");
+			string errorContent = await response.Content.ReadAsStringAsync();
+			Logger.Write($"Error details: {errorContent}");
+			return null;
+		}
+	}
+
+
+
+
+
+	private static async Task GetPoliciesAndAssignments(string accessToken)
+	{
+		using SecHttpClient httpClient = new();
+
+		// Set up the HTTP headers
+		httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+		httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+		try
+		{
+			// Fetch all policies
+			HttpResponseMessage response = await httpClient.GetAsync(new Uri(DeviceConfigurationsURL));
+
+			if (response.IsSuccessStatusCode)
+			{
+				string content = await response.Content.ReadAsStringAsync();
+				JsonElement policiesJson = JsonSerializer.Deserialize<JsonElement>(content);
+
+				// Iterate through each policy
+				if (policiesJson.TryGetProperty("value", out JsonElement policies))
+				{
+					foreach (JsonElement policy in policies.EnumerateArray())
+					{
+						string? policyId = policy.GetProperty("id").GetString();
+						string? policyName = policy.GetProperty("displayName").GetString();
+						Logger.Write($"Policy ID: {policyId}");
+						Logger.Write($"Policy Name: {policyName}");
+
+						// Fetch assignments for the current policy
+						HttpResponseMessage assignmentsResponse = await httpClient.GetAsync(new Uri($"{DeviceConfigurationsURL}/{policyId}/assignments"));
+
+						if (assignmentsResponse.IsSuccessStatusCode)
+						{
+							string assignmentsContent = await assignmentsResponse.Content.ReadAsStringAsync();
+							JsonElement assignmentsJson = JsonSerializer.Deserialize<JsonElement>(assignmentsContent);
+
+							if (assignmentsJson.TryGetProperty("value", out JsonElement assignments))
+							{
+								Logger.Write("Assignments:");
+								foreach (JsonElement assignment in assignments.EnumerateArray())
+								{
+									JsonElement target = assignment.GetProperty("target");
+									string? targetType = target.GetProperty("@odata.type").GetString();
+									Logger.Write($" - Target Type: {targetType}");
+
+									if (targetType == "#microsoft.graph.groupAssignmentTarget" && target.TryGetProperty("groupId", out JsonElement groupId))
+									{
+										Logger.Write($"   Group ID: {groupId.GetString()}");
+									}
+								}
+							}
+							else
+							{
+								Logger.Write("No assignments found.");
+							}
+						}
+						else
+						{
+							Logger.Write($"Failed to fetch assignments for Policy ID: {policyId}. Status code: {assignmentsResponse.StatusCode}");
+						}
+
+						Logger.Write(""); // Add a blank line between policies
+					}
+				}
+			}
+			else
+			{
+				Logger.Write($"Failed to fetch policies. Status code: {response.StatusCode}");
+				string errorContent = await response.Content.ReadAsStringAsync();
+				Logger.Write($"Error details: {errorContent}");
+			}
+		}
+		catch (Exception ex)
+		{
+			Logger.Write($"An error occurred: {ex.Message}");
+		}
+	}
+
+
+	// Define the class structure for the custom policy
+	public class Windows10CustomConfiguration
+	{
+		[JsonPropertyName("@odata.type")]
+		public string? ODataType { get; set; }
+
+		[JsonPropertyName("displayName")]
+		public string? DisplayName { get; set; }
+
+		[JsonPropertyName("description")]
+		public string? Description { get; set; }
+
+		[JsonPropertyName("omaSettings")]
+		public OmaSettingBase64[]? OmaSettings { get; set; }
+
+		[JsonPropertyName("platforms")]
+		public string[]? Platforms { get; set; }
+	}
+
+
+	public class OmaSettingBase64
+	{
+		[JsonPropertyName("@odata.type")]
+		public string? ODataType { get; set; }
+
+		[JsonPropertyName("displayName")]
+		public string? DisplayName { get; set; }
+
+		[JsonPropertyName("description")]
+		public string? Description { get; set; }
+
+		[JsonPropertyName("omaUri")]
+		public string? OmaUri { get; set; }
+
+		[JsonPropertyName("fileName")]
+		public string? FileName { get; set; }
+
+		[JsonPropertyName("value")]
+		public string? Value { get; set; }
+	}
+
+
+
+	private static string ConvertBinFileToBase64(string filePath, int maxSizeInBytes)
+	{
+		FileInfo fileInfo = new(filePath);
+
+		// Check the file size
+		if (fileInfo.Length > maxSizeInBytes)
+		{
+			throw new InvalidOperationException($"The file size exceeds the limit of {maxSizeInBytes} bytes.");
+		}
+
+		// Read the file and convert to Base64
+		byte[] fileBytes = File.ReadAllBytes(filePath);
+		return Convert.ToBase64String(fileBytes);
+	}
+
+}

--- a/AppControl Manager/Others/Intune.cs
+++ b/AppControl Manager/Others/Intune.cs
@@ -384,7 +384,7 @@ internal static class Intune
 
 
 
-
+	/*
 	private static async Task GetPoliciesAndAssignments(string accessToken)
 	{
 		using SecHttpClient httpClient = new();
@@ -455,10 +455,10 @@ internal static class Intune
 			throw new InvalidOperationException($"Error details: {errorContent}");
 		}
 	}
-
+	*/
 
 	// Define the class structure for the custom policy
-	public class Windows10CustomConfiguration
+	public sealed class Windows10CustomConfiguration
 	{
 		[JsonPropertyName("@odata.type")]
 		public string? ODataType { get; set; }
@@ -477,7 +477,7 @@ internal static class Intune
 	}
 
 
-	public class OmaSettingBase64
+	public sealed class OmaSettingBase64
 	{
 		[JsonPropertyName("@odata.type")]
 		public string? ODataType { get; set; }

--- a/AppControl Manager/Pages/Deployment.xaml
+++ b/AppControl Manager/Pages/Deployment.xaml
@@ -82,6 +82,48 @@
                     <win:RepositionThemeTransition IsStaggeringEnabled="False" />
                 </win:StackPanel.ChildrenTransitions>
 
+                <controls:SettingsExpander x:Name="IntuneDeploymentSettingsExpander"
+                     Description="Deploy the policies remotely to the Intune instead of the local system"
+                     Header="Use Intune Deployment"
+           HeaderIcon="{ui:FontIcon Glyph=&#xEA91;}">
+
+                    <TextBlock x:Name="LocalIntuneStatusTextBox" Text="Local Deployment is Currently Active" TextWrapping="Wrap" />
+
+                    <controls:SettingsExpander.Items>
+
+                        <controls:SettingsCard
+                            Description="Sign into your tenant to allow for remote deployment. Make sure you have the necessary permissions."
+                            Header="Entra ID Sign In"
+                            HeaderIcon="{ui:FontIcon Glyph=&#xEC27;}" IsClickEnabled="False" IsActionIconVisible="False">
+
+                            <controls:WrapPanel Orientation="Horizontal" HorizontalSpacing="15" VerticalSpacing="15">
+
+                                <Button Content="Sign In" x:Name="IntuneSignInButton" Click="IntuneSignInButton_Click"/>
+                                
+                                <Button Content="Sign Out" IsEnabled="False" x:Name="IntuneSignOutButton" Click="IntuneSignOutButton_Click"/>
+
+                            </controls:WrapPanel>
+
+                        </controls:SettingsCard>
+
+                        <controls:SettingsCard
+                    Description="Select one of the security groups to assign to the policy in Intune"
+                    Header="Group Assignment (Optional)"
+                    HeaderIcon="{ui:FontIcon Glyph=&#xF0B9;}" IsClickEnabled="False" IsActionIconVisible="False">
+
+                            <controls:WrapPanel Orientation="Horizontal" HorizontalSpacing="15" VerticalSpacing="15">
+
+                                <Button IsEnabled="False" x:Name="RefreshIntuneGroupsButton" Content="Refresh" Click="RefreshIntuneGroupsButton_Click" />
+
+                                <ComboBox IsEnabled="False" x:Name="IntuneGroupsComboBox" />
+
+                            </controls:WrapPanel>
+
+                        </controls:SettingsCard>
+                    </controls:SettingsExpander.Items>
+                </controls:SettingsExpander>
+
+
                 <controls:SettingsCard
                 Description="Browse for XML policy file(s) to deploy unsigned on the system"
                 Header="Select unsigned XML policy file(s)"

--- a/AppControl Manager/Pages/Deployment.xaml
+++ b/AppControl Manager/Pages/Deployment.xaml
@@ -99,8 +99,10 @@
                             <controls:WrapPanel Orientation="Horizontal" HorizontalSpacing="15" VerticalSpacing="15">
 
                                 <Button Content="Sign In" x:Name="IntuneSignInButton" Click="IntuneSignInButton_Click"/>
-                                
+
                                 <Button Content="Sign Out" IsEnabled="False" x:Name="IntuneSignOutButton" Click="IntuneSignOutButton_Click"/>
+
+                                <Button Content="Cancel Sign In" x:Name="IntuneCancelSignInButton" IsEnabled="False" Click="IntuneCancelSignInButton_Click"/>
 
                             </controls:WrapPanel>
 

--- a/AppControl Manager/Pages/Deployment.xaml.cs
+++ b/AppControl Manager/Pages/Deployment.xaml.cs
@@ -9,6 +9,7 @@ using AppControlManager.Others;
 using AppControlManager.SiPolicy;
 using AppControlManager.SiPolicyIntel;
 using AppControlManager.XMLOps;
+using CommunityToolkit.WinUI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
@@ -21,6 +22,9 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 	private readonly HashSet<string> XMLFiles = [];
 	private readonly HashSet<string> SignedXMLFiles = [];
 	private readonly HashSet<string> CIPFiles = [];
+
+	// When true, policies will be deployed to Intune instead of locally
+	private bool deployToIntune;
 
 	public Deployment()
 	{
@@ -143,7 +147,7 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 			MainProgressRing.Visibility = Visibility.Visible;
 
 			// Deploy the selected files
-			await Task.Run(() =>
+			await Task.Run(async () =>
 			{
 
 				DirectoryInfo stagingArea = StagingArea.NewStagingArea("UnsignedDeployments");
@@ -174,24 +178,35 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 					// Convert the XML file to CIP
 					PolicyToCIPConverter.Convert(file, CIPFilePath);
 
-					// Deploy the CIP file
-					CiToolHelper.UpdatePolicy(CIPFilePath);
 
-					// Delete the CIP file after deployment
-					File.Delete(CIPFilePath);
-
-					// Don't need to deploy it for the recommended block rules since they are only explicit Deny mode policies
-					if (!string.Equals(policyObject.FriendlyName, "Microsoft Windows Recommended User Mode BlockList", StringComparison.OrdinalIgnoreCase))
+					if (deployToIntune)
 					{
-						if (!string.Equals(policyObject.FriendlyName, "Microsoft Windows Driver Policy", StringComparison.OrdinalIgnoreCase))
+						await DeployToIntunePrivate(CIPFilePath);
+
+						// Delete the CIP file after deployment
+						File.Delete(CIPFilePath);
+					}
+					else
+					{
+						// Deploy the CIP file locally
+						CiToolHelper.UpdatePolicy(CIPFilePath);
+
+						// Delete the CIP file after deployment
+						File.Delete(CIPFilePath);
+
+						// Don't need to deploy it for the recommended block rules since they are only explicit Deny mode policies
+						if (!string.Equals(policyObject.FriendlyName, "Microsoft Windows Recommended User Mode BlockList", StringComparison.OrdinalIgnoreCase))
 						{
-							// Make sure the policy is a base policy and it doesn't have allow all rule
-							if (policyObject.PolicyType is PolicyType.BasePolicy)
+							if (!string.Equals(policyObject.FriendlyName, "Microsoft Windows Driver Policy", StringComparison.OrdinalIgnoreCase))
 							{
-								if (!CheckForAllowAll.Check(file))
+								// Make sure the policy is a base policy and it doesn't have allow all rule
+								if (policyObject.PolicyType is PolicyType.BasePolicy)
 								{
-									// Deploy the AppControlManager supplemental policy
-									SupplementalForSelf.Deploy(stagingArea.FullName, policyObject.PolicyID);
+									if (!CheckForAllowAll.Check(file))
+									{
+										// Deploy the AppControlManager supplemental policy
+										SupplementalForSelf.Deploy(stagingArea.FullName, policyObject.PolicyID);
+									}
 								}
 							}
 						}
@@ -298,7 +313,7 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 			MainProgressRing.Visibility = Visibility.Visible;
 
 			// Deploy the selected files
-			await Task.Run(() =>
+			await Task.Run(async () =>
 			{
 
 				DirectoryInfo stagingArea = StagingArea.NewStagingArea("SignedDeployments");
@@ -335,38 +350,48 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 					// Rename the .p7 signed file to .cip
 					File.Move(CIPp7SignedFilePath, CIPFilePath, true);
 
-					// Get all of the deployed base and supplemental policies on the system
-					List<CiPolicyInfo> policies = CiToolHelper.GetPolicies(false, true, true);
 
-					CiPolicyInfo? possibleAlreadyDeployedUnsignedVersion = policies.
-					FirstOrDefault(x => string.Equals(policyObject.PolicyID.Trim('{', '}'), x.PolicyID, StringComparison.OrdinalIgnoreCase));
-
-					if (possibleAlreadyDeployedUnsignedVersion is not null)
+					if (deployToIntune)
 					{
-						Logger.Write($"A policy with the same PolicyID {possibleAlreadyDeployedUnsignedVersion.PolicyID} is already deployed on the system in Unsigned version. Removing it before deployed the signed version to prevent boot failures.");
-
-						CiToolHelper.RemovePolicy(possibleAlreadyDeployedUnsignedVersion.PolicyID!);
+						await DeployToIntunePrivate(CIPFilePath);
 					}
-
-					// Don't need to deploy it for the recommended block rules since they are only explicit Deny mode policies
-					if (!string.Equals(policyObject.FriendlyName, "Microsoft Windows Recommended User Mode BlockList", StringComparison.OrdinalIgnoreCase))
+					else
 					{
-						if (!string.Equals(policyObject.FriendlyName, "Microsoft Windows Driver Policy", StringComparison.OrdinalIgnoreCase))
+
+						// Get all of the deployed base and supplemental policies on the system
+						List<CiPolicyInfo> policies = CiToolHelper.GetPolicies(false, true, true);
+
+						CiPolicyInfo? possibleAlreadyDeployedUnsignedVersion = policies.
+						FirstOrDefault(x => string.Equals(policyObject.PolicyID.Trim('{', '}'), x.PolicyID, StringComparison.OrdinalIgnoreCase));
+
+						if (possibleAlreadyDeployedUnsignedVersion is not null)
 						{
-							// Make sure the policy is a base policy and it doesn't have allow all rule
-							if (policyObject.PolicyType is PolicyType.BasePolicy)
+							Logger.Write($"A policy with the same PolicyID {possibleAlreadyDeployedUnsignedVersion.PolicyID} is already deployed on the system in Unsigned version. Removing it before deployed the signed version to prevent boot failures.");
+
+							CiToolHelper.RemovePolicy(possibleAlreadyDeployedUnsignedVersion.PolicyID!);
+						}
+
+						// Don't need to deploy it for the recommended block rules since they are only explicit Deny mode policies
+						if (!string.Equals(policyObject.FriendlyName, "Microsoft Windows Recommended User Mode BlockList", StringComparison.OrdinalIgnoreCase))
+						{
+							if (!string.Equals(policyObject.FriendlyName, "Microsoft Windows Driver Policy", StringComparison.OrdinalIgnoreCase))
 							{
-								if (!CheckForAllowAll.Check(file))
+								// Make sure the policy is a base policy and it doesn't have allow all rule
+								if (policyObject.PolicyType is PolicyType.BasePolicy)
 								{
-									// Sign and deploy the required AppControlManager supplemental policy
-									SupplementalForSelf.DeploySigned(policyObject.PolicyID, CertPath, SignToolPath, CertCN);
+									if (!CheckForAllowAll.Check(file))
+									{
+										// Sign and deploy the required AppControlManager supplemental policy
+										SupplementalForSelf.DeploySigned(policyObject.PolicyID, CertPath, SignToolPath, CertCN);
+									}
 								}
 							}
 						}
-					}
 
-					// Deploy the signed CIP file
-					CiToolHelper.UpdatePolicy(CIPFilePath);
+
+						// Deploy the CIP file locally
+						CiToolHelper.UpdatePolicy(CIPFilePath);
+					}
 				}
 			});
 		}
@@ -440,7 +465,7 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 			MainProgressRing.Visibility = Visibility.Visible;
 
 			// Deploy the selected CIP files
-			await Task.Run(() =>
+			await Task.Run(async () =>
 			{
 				foreach (string file in CIPFiles)
 				{
@@ -449,7 +474,17 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 						StatusInfoBar.Message = $"Currently Deploying CIP file: '{file}'";
 					});
 
-					CiToolHelper.UpdatePolicy(file);
+
+					if (deployToIntune)
+					{
+						await DeployToIntunePrivate(file);
+					}
+					else
+					{
+						// Deploy the CIP file
+						CiToolHelper.UpdatePolicy(file);
+					}
+
 				}
 			});
 		}
@@ -598,5 +633,149 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 	}
 
 
+	/// <summary>
+	/// Event handler for the SignIn button
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="e"></param>
+	private async void IntuneSignInButton_Click(object sender, RoutedEventArgs e)
+	{
 
+		bool signInSuccessful = false;
+
+		try
+		{
+
+			StatusInfoBar.Visibility = Visibility.Visible;
+			StatusInfoBar.IsOpen = true;
+			StatusInfoBar.Message = "Signing into Intune";
+			StatusInfoBar.Severity = InfoBarSeverity.Informational;
+			StatusInfoBar.IsClosable = false;
+
+
+			IntuneSignInButton.IsEnabled = false;
+
+			await Intune.SignIn();
+
+			StatusInfoBar.Message = "Successfully signed into Intune";
+			StatusInfoBar.Severity = InfoBarSeverity.Success;
+
+			deployToIntune = true;
+
+			LocalIntuneStatusTextBox.Text = "Cloud Deployment is Currently Active";
+
+			// Enable the sign out button
+			IntuneSignOutButton.IsEnabled = true;
+
+			signInSuccessful = true;
+
+			IntuneGroupsComboBox.IsEnabled = true;
+			RefreshIntuneGroupsButton.IsEnabled = true;
+		}
+
+		catch (Exception ex)
+		{
+			StatusInfoBar.Message = $"There was an error signing into Intune: {ex.Message}";
+			StatusInfoBar.Severity = InfoBarSeverity.Error;
+
+			throw;
+		}
+
+		finally
+		{
+
+			// If sign in wasn't successful, keep the button enabled
+			if (!signInSuccessful)
+			{
+				IntuneSignInButton.IsEnabled = true;
+			}
+
+			StatusInfoBar.IsClosable = true;
+		}
+
+	}
+
+
+	private async void IntuneSignOutButton_Click(object sender, RoutedEventArgs e)
+	{
+
+		bool signOutSuccessful = false;
+
+		try
+		{
+			StatusInfoBar.Visibility = Visibility.Visible;
+			StatusInfoBar.IsOpen = true;
+			StatusInfoBar.Message = "Signing out of Intune";
+			StatusInfoBar.Severity = InfoBarSeverity.Informational;
+			StatusInfoBar.IsClosable = false;
+
+
+			IntuneSignOutButton.IsEnabled = false;
+
+			await Intune.SignOut();
+
+			signOutSuccessful = true;
+
+			// Enable the Sign in button
+			IntuneSignInButton.IsEnabled = true;
+
+			StatusInfoBar.Message = "Successfully signed out of Intune";
+			StatusInfoBar.Severity = InfoBarSeverity.Success;
+
+			deployToIntune = false;
+			IntuneGroupsComboBox.IsEnabled = false;
+			RefreshIntuneGroupsButton.IsEnabled = false;
+
+			LocalIntuneStatusTextBox.Text = "Local Deployment is Currently Active";
+		}
+
+		catch (Exception ex)
+		{
+			StatusInfoBar.Message = $"There was an error signing out of Intune: {ex.Message}";
+			StatusInfoBar.Severity = InfoBarSeverity.Error;
+
+			throw;
+		}
+
+		finally
+		{
+			// If sign out wasn't successful, keep the button enabled
+			if (!signOutSuccessful)
+			{
+
+				IntuneSignOutButton.IsEnabled = true;
+			}
+
+			StatusInfoBar.IsClosable = true;
+		}
+
+	}
+
+
+	private async void RefreshIntuneGroupsButton_Click(object sender, RoutedEventArgs e)
+	{
+		await Intune.FetchGroups();
+		Dictionary<string, string> groups = Intune.GetGroups();
+
+		// Update the ComboBox with group names
+		IntuneGroupsComboBox.ItemsSource = groups.Keys;
+		IntuneGroupsComboBox.SelectedIndex = 0;
+	}
+
+
+
+
+
+	private async Task DeployToIntunePrivate(string file)
+	{
+		string? groupID = null;
+
+		await DispatcherQueue.EnqueueAsync(() =>
+		{
+			groupID = IntuneGroupsComboBox.SelectedItem as string;
+
+		});
+
+		await Intune.UploadPolicyToIntune(file, groupID);
+	}
 }


### PR DESCRIPTION
You can now use AppControl Manager to deploy App Control policies with 1 click/tap to your entire Intune-managed fleet of workstations. Simply authenticate with your tenant and then deploy the policies in the app as you normally would. The entire process is very simple, automated and fast.