### PR TITLE
AppControl Manager has reduced permissions for Intune and better policyID in Intune

### DIFF
--- a/AppControl Manager/AppControl Manager.csproj
+++ b/AppControl Manager/AppControl Manager.csproj
@@ -91,7 +91,7 @@
     <AssemblyName>AppControlManager</AssemblyName>
     <PublishAot>False</PublishAot>
     <ErrorReport>send</ErrorReport>
-    <FileVersion>1.8.4.0</FileVersion>
+    <FileVersion>1.8.5.0</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
@@ -145,7 +145,7 @@
     <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.DataGrid" Version="7.1.2" />
     <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.3.1" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.67.2" />
-    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.106">
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.162">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/AppControl Manager/Package.appxmanifest
+++ b/AppControl Manager/Package.appxmanifest
@@ -11,7 +11,7 @@
   <Identity
     Name="AppControlManager"
     Publisher="CN=SelfSignedCertForAppControlManager"
-    Version="1.8.4.0" />
+    Version="1.8.5.0" />
 
   <mp:PhoneIdentity PhoneProductId="199a23ec-7cb6-4ab5-ab50-8baca348bc79" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/AppControl Manager/Pages/Deployment.xaml.cs
+++ b/AppControl Manager/Pages/Deployment.xaml.cs
@@ -181,7 +181,7 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 
 					if (deployToIntune)
 					{
-						await DeployToIntunePrivate(CIPFilePath, file);
+						await DeployToIntunePrivate(CIPFilePath, policyObject.PolicyID, file);
 
 						// Delete the CIP file after deployment
 						File.Delete(CIPFilePath);
@@ -353,7 +353,7 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 
 					if (deployToIntune)
 					{
-						await DeployToIntunePrivate(CIPFilePath, file);
+						await DeployToIntunePrivate(CIPFilePath, policyObject.PolicyID, file);
 					}
 					else
 					{
@@ -474,10 +474,11 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 						StatusInfoBar.Message = $"Currently Deploying CIP file: '{file}'";
 					});
 
+					string randomPolicyID = Guid.CreateVersion7().ToString().ToUpperInvariant();
 
 					if (deployToIntune)
 					{
-						await DeployToIntunePrivate(file);
+						await DeployToIntunePrivate(file, randomPolicyID, null);
 					}
 					else
 					{
@@ -777,7 +778,7 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 
 
 
-	private async Task DeployToIntunePrivate(string file, string? xmlFile = null)
+	private async Task DeployToIntunePrivate(string file, string policyID, string? xmlFile = null)
 	{
 		string? groupID = null;
 
@@ -811,7 +812,7 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 		});
 
 
-		await Intune.UploadPolicyToIntune(file, groupID, policyName);
+		await Intune.UploadPolicyToIntune(file, groupID, policyName, policyID);
 	}
 
 

--- a/AppControl Manager/app.manifest
+++ b/AppControl Manager/app.manifest
@@ -2,7 +2,7 @@
 <!-- INFO: https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests -->
 <!-- INFO (for legacy UWP but its info can be used for better understanding): https://learn.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/root-elements -->
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.8.4.0" name="AppControlManager"/>
+  <assemblyIdentity version="1.8.5.0" name="AppControlManager"/>
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>

--- a/Wiki posts/App Control for Business/How To Create and Maintain Strict Kernel-Mode App Control Policy.md
+++ b/Wiki posts/App Control for Business/How To Create and Maintain Strict Kernel-Mode App Control Policy.md
@@ -27,7 +27,27 @@ Navigate to the [Create App Control policy](https://github.com/HotCakeX/Harden-W
 
 ## Creating the Supplemental Policy
 
-After restarting the system and relaunching the AppControl Manager, navigate to the [Create Supplemental Policy](https://github.com/HotCakeX/Harden-Windows-Security/wiki/Create-Supplemental-App-Control-Policy#create-kernel-mode-supplemental-policy) page. Scroll down to the `Kernel-mode policy` section.
+After restarting the system and relaunching the AppControl Manager, navigate to the [System Information](https://github.com/HotCakeX/Harden-Windows-Security/wiki/System-Information) page. Press the `Retrieve Policies` button, locate the Strict kernel-mode base policy, and remove it from the system.
+
+<br>
+
+<img src="https://raw.githubusercontent.com/HotCakeX/.github/8a4f06e919efc7ddd5b833203445ac9ea64b184c/Pictures/PNG%20and%20JPG/How%20To%20Create%20and%20Maintain%20Strict%20Kernel-Mode%20App%20Control%20Policy/Remove%20base%20policy.png" alt="Removing app control policy using AppControl Manager">
+
+<br>
+
+<br>
+
+Once removed, redeploy the same base policy using the [Create App Control policy](https://github.com/HotCakeX/Harden-Windows-Security/wiki/Create-App-Control-Policy) page, but this time ensure that Audit Mode is disabled.
+
+<br>
+
+<img src="https://raw.githubusercontent.com/HotCakeX/.github/d14d7437685416117edda8a56496180a2047984f/Pictures/PNG%20and%20JPG/How%20To%20Create%20and%20Maintain%20Strict%20Kernel-Mode%20App%20Control%20Policy/redeploy%20base%20policy%20in%20enforced%20mode.png" alt="redeploy strict kernel mode base policy in enforced mode">
+
+<br>
+
+<br>
+
+Now navigate to the [Create Supplemental Policy](https://github.com/HotCakeX/Harden-Windows-Security/wiki/Create-Supplemental-App-Control-Policy#create-kernel-mode-supplemental-policy) page. Scroll down to the `Kernel-mode policy` section.
 
 <br>
 

--- a/Wiki posts/App Control for Business/How To Upload App Control Policies To Intune Using AppControl Manager.md
+++ b/Wiki posts/App Control for Business/How To Upload App Control Policies To Intune Using AppControl Manager.md
@@ -46,9 +46,9 @@ By ensuring these permissions are in place, you can seamlessly deploy App Contro
 
 ## Select Policies To Deploy
 
-Select one or more XML files to deploy to Intune. You have the option to deploy them as-is (unsigned) or cryptographically sign them before deployment. Each XML file will be deployed as a separate Intune configuration policy, as Intune does not allow two OMA-URI custom policies to exist within the same configuration policy.
+Select one or more XML files to deploy to Intune. You have the option to deploy them as-is (unsigned) or cryptographically sign them before deployment. Each XML file will be deployed as a separate Intune configuration policy for better management of policies.
 
-The name defined in the XML file will become the name of the corresponding Intune configuration policy visible in the Intune portal.
+The name specified in the XML file will appear as the name of the corresponding Intune configuration policy in the Intune portal. Similarly, the policy ID from the XML file will be used as the uploaded policy's ID, enabling easy identification of policies on workstations after deployment.
 
 You can optionally use the `Refresh` button and select a group to assign to the policies you upload to Intune.
 


### PR DESCRIPTION
* Using reduced permissions for Intune deployment to adhere to the least privilege principle.

* The policyID will be properly reflected to the Intune portal.

* Version bump to `1.8.5.0`

* Dependency version update for `Microsoft.Windows.CsWin32`.

* Document update.

