### PR TITLE
Fixed Audit/Block categorization of the MDE Advanced Hunting data

### DIFF
--- a/AppControl Manager/IntelGathering/GetMDEAdvancedHuntingLogsData.cs
+++ b/AppControl Manager/IntelGathering/GetMDEAdvancedHuntingLogsData.cs
@@ -184,7 +184,7 @@ internal static class GetMDEAdvancedHuntingLogsData
 				{
 
 					Origin = FileIdentityOrigin.MDEAdvancedHunting,
-					Action = EventAction.Audit,
+					Action = EventAction.Block,
 					TimeCreated = GetEventDataDateTimeValue(possibleCodeIntegrityBlockEvent.Timestamp),
 					ComputerName = possibleCodeIntegrityBlockEvent.DeviceName,
 					UserID = possibleCodeIntegrityBlockEvent.InitiatingProcessAccountName,
@@ -396,7 +396,7 @@ internal static class GetMDEAdvancedHuntingLogsData
 				{
 
 					Origin = FileIdentityOrigin.MDEAdvancedHunting,
-					Action = EventAction.Audit,
+					Action = EventAction.Block,
 					TimeCreated = GetEventDataDateTimeValue(possibleAppLockerBlockEvent.Timestamp),
 					ComputerName = possibleAppLockerBlockEvent.DeviceName,
 					UserID = possibleAppLockerBlockEvent.InitiatingProcessAccountName,


### PR DESCRIPTION
When parsing the Microsoft Defender for Endpoint Advanced Hunting logs, Blocked events would show as Audit events in the data grid, that is now fixed.