### PR TITLE
AppControl Manager v.1.8.7.0

### DIFF
--- a/AppControl Manager/AppControl Manager.csproj
+++ b/AppControl Manager/AppControl Manager.csproj
@@ -91,7 +91,7 @@
     <AssemblyName>AppControlManager</AssemblyName>
     <PublishAot>False</PublishAot>
     <ErrorReport>send</ErrorReport>
-    <FileVersion>1.8.6.0</FileVersion>
+    <FileVersion>1.8.7.0</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/AppControl Manager/Main/SetCiRuleOptions.cs
+++ b/AppControl Manager/Main/SetCiRuleOptions.cs
@@ -467,7 +467,6 @@ internal static class CiRuleOptions
 
 			// Add the new Rule element to the Rules node
 			_ = RulesNode.AppendChild(NewRuleNode);
-
 		}
 
 		// Save the XML

--- a/AppControl Manager/Others/CodeIntegrityPolicy.cs
+++ b/AppControl Manager/Others/CodeIntegrityPolicy.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Xml;
 using AppControlManager.XMLOps;
@@ -28,6 +29,8 @@ internal sealed class CodeIntegrityPolicy
 
 	internal XmlNode PolicyIDNode { get; }
 	internal XmlNode BasePolicyIDNode { get; }
+
+	internal List<string>? Rules { get; }
 
 	internal XmlNode FileRulesNode { get; }
 
@@ -248,7 +251,40 @@ internal sealed class CodeIntegrityPolicy
 		VersionExNode = SiPolicyNode.SelectSingleNode("ns:VersionEx", NamespaceManager) ?? throw new InvalidOperationException($"VersionEx was not found.");
 
 		#endregion
+
+		#region Rules
+		Rules = LoadRules();
+		#endregion
 	}
+
+
+	private List<string>? LoadRules()
+	{
+		XmlNode? rulesNode = SiPolicyNode.SelectSingleNode("ns:Rules", NamespaceManager);
+
+		if (rulesNode is null)
+		{
+			return null;
+		}
+
+		List<string> rulesList = [];
+
+		XmlNodeList? ruleOptions = rulesNode.SelectNodes("ns:Rule/ns:Option", NamespaceManager);
+
+		if (ruleOptions is not null)
+		{
+			foreach (XmlNode ruleNode in ruleOptions)
+			{
+				if (!string.IsNullOrWhiteSpace(ruleNode.InnerText))
+				{
+					rulesList.Add(ruleNode.InnerText);
+				}
+			}
+		}
+
+		return rulesList.Count > 0 ? rulesList : null;
+	}
+
 
 	private XmlNode EnsureFileRulesRefNode(XmlNode parentNode, string mode)
 	{

--- a/AppControl Manager/Package.appxmanifest
+++ b/AppControl Manager/Package.appxmanifest
@@ -11,7 +11,7 @@
   <Identity
     Name="AppControlManager"
     Publisher="CN=SelfSignedCertForAppControlManager"
-    Version="1.8.6.0" />
+    Version="1.8.7.0" />
 
   <mp:PhoneIdentity PhoneProductId="199a23ec-7cb6-4ab5-ab50-8baca348bc79" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/AppControl Manager/Pages/AllowNewApps/AllowNewAppsStart.xaml
+++ b/AppControl Manager/Pages/AllowNewApps/AllowNewAppsStart.xaml
@@ -81,7 +81,8 @@
                     <controls:WrapPanel Grid.Row="1" Orientation="Horizontal" VerticalSpacing="15" HorizontalSpacing="15">
 
                         <TextBox x:Name="SupplementalPolicyNameTextBox" Header="Supplemental Policy Name" PlaceholderText="Enter a name for the Supplemental Policy" />
-                        <Button x:Name="BrowseForXMLPolicyButton" Click="BrowseForXMLPolicyButton_Click" Margin="0,27,0,0" ToolTipService.ToolTip="Click/Tap to choose a XML policy file from your device.">
+                        <Button x:Name="BrowseForXMLPolicyButton" Click="BrowseForXMLPolicyButton_Click" Margin="0,27,0,0"
+                               RightTapped="BrowseForXMLPolicyButton_RightTapped" Holding="BrowseForXMLPolicyButton_Holding" ToolTipService.ToolTip="Click/Tap to choose a XML policy file from your device.">
 
                             <Button.Flyout>
                                 <Flyout x:Name="BrowseForXMLPolicyButton_FlyOut">
@@ -155,10 +156,11 @@ LargeChange="10" Minimum="2" Maximum="1000000" ValueChanged="LogSizeNumberBox_Va
 
                     <controls:WrapPanel Grid.Row="1" Orientation="Horizontal" VerticalSpacing="8" HorizontalSpacing="8">
 
-                        <Button x:Name="BrowseForFoldersButton" Click="BrowseForFoldersButton_Click" Content="Browse for folders" ToolTipService.ToolTip="Browse for folders of your new or existing apps that are installed and are getting blocked">
+                        <Button x:Name="BrowseForFoldersButton" RightTapped="BrowseForFoldersButton_RightTapped"
+                               Holding="BrowseForFoldersButton_Holding" Click="BrowseForFoldersButton_Click" Content="Browse for folders" ToolTipService.ToolTip="Browse for folders of your new or existing apps that are installed and are getting blocked">
 
                             <Button.Flyout>
-                                <Flyout>
+                                <Flyout x:Name="BrowseForFoldersButton_FlyOut">
 
                                     <controls:WrapPanel Orientation="Vertical" HorizontalSpacing="15" VerticalSpacing="15">
 

--- a/AppControl Manager/Pages/AllowNewApps/AllowNewAppsStart.xaml.cs
+++ b/AppControl Manager/Pages/AllowNewApps/AllowNewAppsStart.xaml.cs
@@ -13,11 +13,12 @@ using AppControlManager.SiPolicy;
 using AppControlManager.SiPolicyIntel;
 using AppControlManager.XMLOps;
 using Microsoft.UI;
+using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
-
 
 namespace AppControlManager.Pages;
 
@@ -1051,5 +1052,33 @@ public sealed partial class AllowNewAppsStart : Page, Sidebar.IAnimatedIconsMana
 		BrowseForXMLPolicyButton_SelectedBasePolicyTextBox.Text = null;
 		selectedXMLFilePath = null;
 		tempBasePolicyPath = null;
+	}
+
+
+	private void BrowseForXMLPolicyButton_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!BrowseForXMLPolicyButton_FlyOut.IsOpen)
+			BrowseForXMLPolicyButton_FlyOut.ShowAt(BrowseForXMLPolicyButton);
+	}
+
+	private void BrowseForXMLPolicyButton_Holding(object sender, HoldingRoutedEventArgs e)
+	{
+		if (e.HoldingState is HoldingState.Started)
+			if (!BrowseForXMLPolicyButton_FlyOut.IsOpen)
+				BrowseForXMLPolicyButton_FlyOut.ShowAt(BrowseForXMLPolicyButton);
+	}
+
+
+	private void BrowseForFoldersButton_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!BrowseForFoldersButton_FlyOut.IsOpen)
+			BrowseForFoldersButton_FlyOut.ShowAt(BrowseForFoldersButton);
+	}
+
+	private void BrowseForFoldersButton_Holding(object sender, HoldingRoutedEventArgs e)
+	{
+		if (e.HoldingState is HoldingState.Started)
+			if (!BrowseForFoldersButton_FlyOut.IsOpen)
+				BrowseForFoldersButton_FlyOut.ShowAt(BrowseForFoldersButton);
 	}
 }

--- a/AppControl Manager/Pages/BuildNewCertificate.xaml
+++ b/AppControl Manager/Pages/BuildNewCertificate.xaml
@@ -61,7 +61,8 @@
             </controls:WrapPanel>
 
             <Button Grid.Row="1" HorizontalAlignment="Center" x:Name="BuildCertificateButton"
-                    HorizontalContentAlignment="Center" Margin="15" Click="BuildCertificateButton_Click">
+                    HorizontalContentAlignment="Center" Margin="15" Click="BuildCertificateButton_Click"
+                    ToolTipService.ToolTip="Build the certificate based on the configurations displayed below">
                 <Button.Content>
                     <StackPanel Orientation="Horizontal">
                         <ProgressRing Visibility="Collapsed" x:Name="ProgressRing" Margin="5,5,15,5" Value="0" IsIndeterminate="True" Minimum="0" Maximum="100"/>

--- a/AppControl Manager/Pages/ConfigurePolicyRuleOptions.xaml
+++ b/AppControl Manager/Pages/ConfigurePolicyRuleOptions.xaml
@@ -33,7 +33,6 @@
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
-
             <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Horizontal" Margin="6,5,6,5">
 
                 <TextBlock TextWrapping="WrapWholeWords" Style="{StaticResource BodyTextBlockStyle}">
@@ -50,9 +49,8 @@
             </controls:WrapPanel>
 
 
-
             <Button Grid.Row="1" Margin="0,0,0,20" x:Name="PickPolicyFileButton" Click="PickPolicyFileButton_Click"
-     HorizontalAlignment="Center"
+     HorizontalAlignment="Center" RightTapped="PickPolicyFileButton_RightTapped" Holding="PickPolicyFileButton_Holding"
     ToolTipService.ToolTip="Click/Tap to choose a XML policy file from your device.">
 
                 <Button.Flyout>
@@ -104,16 +102,13 @@
                            HeaderIcon="{ui:FontIcon Glyph=&#xE71D;}">
 
                     <controls:WrapPanel Orientation="Horizontal" HorizontalSpacing="15" VerticalSpacing="10">
-                        <Button x:Name="Add" Content="Add"
-            Style="{StaticResource AccentButtonStyle}" />
-                        <Button x:Name="Remove" Content="Remove"
-Style="{StaticResource AccentButtonStyle}" />
-                        <Button x:Name="ResetSelections" Content="Reset Selections"
-Style="{StaticResource AccentButtonStyle}" />
+                        <Button x:Name="ApplyTheChangesButton" Content="Appy the Changes" Click="ApplyTheChangesButton_Click"
+            Style="{StaticResource AccentButtonStyle}" ToolTipService.ToolTip="If you checked or unchecked any new check boxes among the rule options, use this button to apply them to the policy you selected" />
 
-                        <!-- Select All button to select all checkboxes -->
-                        <Button x:Name="SelectAll" Content="Select All"
-Style="{StaticResource AccentButtonStyle}" />
+                        <Button x:Name="RefreshRuleOptionsState" Content="Retrieve Rules States" Click="RefreshRuleOptionsState_Click"
+                                ToolTipService.ToolTip="Retrieve the latest state of policy rule options from the policy file you selected"/>
+
+                        <TeachingTip x:Name="MainTeachingTip" Target="{x:Bind PolicyRuleExpander}" Title="Error"/>
                     </controls:WrapPanel>
                 </controls:SettingsExpander>
                 <controls:SettingsCard x:Name="PolicyTemplate"

--- a/AppControl Manager/Pages/CreateDenyPolicy.xaml
+++ b/AppControl Manager/Pages/CreateDenyPolicy.xaml
@@ -140,10 +140,11 @@
 
                     <controls:WrapPanel Orientation="Horizontal" HorizontalSpacing="6" VerticalSpacing="10">
 
-                        <Button x:Name="CreateFilesAndFoldersDenyPolicyButton" Content="Create Deny Policy"
+                        <Button x:Name="CreateFilesAndFoldersDenyPolicyButton" Content="Create Deny Policy" ToolTipService.ToolTip="Create the deny policy based on the configurations you selected"
             Style="{StaticResource AccentButtonStyle}" Margin="0,0,15,0" Click="CreateFilesAndFoldersDenyPolicyButton_Click" />
 
-                        <ToggleButton x:Name="FilesAndFoldersPolicyDeployToggleButton" Click="FilesAndFoldersPolicyDeployToggleButton_Click" Content="Deploy after Creation" Margin="0,0,15,0" />
+                        <ToggleButton x:Name="FilesAndFoldersPolicyDeployToggleButton" Click="FilesAndFoldersPolicyDeployToggleButton_Click" Content="Deploy after Creation" Margin="0,0,15,0"
+                                      ToolTipService.ToolTip="Toggling this button means the deny policy will be deployed on the system after it's created"/>
 
                         <TeachingTip x:Name="CreateDenyPolicyTeachingTip"
  Target="{x:Bind CreateFilesAndFoldersDenyPolicyButton}" />
@@ -153,10 +154,10 @@
                     <controls:SettingsExpander.Items>
 
                         <controls:SettingsCard x:Name="FilesAndFoldersBrowseForFilesSettingsCard" Description="Browse for file paths to scan and include in the Deny policy."
-                               Header="Browse For Files"
+                               Header="Browse For Files" Holding="FilesAndFoldersBrowseForFilesSettingsCard_Holding" RightTapped="FilesAndFoldersBrowseForFilesSettingsCard_RightTapped"
                                IsClickEnabled="True" IsActionIconVisible="False" Click="FilesAndFoldersBrowseForFilesSettingsCard_Click">
 
-                            <Button x:Name="FilesAndFoldersBrowseForFilesButton" Content="Browse" Click="FilesAndFoldersBrowseForFilesButton_Click">
+                            <Button x:Name="FilesAndFoldersBrowseForFilesButton" RightTapped="FilesAndFoldersBrowseForFilesButton_RightTapped" Content="Browse" Click="FilesAndFoldersBrowseForFilesButton_Click">
 
                                 <Button.Flyout>
                                     <Flyout x:Name="FilesAndFoldersBrowseForFilesButton_Flyout">
@@ -181,9 +182,10 @@
                         </controls:SettingsCard>
 
                         <controls:SettingsCard Description="Browse for Folder paths to scan and include in the Deny policy. The folders will be scanned recursively."
-            Header="Browse For Folders" x:Name="FilesAndFoldersBrowseForFoldersSettingsCard" Click="FilesAndFoldersBrowseForFoldersSettingsCard_Click" IsClickEnabled="True" IsActionIconVisible="False">
+            Header="Browse For Folders" x:Name="FilesAndFoldersBrowseForFoldersSettingsCard" Click="FilesAndFoldersBrowseForFoldersSettingsCard_Click"
+             Holding="FilesAndFoldersBrowseForFoldersSettingsCard_Holding" RightTapped="FilesAndFoldersBrowseForFoldersSettingsCard_RightTapped" IsClickEnabled="True" IsActionIconVisible="False">
 
-                            <Button x:Name="FilesAndFoldersBrowseForFoldersButton" Content="Browse" Click="FilesAndFoldersBrowseForFoldersButton_Click">
+                            <Button x:Name="FilesAndFoldersBrowseForFoldersButton" RightTapped="FilesAndFoldersBrowseForFoldersButton_RightTapped" Content="Browse" Click="FilesAndFoldersBrowseForFoldersButton_Click">
 
                                 <Button.Flyout>
                                     <Flyout x:Name="FilesAndFoldersBrowseForFoldersButton_FlyOut">
@@ -302,9 +304,9 @@ Header="Policy Name" IsClickEnabled="False" IsActionIconVisible="False">
                     <controls:WrapPanel Orientation="Horizontal" HorizontalSpacing="6" VerticalSpacing="10">
 
                         <Button x:Name="CreatePFNDenyPolicyButton" Click="CreatePFNDenyPolicyButton_Click" Content="Create Deny Policy"
-Style="{StaticResource AccentButtonStyle}" Margin="0,0,15,0" />
+Style="{StaticResource AccentButtonStyle}" Margin="0,0,15,0" ToolTipService.ToolTip="Create the deny policy based on the configurations you selected"/>
 
-                        <ToggleButton x:Name="PFNPolicyDeployToggleButton" Content="Deploy after Creation" Margin="0,0,15,0" />
+                        <ToggleButton x:Name="PFNPolicyDeployToggleButton" Content="Deploy after Creation" Margin="0,0,15,0" ToolTipService.ToolTip="Toggling this button means the deny policy will be deployed on the system after it's created" />
 
                         <TeachingTip x:Name="CreatePFNDenyPolicyTeachingTip"
     Target="{x:Bind CreatePFNDenyPolicyButton}" />

--- a/AppControl Manager/Pages/CreateDenyPolicy.xaml.cs
+++ b/AppControl Manager/Pages/CreateDenyPolicy.xaml.cs
@@ -64,6 +64,46 @@ public sealed partial class CreateDenyPolicy : Page
 	internal List<FileIdentity> filesAndFoldersScanResultsList = [];
 
 
+	private void FilesAndFoldersBrowseForFilesSettingsCard_Holding(object sender, HoldingRoutedEventArgs e)
+	{
+		if (e.HoldingState is HoldingState.Started)
+			if (!FilesAndFoldersBrowseForFilesButton_Flyout.IsOpen)
+				FilesAndFoldersBrowseForFilesButton_Flyout.ShowAt(FilesAndFoldersBrowseForFilesSettingsCard);
+	}
+
+	private void FilesAndFoldersBrowseForFilesSettingsCard_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!FilesAndFoldersBrowseForFilesButton_Flyout.IsOpen)
+			FilesAndFoldersBrowseForFilesButton_Flyout.ShowAt(FilesAndFoldersBrowseForFilesSettingsCard);
+	}
+
+	private void FilesAndFoldersBrowseForFilesButton_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!FilesAndFoldersBrowseForFilesButton_Flyout.IsOpen)
+			FilesAndFoldersBrowseForFilesButton_Flyout.ShowAt(FilesAndFoldersBrowseForFilesButton);
+	}
+
+
+
+	private void FilesAndFoldersBrowseForFoldersSettingsCard_Holding(object sender, HoldingRoutedEventArgs e)
+	{
+		if (e.HoldingState is HoldingState.Started)
+			if (!FilesAndFoldersBrowseForFoldersButton_FlyOut.IsOpen)
+				FilesAndFoldersBrowseForFoldersButton_FlyOut.ShowAt(FilesAndFoldersBrowseForFoldersSettingsCard);
+	}
+
+	private void FilesAndFoldersBrowseForFoldersSettingsCard_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!FilesAndFoldersBrowseForFoldersButton_FlyOut.IsOpen)
+			FilesAndFoldersBrowseForFoldersButton_FlyOut.ShowAt(FilesAndFoldersBrowseForFoldersSettingsCard);
+	}
+
+	private void FilesAndFoldersBrowseForFoldersButton_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!FilesAndFoldersBrowseForFoldersButton_FlyOut.IsOpen)
+			FilesAndFoldersBrowseForFoldersButton_FlyOut.ShowAt(FilesAndFoldersBrowseForFoldersButton);
+	}
+
 
 	/// <summary>
 	/// Main button's event handler for files and folder Deny policy creation
@@ -257,7 +297,6 @@ public sealed partial class CreateDenyPolicy : Page
 				}
 
 
-
 			});
 
 		}
@@ -323,13 +362,11 @@ public sealed partial class CreateDenyPolicy : Page
 
 				// Append the new file to the TextBox, followed by a newline
 				FilesAndFoldersBrowseForFilesButton_SelectedFilesTextBox.Text += file + Environment.NewLine;
-
 			}
+
+			// Display the Flyout manually at SettingsCard element since the click event happened on the Settings card
+			FilesAndFoldersBrowseForFilesButton_Flyout.ShowAt(FilesAndFoldersBrowseForFilesSettingsCard);
 		}
-
-		// Display the Flyout manually at SettingsCard element since the click event happened on the Settings card
-		FilesAndFoldersBrowseForFilesButton_Flyout.ShowAt(FilesAndFoldersBrowseForFilesSettingsCard);
-
 	}
 
 	/// <summary>
@@ -349,7 +386,6 @@ public sealed partial class CreateDenyPolicy : Page
 
 				// Append the new file to the TextBox, followed by a newline
 				FilesAndFoldersBrowseForFilesButton_SelectedFilesTextBox.Text += file + Environment.NewLine;
-
 			}
 		}
 	}
@@ -372,12 +408,11 @@ public sealed partial class CreateDenyPolicy : Page
 
 				// Append the new directory to the TextBox, followed by a newline
 				FilesAndFoldersBrowseForFoldersButton_SelectedFoldersTextBox.Text += dir + Environment.NewLine;
-
 			}
-		}
 
-		// Display the Flyout manually at SettingsCard element since the click event happened on the Settings card
-		FilesAndFoldersBrowseForFoldersButton_FlyOut.ShowAt(FilesAndFoldersBrowseForFoldersSettingsCard);
+			// Display the Flyout manually at SettingsCard element since the click event happened on the Settings card
+			FilesAndFoldersBrowseForFoldersButton_FlyOut.ShowAt(FilesAndFoldersBrowseForFoldersSettingsCard);
+		}
 	}
 
 	/// <summary>
@@ -397,7 +432,6 @@ public sealed partial class CreateDenyPolicy : Page
 
 				// Append the new directory to the TextBox, followed by a newline
 				FilesAndFoldersBrowseForFoldersButton_SelectedFoldersTextBox.Text += dir + Environment.NewLine;
-
 			}
 		}
 	}
@@ -903,9 +937,6 @@ public sealed partial class CreateDenyPolicy : Page
 
 	}
 
-
-
 	#endregion
-
 
 }

--- a/AppControl Manager/Pages/CreateSupplementalPolicy.xaml
+++ b/AppControl Manager/Pages/CreateSupplementalPolicy.xaml
@@ -153,9 +153,9 @@
 
                         <controls:SettingsCard x:Name="FilesAndFoldersBrowseForFilesSettingsCard" Description="Browse for file paths to scan and include in the Supplemental policy."
                             Header="Browse For Files"
-                            IsClickEnabled="True" IsActionIconVisible="False" Click="FilesAndFoldersBrowseForFilesSettingsCard_Click">
+                            IsClickEnabled="True" IsActionIconVisible="False" Click="FilesAndFoldersBrowseForFilesSettingsCard_Click" Holding="FilesAndFoldersBrowseForFilesSettingsCard_Holding" RightTapped="FilesAndFoldersBrowseForFilesSettingsCard_RightTapped">
 
-                            <Button x:Name="FilesAndFoldersBrowseForFilesButton" Content="Browse" Click="FilesAndFoldersBrowseForFilesButton_Click">
+                            <Button x:Name="FilesAndFoldersBrowseForFilesButton" Content="Browse" Click="FilesAndFoldersBrowseForFilesButton_Click" RightTapped="FilesAndFoldersBrowseForFilesButton_RightTapped">
 
                                 <Button.Flyout>
                                     <Flyout x:Name="FilesAndFoldersBrowseForFilesButton_Flyout">
@@ -180,9 +180,9 @@
                         </controls:SettingsCard>
 
                         <controls:SettingsCard Description="Browse for Folder paths to scan and include in the Supplemental policy. The folders will be scanned recursively."
-                            Header="Browse For Folders" x:Name="FilesAndFoldersBrowseForFoldersSettingsCard" Click="FilesAndFoldersBrowseForFoldersSettingsCard_Click" IsClickEnabled="True" IsActionIconVisible="False">
+                            Header="Browse For Folders" Holding="FilesAndFoldersBrowseForFoldersSettingsCard_Holding" RightTapped="FilesAndFoldersBrowseForFoldersSettingsCard_RightTapped" x:Name="FilesAndFoldersBrowseForFoldersSettingsCard" Click="FilesAndFoldersBrowseForFoldersSettingsCard_Click" IsClickEnabled="True" IsActionIconVisible="False">
 
-                            <Button x:Name="FilesAndFoldersBrowseForFoldersButton" Content="Browse" Click="FilesAndFoldersBrowseForFoldersButton_Click">
+                            <Button RightTapped="FilesAndFoldersBrowseForFoldersButton_RightTapped" x:Name="FilesAndFoldersBrowseForFoldersButton" Content="Browse" Click="FilesAndFoldersBrowseForFoldersButton_Click">
 
                                 <Button.Flyout>
                                     <Flyout x:Name="FilesAndFoldersBrowseForFoldersButton_FlyOut">
@@ -215,9 +215,9 @@
 
                         <controls:SettingsCard Description="Browse for the Base policy XML file that this Supplemental policy will be associated to."
                             Header="Base Policy File" IsClickEnabled="True" Click="FilesAndFoldersBrowseForBasePolicySettingsCard_Click"
-                            x:Name="FilesAndFoldersBrowseForBasePolicySettingsCard" IsActionIconVisible="False">
+                            x:Name="FilesAndFoldersBrowseForBasePolicySettingsCard" Holding="FilesAndFoldersBrowseForBasePolicySettingsCard_Holding" RightTapped="FilesAndFoldersBrowseForBasePolicySettingsCard_RightTapped" IsActionIconVisible="False">
 
-                            <Button x:Name="FilesAndFoldersBrowseForBasePolicyButton" Click="FilesAndFoldersBrowseForBasePolicyButton_Click">
+                            <Button x:Name="FilesAndFoldersBrowseForBasePolicyButton" RightTapped="FilesAndFoldersBrowseForBasePolicyButton_RightTapped" Click="FilesAndFoldersBrowseForBasePolicyButton_Click">
 
                                 <Button.Flyout>
                                     <Flyout x:Name="FilesAndFoldersBrowseForBasePolicyButton_FlyOut">
@@ -371,9 +371,10 @@
                         </controls:SettingsCard>
 
                         <controls:SettingsCard x:Name="CertificatesBrowseForBasePolicySettingsCard" Description="Browse for the Base policy XML file that this Supplemental policy will be associated to."
-                                Header="Base Policy File" IsClickEnabled="True" IsActionIconVisible="False" Click="CertificatesBrowseForBasePolicySettingsCard_Click">
+                                Header="Base Policy File" IsClickEnabled="True" IsActionIconVisible="False" Click="CertificatesBrowseForBasePolicySettingsCard_Click"
+                                               RightTapped="CertificatesBrowseForBasePolicySettingsCard_RightTapped" Holding="CertificatesBrowseForBasePolicySettingsCard_Holding">
 
-                            <Button x:Name="CertificatesBrowseForBasePolicyButton" Click="CertificatesBrowseForBasePolicyButton_Click">
+                            <Button x:Name="CertificatesBrowseForBasePolicyButton" RightTapped="CertificatesBrowseForBasePolicyButton_RightTapped" Click="CertificatesBrowseForBasePolicyButton_Click">
 
                                 <Button.Flyout>
                                     <Flyout x:Name="CertificatesBrowseForBasePolicyButton_FlyOut">
@@ -467,9 +468,10 @@
                         </controls:SettingsCard>
 
                         <controls:SettingsCard x:Name="ISGBrowseForBasePolicySettingsCard" Description="Browse for the Base policy XML file that this Supplemental policy will be associated to."
-                            Header="Base Policy File" IsClickEnabled="True" IsActionIconVisible="False" Click="ISGBrowseForBasePolicySettingsCard_Click">
+                            Header="Base Policy File" IsClickEnabled="True" IsActionIconVisible="False" Click="ISGBrowseForBasePolicySettingsCard_Click"
+                                               Holding="ISGBrowseForBasePolicySettingsCard_Holding" RightTapped="ISGBrowseForBasePolicySettingsCard_RightTapped">
 
-                            <Button x:Name="ISGBrowseForBasePolicyButton" Click="ISGBrowseForBasePolicyButton_Click">
+                            <Button x:Name="ISGBrowseForBasePolicyButton" Click="ISGBrowseForBasePolicyButton_Click" RightTapped="ISGBrowseForBasePolicyButton_RightTapped">
 
                                 <Button.Flyout>
                                     <Flyout x:Name="ISGBrowseForBasePolicyButton_FlyOut">
@@ -571,9 +573,10 @@
 
 
                         <controls:SettingsCard x:Name="StrictKernelModeBrowseForBasePolicySettingsCard" Description="Browse for the Base policy XML file that this Supplemental policy will be associated to."
-                            Header="Base Policy File" IsClickEnabled="True" IsActionIconVisible="False" Click="StrictKernelModeBrowseForBasePolicySettingsCard_Click">
+                            Header="Base Policy File" IsClickEnabled="True" IsActionIconVisible="False" Click="StrictKernelModeBrowseForBasePolicySettingsCard_Click"
+                                               RightTapped="StrictKernelModeBrowseForBasePolicySettingsCard_RightTapped" Holding="StrictKernelModeBrowseForBasePolicySettingsCard_Holding">
 
-                            <Button x:Name="StrictKernelModeBrowseForBasePolicyButton" Click="StrictKernelModeBrowseForBasePolicyButton_Click">
+                            <Button x:Name="StrictKernelModeBrowseForBasePolicyButton" RightTapped="StrictKernelModeBrowseForBasePolicyButton_RightTapped" Click="StrictKernelModeBrowseForBasePolicyButton_Click">
 
                                 <Button.Flyout>
                                     <Flyout x:Name="StrictKernelModeBrowseForBasePolicyButton_FlyOut">
@@ -676,9 +679,10 @@
                         </controls:SettingsCard>
 
                         <controls:SettingsCard x:Name="PFNBrowseForBasePolicySettingsCard" Description="Browse for the Base policy XML file that this Supplemental policy will be associated to."
-                            Header="Base Policy File" IsClickEnabled="True" Click="PFNBrowseForBasePolicySettingsCard_Click" IsActionIconVisible="False">
+                            Header="Base Policy File" IsClickEnabled="True" Click="PFNBrowseForBasePolicySettingsCard_Click" IsActionIconVisible="False"
+                                               RightTapped="PFNBrowseForBasePolicySettingsCard_RightTapped" Holding="PFNBrowseForBasePolicySettingsCard_Holding">
 
-                            <Button x:Name="PFNBrowseForBasePolicyButton" Click="PFNBrowseForBasePolicyButton_Click">
+                            <Button x:Name="PFNBrowseForBasePolicyButton" RightTapped="PFNBrowseForBasePolicyButton_RightTapped" Click="PFNBrowseForBasePolicyButton_Click">
 
                                 <Button.Flyout>
                                     <Flyout x:Name="PFNBrowseForBasePolicyButton_FlyOut">

--- a/AppControl Manager/Pages/CreateSupplementalPolicy.xaml.cs
+++ b/AppControl Manager/Pages/CreateSupplementalPolicy.xaml.cs
@@ -190,6 +190,64 @@ public sealed partial class CreateSupplementalPolicy : Page, Sidebar.IAnimatedIc
 	internal List<FileIdentity> filesAndFoldersScanResultsList = [];
 
 
+	private void FilesAndFoldersBrowseForFilesButton_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!FilesAndFoldersBrowseForFilesButton_Flyout.IsOpen)
+			FilesAndFoldersBrowseForFilesButton_Flyout.ShowAt(FilesAndFoldersBrowseForFilesButton);
+	}
+
+	private void FilesAndFoldersBrowseForFilesSettingsCard_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!FilesAndFoldersBrowseForFilesButton_Flyout.IsOpen)
+			FilesAndFoldersBrowseForFilesButton_Flyout.ShowAt(FilesAndFoldersBrowseForFilesSettingsCard);
+	}
+
+	private void FilesAndFoldersBrowseForFilesSettingsCard_Holding(object sender, HoldingRoutedEventArgs e)
+	{
+		if (e.HoldingState is HoldingState.Started)
+			if (!FilesAndFoldersBrowseForFilesButton_Flyout.IsOpen)
+				FilesAndFoldersBrowseForFilesButton_Flyout.ShowAt(FilesAndFoldersBrowseForFilesSettingsCard);
+	}
+
+	private void FilesAndFoldersBrowseForFoldersSettingsCard_Holding(object sender, HoldingRoutedEventArgs e)
+	{
+		if (e.HoldingState is HoldingState.Started)
+			if (!FilesAndFoldersBrowseForFoldersButton_FlyOut.IsOpen)
+				FilesAndFoldersBrowseForFoldersButton_FlyOut.ShowAt(FilesAndFoldersBrowseForFoldersSettingsCard);
+	}
+
+	private void FilesAndFoldersBrowseForFoldersSettingsCard_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!FilesAndFoldersBrowseForFoldersButton_FlyOut.IsOpen)
+			FilesAndFoldersBrowseForFoldersButton_FlyOut.ShowAt(FilesAndFoldersBrowseForFoldersSettingsCard);
+	}
+
+	private void FilesAndFoldersBrowseForFoldersButton_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!FilesAndFoldersBrowseForFoldersButton_FlyOut.IsOpen)
+			FilesAndFoldersBrowseForFoldersButton_FlyOut.ShowAt(FilesAndFoldersBrowseForFoldersButton);
+	}
+
+
+	private void FilesAndFoldersBrowseForBasePolicySettingsCard_Holding(object sender, HoldingRoutedEventArgs e)
+	{
+		if (e.HoldingState is HoldingState.Started)
+			if (!FilesAndFoldersBrowseForBasePolicyButton_FlyOut.IsOpen)
+				FilesAndFoldersBrowseForBasePolicyButton_FlyOut.ShowAt(FilesAndFoldersBrowseForBasePolicySettingsCard);
+	}
+
+	private void FilesAndFoldersBrowseForBasePolicySettingsCard_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!FilesAndFoldersBrowseForBasePolicyButton_FlyOut.IsOpen)
+			FilesAndFoldersBrowseForBasePolicyButton_FlyOut.ShowAt(FilesAndFoldersBrowseForBasePolicySettingsCard);
+	}
+
+	private void FilesAndFoldersBrowseForBasePolicyButton_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!FilesAndFoldersBrowseForBasePolicyButton_FlyOut.IsOpen)
+			FilesAndFoldersBrowseForBasePolicyButton_FlyOut.ShowAt(FilesAndFoldersBrowseForBasePolicyButton);
+	}
+
 	/// <summary>
 	/// Browse for Files - Settings Card Click
 	/// </summary>
@@ -208,12 +266,12 @@ public sealed partial class CreateSupplementalPolicy : Page, Sidebar.IAnimatedIc
 				// Append the new file to the TextBox, followed by a newline
 				FilesAndFoldersBrowseForFilesButton_SelectedFilesTextBox.Text += file + Environment.NewLine;
 			}
+
+			// Display the Flyout manually at SettingsCard element since the click event happened on the Settings card
+			FilesAndFoldersBrowseForFilesButton_Flyout.ShowAt(FilesAndFoldersBrowseForFilesSettingsCard);
 		}
-
-		// Display the Flyout manually at SettingsCard element since the click event happened on the Settings card
-		FilesAndFoldersBrowseForFilesButton_Flyout.ShowAt(FilesAndFoldersBrowseForFilesSettingsCard);
-
 	}
+
 
 	/// <summary>
 	/// Browse for Files - Button Click
@@ -256,10 +314,10 @@ public sealed partial class CreateSupplementalPolicy : Page, Sidebar.IAnimatedIc
 				// Append the new directory to the TextBox, followed by a newline
 				FilesAndFoldersBrowseForFoldersButton_SelectedFoldersTextBox.Text += dir + Environment.NewLine;
 			}
-		}
 
-		// Display the Flyout manually at SettingsCard element since the click event happened on the Settings card
-		FilesAndFoldersBrowseForFoldersButton_FlyOut.ShowAt(FilesAndFoldersBrowseForFoldersSettingsCard);
+			// Display the Flyout manually at SettingsCard element since the click event happened on the Settings card
+			FilesAndFoldersBrowseForFoldersButton_FlyOut.ShowAt(FilesAndFoldersBrowseForFoldersSettingsCard);
+		}
 	}
 
 
@@ -302,10 +360,10 @@ public sealed partial class CreateSupplementalPolicy : Page, Sidebar.IAnimatedIc
 
 			// Add the file path to the GUI's text box
 			FilesAndFoldersBrowseForBasePolicyButton_SelectedBasePolicyTextBox.Text = selectedFile;
-		}
 
-		// Display the Flyout manually at SettingsCard element since the click event happened on the Settings card
-		FilesAndFoldersBrowseForBasePolicyButton_FlyOut.ShowAt(FilesAndFoldersBrowseForBasePolicySettingsCard);
+			// Display the Flyout manually at SettingsCard element since the click event happened on the Settings card
+			FilesAndFoldersBrowseForBasePolicyButton_FlyOut.ShowAt(FilesAndFoldersBrowseForBasePolicySettingsCard);
+		}
 	}
 
 
@@ -727,6 +785,25 @@ public sealed partial class CreateSupplementalPolicy : Page, Sidebar.IAnimatedIc
 	// False = Kernel Mode
 	private bool signingScenario = true;
 
+	private void CertificatesBrowseForBasePolicyButton_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!CertificatesBrowseForBasePolicyButton_FlyOut.IsOpen)
+			CertificatesBrowseForBasePolicyButton_FlyOut.ShowAt(CertificatesBrowseForBasePolicyButton);
+	}
+
+	private void CertificatesBrowseForBasePolicySettingsCard_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!CertificatesBrowseForBasePolicyButton_FlyOut.IsOpen)
+			CertificatesBrowseForBasePolicyButton_FlyOut.ShowAt(CertificatesBrowseForBasePolicySettingsCard);
+	}
+
+	private void CertificatesBrowseForBasePolicySettingsCard_Holding(object sender, HoldingRoutedEventArgs e)
+	{
+		if (e.HoldingState is HoldingState.Started)
+			if (!CertificatesBrowseForBasePolicyButton_FlyOut.IsOpen)
+				CertificatesBrowseForBasePolicyButton_FlyOut.ShowAt(CertificatesBrowseForBasePolicySettingsCard);
+	}
+
 	/// <summary>
 	/// Deploy button event handler for Certificates-based Supplemental policy
 	/// </summary>
@@ -780,9 +857,9 @@ public sealed partial class CreateSupplementalPolicy : Page, Sidebar.IAnimatedIc
 			CertificatesBasedBasePolicyPath = selectedFile;
 
 			CertificatesBrowseForBasePolicyButton_SelectedBasePolicyTextBox.Text = selectedFile;
-		}
 
-		CertificatesBrowseForBasePolicyButton_FlyOut.ShowAt(CertificatesBrowseForBasePolicySettingsCard);
+			CertificatesBrowseForBasePolicyButton_FlyOut.ShowAt(CertificatesBrowseForBasePolicySettingsCard);
+		}
 	}
 
 	private void CertificatesBrowseForBasePolicyButton_Click(object sender, RoutedEventArgs e)
@@ -1016,6 +1093,24 @@ public sealed partial class CreateSupplementalPolicy : Page, Sidebar.IAnimatedIc
 	// Selected Supplemental policy name
 	private string? ISGBasedSupplementalPolicyName;
 
+	private void ISGBrowseForBasePolicySettingsCard_Holding(object sender, HoldingRoutedEventArgs e)
+	{
+		if (e.HoldingState is HoldingState.Started)
+			if (!ISGBrowseForBasePolicyButton_FlyOut.IsOpen)
+				ISGBrowseForBasePolicyButton_FlyOut.ShowAt(ISGBrowseForBasePolicySettingsCard);
+	}
+
+	private void ISGBrowseForBasePolicySettingsCard_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!ISGBrowseForBasePolicyButton_FlyOut.IsOpen)
+			ISGBrowseForBasePolicyButton_FlyOut.ShowAt(ISGBrowseForBasePolicySettingsCard);
+	}
+
+	private void ISGBrowseForBasePolicyButton_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!ISGBrowseForBasePolicyButton_FlyOut.IsOpen)
+			ISGBrowseForBasePolicyButton_FlyOut.ShowAt(ISGBrowseForBasePolicyButton);
+	}
 
 	/// <summary>
 	/// Event handler for the main button - to create Supplemental ISG based policy
@@ -1158,9 +1253,9 @@ public sealed partial class CreateSupplementalPolicy : Page, Sidebar.IAnimatedIc
 			ISGBasedBasePolicyPath = selectedFile;
 
 			ISGBrowseForBasePolicyButton_SelectedBasePolicyTextBox.Text = selectedFile;
-		}
 
-		ISGBrowseForBasePolicyButton_FlyOut.ShowAt(ISGBrowseForBasePolicySettingsCard);
+			ISGBrowseForBasePolicyButton_FlyOut.ShowAt(ISGBrowseForBasePolicySettingsCard);
+		}
 	}
 
 
@@ -1199,6 +1294,25 @@ public sealed partial class CreateSupplementalPolicy : Page, Sidebar.IAnimatedIc
 	internal List<FileIdentity> ScanResultsList = [];
 
 
+	private void StrictKernelModeBrowseForBasePolicySettingsCard_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!StrictKernelModeBrowseForBasePolicyButton_FlyOut.IsOpen)
+			StrictKernelModeBrowseForBasePolicyButton_FlyOut.ShowAt(StrictKernelModeBrowseForBasePolicySettingsCard);
+	}
+
+	private void StrictKernelModeBrowseForBasePolicySettingsCard_Holding(object sender, HoldingRoutedEventArgs e)
+	{
+		if (e.HoldingState is HoldingState.Started)
+			if (!StrictKernelModeBrowseForBasePolicyButton_FlyOut.IsOpen)
+				StrictKernelModeBrowseForBasePolicyButton_FlyOut.ShowAt(StrictKernelModeBrowseForBasePolicySettingsCard);
+	}
+
+	private void StrictKernelModeBrowseForBasePolicyButton_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!StrictKernelModeBrowseForBasePolicyButton_FlyOut.IsOpen)
+			StrictKernelModeBrowseForBasePolicyButton_FlyOut.ShowAt(StrictKernelModeBrowseForBasePolicyButton);
+	}
+
 	private void StrictKernelModeScanButton_Click(object sender, RoutedEventArgs e)
 	{
 		StrictKernelModePerformScans(false);
@@ -1228,10 +1342,10 @@ public sealed partial class CreateSupplementalPolicy : Page, Sidebar.IAnimatedIc
 
 			// Add the file path to the GUI's text box
 			StrictKernelModeBrowseForBasePolicyButton_SelectedBasePolicyTextBox.Text = selectedFile;
-		}
 
-		// Display the Flyout manually at SettingsCard element since the click event happened on the Settings card
-		StrictKernelModeBrowseForBasePolicyButton_FlyOut.ShowAt(StrictKernelModeBrowseForBasePolicySettingsCard);
+			// Display the Flyout manually at SettingsCard element since the click event happened on the Settings card
+			StrictKernelModeBrowseForBasePolicyButton_FlyOut.ShowAt(StrictKernelModeBrowseForBasePolicySettingsCard);
+		}
 	}
 
 
@@ -1675,6 +1789,26 @@ public sealed partial class CreateSupplementalPolicy : Page, Sidebar.IAnimatedIc
 	// Path to the base policy for the PFN based supplemental policy
 	private string? PFNBasePolicyPath;
 
+
+	private void PFNBrowseForBasePolicySettingsCard_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!PFNBrowseForBasePolicyButton_FlyOut.IsOpen)
+			PFNBrowseForBasePolicyButton_FlyOut.ShowAt(PFNBrowseForBasePolicySettingsCard);
+	}
+
+	private void PFNBrowseForBasePolicySettingsCard_Holding(object sender, HoldingRoutedEventArgs e)
+	{
+		if (e.HoldingState is HoldingState.Started)
+			if (!PFNBrowseForBasePolicyButton_FlyOut.IsOpen)
+				PFNBrowseForBasePolicyButton_FlyOut.ShowAt(PFNBrowseForBasePolicySettingsCard);
+	}
+
+	private void PFNBrowseForBasePolicyButton_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!PFNBrowseForBasePolicyButton_FlyOut.IsOpen)
+			PFNBrowseForBasePolicyButton_FlyOut.ShowAt(PFNBrowseForBasePolicyButton);
+	}
+
 	/// <summary>
 	/// Gets the list of all installed Packaged Apps
 	/// </summary>
@@ -1922,10 +2056,10 @@ public sealed partial class CreateSupplementalPolicy : Page, Sidebar.IAnimatedIc
 
 			// Add the file path to the GUI's text box
 			PFNBrowseForBasePolicyButton_SelectedBasePolicyTextBox.Text = selectedFile;
-		}
 
-		// Display the Flyout manually at SettingsCard element since the click event happened on the Settings card
-		PFNBrowseForBasePolicyButton_FlyOut.ShowAt(PFNBrowseForBasePolicySettingsCard);
+			// Display the Flyout manually at SettingsCard element since the click event happened on the Settings card
+			PFNBrowseForBasePolicyButton_FlyOut.ShowAt(PFNBrowseForBasePolicySettingsCard);
+		}
 	}
 
 
@@ -2112,7 +2246,6 @@ public sealed partial class CreateSupplementalPolicy : Page, Sidebar.IAnimatedIc
 		}
 
 	}
-
 
 	#endregion
 

--- a/AppControl Manager/Pages/Deployment.xaml
+++ b/AppControl Manager/Pages/Deployment.xaml
@@ -131,7 +131,8 @@
 
                     <controls:WrapPanel HorizontalSpacing="15" VerticalSpacing="15">
 
-                        <Button x:Name="BrowseForXMLPolicyFilesButton" Click="BrowseForXMLPolicyFilesButton_Click">
+                        <Button x:Name="BrowseForXMLPolicyFilesButton" Click="BrowseForXMLPolicyFilesButton_Click"
+                                RightTapped="BrowseForXMLPolicyFilesButton_RightTapped" Holding="BrowseForXMLPolicyFilesButton_Holding">
                             <Button.Content>
                                 <controls:WrapPanel Orientation="Horizontal">
 
@@ -198,7 +199,8 @@
 
                     <controls:WrapPanel HorizontalSpacing="15" VerticalSpacing="15">
 
-                        <Button x:Name="BrowseForSignedXMLPolicyFilesButton" Click="BrowseForSignedXMLPolicyFilesButton_Click">
+                        <Button x:Name="BrowseForSignedXMLPolicyFilesButton" Click="BrowseForSignedXMLPolicyFilesButton_Click"
+                                RightTapped="BrowseForSignedXMLPolicyFilesButton_RightTapped" Holding="BrowseForSignedXMLPolicyFilesButton_Holding">
                             <Button.Content>
                                 <controls:WrapPanel Orientation="Horizontal">
 
@@ -257,7 +259,6 @@
                 </controls:SettingsCard>
 
 
-
                 <controls:SettingsCard
                     Description="Browse for CIP Binary file(s) to deploy on the system"
                     Header="Select CIP Binary file(s)"
@@ -265,7 +266,8 @@
 
                     <controls:WrapPanel HorizontalSpacing="15" VerticalSpacing="15">
 
-                        <Button x:Name="BrowseForCIPBinaryFilesButton" Content="Browse" Click="BrowseForCIPBinaryFilesButton_Click">
+                        <Button x:Name="BrowseForCIPBinaryFilesButton" Content="Browse" Click="BrowseForCIPBinaryFilesButton_Click"
+                                Holding="BrowseForCIPBinaryFilesButton_Holding" RightTapped="BrowseForCIPBinaryFilesButton_RightTapped">
 
                             <Button.Flyout>
                                 <Flyout x:Name="BrowseForCIPBinaryFilesButton_Flyout">

--- a/AppControl Manager/Pages/Deployment.xaml.cs
+++ b/AppControl Manager/Pages/Deployment.xaml.cs
@@ -10,8 +10,10 @@ using AppControlManager.SiPolicy;
 using AppControlManager.SiPolicyIntel;
 using AppControlManager.XMLOps;
 using CommunityToolkit.WinUI;
+using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Navigation;
 
 namespace AppControlManager.Pages;
@@ -89,9 +91,9 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 				// Append the new file to the TextBox, followed by a newline
 				BrowseForXMLPolicyFilesButton_SelectedFilesTextBox.Text += unsignedBasePolicyPathFromSidebar + Environment.NewLine;
 			}
-		}
 
-		BrowseForXMLPolicyFilesButton_Flyout.ShowAt(BrowseForXMLPolicyFilesButton);
+			BrowseForXMLPolicyFilesButton_Flyout.ShowAt(BrowseForXMLPolicyFilesButton);
+		}
 	}
 
 	private void LightUp2(object sender, RoutedEventArgs e)
@@ -104,9 +106,9 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 				// Append the new file to the TextBox, followed by a newline
 				BrowseForSignedXMLPolicyFilesButton_SelectedFilesTextBox.Text += unsignedBasePolicyPathFromSidebar + Environment.NewLine;
 			}
-		}
 
-		BrowseForSignedXMLPolicyFilesButton_Flyout.ShowAt(BrowseForSignedXMLPolicyFilesButton);
+			BrowseForSignedXMLPolicyFilesButton_Flyout.ShowAt(BrowseForSignedXMLPolicyFilesButton);
+		}
 	}
 
 	#endregion
@@ -809,4 +811,44 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 	{
 		Intune.CancelSignIn();
 	}
+
+	private void BrowseForXMLPolicyFilesButton_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!BrowseForXMLPolicyFilesButton_Flyout.IsOpen)
+			BrowseForXMLPolicyFilesButton_Flyout.ShowAt(BrowseForXMLPolicyFilesButton);
+	}
+
+	private void BrowseForXMLPolicyFilesButton_Holding(object sender, HoldingRoutedEventArgs e)
+	{
+		if (e.HoldingState is HoldingState.Started)
+			if (!BrowseForXMLPolicyFilesButton_Flyout.IsOpen)
+				BrowseForXMLPolicyFilesButton_Flyout.ShowAt(BrowseForXMLPolicyFilesButton);
+	}
+
+	private void BrowseForSignedXMLPolicyFilesButton_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!BrowseForSignedXMLPolicyFilesButton_Flyout.IsOpen)
+			BrowseForSignedXMLPolicyFilesButton_Flyout.ShowAt(BrowseForSignedXMLPolicyFilesButton);
+	}
+
+	private void BrowseForSignedXMLPolicyFilesButton_Holding(object sender, HoldingRoutedEventArgs e)
+	{
+		if (e.HoldingState is HoldingState.Started)
+			if (!BrowseForSignedXMLPolicyFilesButton_Flyout.IsOpen)
+				BrowseForSignedXMLPolicyFilesButton_Flyout.ShowAt(BrowseForSignedXMLPolicyFilesButton);
+	}
+
+	private void BrowseForCIPBinaryFilesButton_Holding(object sender, HoldingRoutedEventArgs e)
+	{
+		if (e.HoldingState is HoldingState.Started)
+			if (!BrowseForCIPBinaryFilesButton_Flyout.IsOpen)
+				BrowseForCIPBinaryFilesButton_Flyout.ShowAt(BrowseForCIPBinaryFilesButton);
+	}
+
+	private void BrowseForCIPBinaryFilesButton_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!BrowseForCIPBinaryFilesButton_Flyout.IsOpen)
+			BrowseForCIPBinaryFilesButton_Flyout.ShowAt(BrowseForCIPBinaryFilesButton);
+	}
+
 }

--- a/AppControl Manager/Pages/EventLogsPolicyCreation.xaml
+++ b/AppControl Manager/Pages/EventLogsPolicyCreation.xaml
@@ -255,13 +255,13 @@ MinWidth="400" IsReadOnly="True" />
 
                         <MenuFlyout Placement="Bottom">
 
-                            <MenuFlyoutItem Text="Select Code Integrity EVTX Files" Click="SelectCodeIntegrityEVTXFiles_Click" ToolTipService.ToolTip="Browse for Code Integrity Operational EVTX logs">
+                            <MenuFlyoutItem x:Name="BrowseForCodeIntegrityEVTXFilesButton" RightTapped="BrowseForCodeIntegrityEVTXFilesButton_RightTapped" Holding="BrowseForCodeIntegrityEVTXFilesButton_Holding" Text="Select Code Integrity EVTX Files" Click="SelectCodeIntegrityEVTXFiles_Click" ToolTipService.ToolTip="Browse for Code Integrity Operational EVTX logs">
                                 <MenuFlyoutItem.Icon>
                                     <FontIcon Glyph="&#xEC50;" />
                                 </MenuFlyoutItem.Icon>
                             </MenuFlyoutItem>
 
-                            <MenuFlyoutItem Text="Select AppLocker EVTX Files" Click="SelectAppLockerEVTXFiles_Click" ToolTipService.ToolTip="Browse for AppLocker EVTX logs">
+                            <MenuFlyoutItem x:Name="BrowseForAppLockerEVTXFilesButton" RightTapped="BrowseForAppLockerEVTXFilesButton_RightTapped" Holding="BrowseForAppLockerEVTXFilesButton_Holding" Text="Select AppLocker EVTX Files" Click="SelectAppLockerEVTXFiles_Click" ToolTipService.ToolTip="Browse for AppLocker EVTX logs">
                                 <MenuFlyoutItem.Icon>
                                     <FontIcon Glyph="&#xEC50;" />
                                 </MenuFlyoutItem.Icon>

--- a/AppControl Manager/Pages/EventLogsPolicyCreation.xaml
+++ b/AppControl Manager/Pages/EventLogsPolicyCreation.xaml
@@ -78,6 +78,38 @@
                 </Style.Setters>
             </Style>
 
+            <Flyout x:Name="SelectedCodeIntegrityEVTXFilesFlyout">
+
+                <controls:WrapPanel Orientation="Vertical" HorizontalSpacing="15" VerticalSpacing="15">
+
+                    <Button Content="Clear" Click="SelectedCodeIntegrityEVTXFilesFlyout_Clear_Click" />
+
+                    <TextBlock Text="View the Code Integrity EVTX files you selected." TextWrapping="WrapWholeWords" />
+
+                    <TextBox x:Name="SelectedCodeIntegrityEVTXFilesFlyout_TextBox"
+TextWrapping="Wrap" AcceptsReturn="True" IsSpellCheckEnabled="False"
+MinWidth="400" IsReadOnly="True" />
+
+                </controls:WrapPanel>
+
+            </Flyout>
+
+            <Flyout x:Name="SelectedAppLockerEVTXFilesFlyout">
+
+                <controls:WrapPanel Orientation="Vertical" HorizontalSpacing="15" VerticalSpacing="15">
+
+                    <Button Content="Clear" Click="SelectedAppLockerEVTXFilesFlyout_Clear_Click" />
+
+                    <TextBlock Text="View the AppLocker EVTX files you selected." TextWrapping="WrapWholeWords" />
+
+                    <TextBox x:Name="SelectedAppLockerEVTXFilesFlyout_TextBox"
+TextWrapping="Wrap" AcceptsReturn="True" IsSpellCheckEnabled="False"
+MinWidth="400" IsReadOnly="True" />
+
+                </controls:WrapPanel>
+
+            </Flyout>
+
         </Grid.Resources>
 
 
@@ -217,7 +249,7 @@
                 </SplitButton>
 
 
-                <DropDownButton Content="Browse for EVTX" ToolTipService.ToolTip="Select EVTX files">
+                <DropDownButton x:Name="BrowseForEVTXDropDownButton" Content="Browse for EVTX" ToolTipService.ToolTip="Select EVTX files">
 
                     <DropDownButton.Flyout>
 

--- a/AppControl Manager/Pages/EventLogsPolicyCreation.xaml.cs
+++ b/AppControl Manager/Pages/EventLogsPolicyCreation.xaml.cs
@@ -10,8 +10,10 @@ using AppControlManager.Main;
 using AppControlManager.Others;
 using AppControlManager.XMLOps;
 using CommunityToolkit.WinUI.UI.Controls;
+using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Navigation;
 using Windows.ApplicationModel.DataTransfer;
 
@@ -242,9 +244,9 @@ public sealed partial class EventLogsPolicyCreation : Page
 			Logger.Write($"Selected {selectedFile} for Code Integrity EVTX log scanning");
 
 			SelectedCodeIntegrityEVTXFilesFlyout_TextBox.Text = selectedFile;
-		}
 
-		SelectedCodeIntegrityEVTXFilesFlyout.ShowAt(BrowseForEVTXDropDownButton);
+			SelectedCodeIntegrityEVTXFilesFlyout.ShowAt(BrowseForEVTXDropDownButton);
+		}
 	}
 
 
@@ -272,9 +274,9 @@ public sealed partial class EventLogsPolicyCreation : Page
 			Logger.Write($"Selected {selectedFile} for AppLocker EVTX log scanning");
 
 			SelectedAppLockerEVTXFilesFlyout_TextBox.Text = selectedFile;
-		}
 
-		SelectedAppLockerEVTXFilesFlyout.ShowAt(BrowseForEVTXDropDownButton);
+			SelectedAppLockerEVTXFilesFlyout.ShowAt(BrowseForEVTXDropDownButton);
+		}
 	}
 
 
@@ -987,4 +989,30 @@ public sealed partial class EventLogsPolicyCreation : Page
 		}
 	}
 
+
+	private void BrowseForCodeIntegrityEVTXFilesButton_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!SelectedCodeIntegrityEVTXFilesFlyout.IsOpen)
+			SelectedCodeIntegrityEVTXFilesFlyout.ShowAt(BrowseForEVTXDropDownButton);
+	}
+
+	private void BrowseForCodeIntegrityEVTXFilesButton_Holding(object sender, HoldingRoutedEventArgs e)
+	{
+		if (e.HoldingState is HoldingState.Started)
+			if (!SelectedCodeIntegrityEVTXFilesFlyout.IsOpen)
+				SelectedCodeIntegrityEVTXFilesFlyout.ShowAt(BrowseForEVTXDropDownButton);
+	}
+
+	private void BrowseForAppLockerEVTXFilesButton_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!SelectedAppLockerEVTXFilesFlyout.IsOpen)
+			SelectedAppLockerEVTXFilesFlyout.ShowAt(BrowseForEVTXDropDownButton);
+	}
+
+	private void BrowseForAppLockerEVTXFilesButton_Holding(object sender, HoldingRoutedEventArgs e)
+	{
+		if (e.HoldingState is HoldingState.Started)
+			if (!SelectedAppLockerEVTXFilesFlyout.IsOpen)
+				SelectedAppLockerEVTXFilesFlyout.ShowAt(BrowseForEVTXDropDownButton);
+	}
 }

--- a/AppControl Manager/Pages/EventLogsPolicyCreation.xaml.cs
+++ b/AppControl Manager/Pages/EventLogsPolicyCreation.xaml.cs
@@ -240,7 +240,18 @@ public sealed partial class EventLogsPolicyCreation : Page
 			CodeIntegrityEVTX = selectedFile;
 
 			Logger.Write($"Selected {selectedFile} for Code Integrity EVTX log scanning");
+
+			SelectedCodeIntegrityEVTXFilesFlyout_TextBox.Text = selectedFile;
 		}
+
+		SelectedCodeIntegrityEVTXFilesFlyout.ShowAt(BrowseForEVTXDropDownButton);
+	}
+
+
+	private void SelectedCodeIntegrityEVTXFilesFlyout_Clear_Click(object sender, RoutedEventArgs e)
+	{
+		SelectedCodeIntegrityEVTXFilesFlyout_TextBox.Text = null;
+		CodeIntegrityEVTX = null;
 	}
 
 
@@ -259,9 +270,19 @@ public sealed partial class EventLogsPolicyCreation : Page
 			AppLockerEVTX = selectedFile;
 
 			Logger.Write($"Selected {selectedFile} for AppLocker EVTX log scanning");
+
+			SelectedAppLockerEVTXFilesFlyout_TextBox.Text = selectedFile;
 		}
+
+		SelectedAppLockerEVTXFilesFlyout.ShowAt(BrowseForEVTXDropDownButton);
 	}
 
+
+	private void SelectedAppLockerEVTXFilesFlyout_Clear_Click(object sender, RoutedEventArgs e)
+	{
+		SelectedAppLockerEVTXFilesFlyout_TextBox.Text = null;
+		AppLockerEVTX = null;
+	}
 
 
 	/// <summary>

--- a/AppControl Manager/Pages/MDEAHPolicyCreation.xaml
+++ b/AppControl Manager/Pages/MDEAHPolicyCreation.xaml
@@ -207,7 +207,27 @@ Spacing="8">
                 </SplitButton>
 
 
-                <Button x:Name="BrowseForLogs" ToolTipService.ToolTip="Browse for Advanced Hunting Logs" Click="BrowseForLogs_Click" >
+                <Button x:Name="BrowseForLogs" ToolTipService.ToolTip="Browse for Advanced Hunting Logs" Click="BrowseForLogs_Click"
+                        Holding="BrowseForLogs_Holding" RightTapped="BrowseForLogs_RightTapped">
+
+                    <Button.Flyout>
+                        <Flyout x:Name="BrowseForLogs_Flyout">
+
+                            <controls:WrapPanel Orientation="Vertical" HorizontalSpacing="15" VerticalSpacing="15">
+
+                                <Button Content="Clear" Click="BrowseForLogs_Flyout_Clear_Click" />
+
+                                <TextBlock Text="View the log files you selected." TextWrapping="WrapWholeWords" />
+
+                                <TextBox x:Name="BrowseForLogs_SelectedFilesTextBox"
+                                    TextWrapping="Wrap" AcceptsReturn="True" IsSpellCheckEnabled="False"
+                                    MinWidth="400" IsReadOnly="True" />
+
+                            </controls:WrapPanel>
+
+                        </Flyout>
+                    </Button.Flyout>
+
                     <Button.Content>
                         <StackPanel Orientation="Horizontal">
                             <FontIcon Glyph="&#xEC50;" />

--- a/AppControl Manager/Pages/MDEAHPolicyCreation.xaml.cs
+++ b/AppControl Manager/Pages/MDEAHPolicyCreation.xaml.cs
@@ -10,8 +10,10 @@ using AppControlManager.Main;
 using AppControlManager.Others;
 using AppControlManager.XMLOps;
 using CommunityToolkit.WinUI.UI.Controls;
+using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Navigation;
 using Windows.ApplicationModel.DataTransfer;
 
@@ -260,6 +262,8 @@ public sealed partial class MDEAHPolicyCreation : Page
 			Logger.Write($"Selected {selectedFile} for MDE Advanced Hunting scan");
 
 			ScanLogs.IsEnabled = true;
+
+			BrowseForLogs_SelectedFilesTextBox.Text += selectedFile + Environment.NewLine;
 		}
 	}
 
@@ -969,6 +973,25 @@ public sealed partial class MDEAHPolicyCreation : Page
 				throw new InvalidOperationException($"{selectedText} is not a valid Scan Level");
 			}
 		}
+	}
+
+	private void BrowseForLogs_Holding(object sender, HoldingRoutedEventArgs e)
+	{
+		if (e.HoldingState is HoldingState.Started)
+			if (!BrowseForLogs_Flyout.IsOpen)
+				BrowseForLogs_Flyout.ShowAt(BrowseForLogs);
+	}
+
+	private void BrowseForLogs_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!BrowseForLogs_Flyout.IsOpen)
+			BrowseForLogs_Flyout.ShowAt(BrowseForLogs);
+	}
+
+	private void BrowseForLogs_Flyout_Clear_Click(object sender, RoutedEventArgs e)
+	{
+		BrowseForLogs_SelectedFilesTextBox.Text = null;
+		MDEAdvancedHuntingLogs = null;
 	}
 
 }

--- a/AppControl Manager/Pages/MergePolicies.xaml
+++ b/AppControl Manager/Pages/MergePolicies.xaml
@@ -97,9 +97,10 @@
                     <controls:SettingsExpander.Items>
 
                         <controls:SettingsCard Description="Browse for the path to the main policy XML file." IsClickEnabled="True"
-                               Header="Select Main Policy" x:Name="MainPolicySettingsCard" Click="MainPolicySettingsCard_Click" IsActionIconVisible="False">
+                               Header="Select Main Policy" x:Name="MainPolicySettingsCard" Click="MainPolicySettingsCard_Click"
+                               Holding="MainPolicySettingsCard_Holding" RightTapped="MainPolicySettingsCard_RightTapped" IsActionIconVisible="False">
 
-                            <Button Content="Browse" x:Name="MainPolicyBrowseButton" Click="MainPolicyBrowseButton_Click">
+                            <Button Content="Browse" RightTapped="MainPolicyBrowseButton_RightTapped" x:Name="MainPolicyBrowseButton" Click="MainPolicyBrowseButton_Click">
 
                                 <Button.Flyout>
                                     <Flyout x:Name="MainPolicy_Flyout">
@@ -124,9 +125,10 @@
                         </controls:SettingsCard>
 
                         <controls:SettingsCard Description="Select other policies to merge with the main policy" IsClickEnabled="True"
-                            Header="Select other policies" x:Name="OtherPoliciesSettingsCard" Click="OtherPoliciesSettingsCard_Click" IsActionIconVisible="False">
+                            Header="Select other policies" x:Name="OtherPoliciesSettingsCard" Click="OtherPoliciesSettingsCard_Click"
+                            Holding="OtherPoliciesSettingsCard_Holding" RightTapped="OtherPoliciesSettingsCard_RightTapped" IsActionIconVisible="False">
 
-                            <Button Content="Browse" x:Name="OtherPoliciesBrowseButton" Click="OtherPoliciesBrowseButton_Click">
+                            <Button Content="Browse" x:Name="OtherPoliciesBrowseButton" RightTapped="OtherPoliciesBrowseButton_RightTapped" Click="OtherPoliciesBrowseButton_Click">
 
                                 <Button.Flyout>
                                     <Flyout x:Name="OtherPolicies_Flyout">

--- a/AppControl Manager/Pages/MergePolicies.xaml.cs
+++ b/AppControl Manager/Pages/MergePolicies.xaml.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using AppControlManager.Others;
+using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Navigation;
 
 namespace AppControlManager.Pages;
@@ -81,11 +83,11 @@ public sealed partial class MergePolicies : Page
 				{
 
 					_ = DispatcherQueue.TryEnqueue(() =>
-					 {
-						 PolicyMergerInfoBar.Message = "Deploying the main policy after merge.";
-					 });
+					{
+						PolicyMergerInfoBar.Message = "Deploying the main policy after merge.";
+					});
 
-					string stagingArea = (StagingArea.NewStagingArea("PolicyMerger")).FullName;
+					string stagingArea = StagingArea.NewStagingArea("PolicyMerger").FullName;
 
 					string CIPPath = Path.Combine(stagingArea, "MergedPolicy.cip");
 
@@ -95,16 +97,12 @@ public sealed partial class MergePolicies : Page
 				}
 
 			});
-
 		}
-
 		catch
 		{
 			errorsOccurred = true;
-
 			throw;
 		}
-
 		finally
 		{
 
@@ -160,10 +158,10 @@ public sealed partial class MergePolicies : Page
 
 			// Add the selected main XML policy file path to the flyout's TextBox
 			MainPolicy_Flyout_TextBox.Text = selectedFile;
-		}
 
-		// Manually display the Flyout since user clicked/tapped on the Settings card and not the button itself
-		MainPolicy_Flyout.ShowAt(MainPolicySettingsCard);
+			// Manually display the Flyout since user clicked/tapped on the Settings card and not the button itself
+			MainPolicy_Flyout.ShowAt(MainPolicySettingsCard);
+		}
 	}
 
 
@@ -200,10 +198,10 @@ public sealed partial class MergePolicies : Page
 				// Append the new file to the TextBox, followed by a newline
 				OtherPolicies_Flyout_TextBox.Text += file + Environment.NewLine;
 			}
-		}
 
-		// Manually display the Flyout since user clicked/tapped on the Settings card and not the button itself
-		OtherPolicies_Flyout.ShowAt(OtherPoliciesSettingsCard);
+			// Manually display the Flyout since user clicked/tapped on the Settings card and not the button itself
+			OtherPolicies_Flyout.ShowAt(OtherPoliciesSettingsCard);
+		}
 	}
 
 	private void MainPolicy_Flyout_ClearButton(object sender, RoutedEventArgs e)
@@ -218,5 +216,41 @@ public sealed partial class MergePolicies : Page
 		otherPolicies.Clear();
 	}
 
+	private void MainPolicySettingsCard_Holding(object sender, HoldingRoutedEventArgs e)
+	{
+		if (e.HoldingState is HoldingState.Started)
+			if (!MainPolicy_Flyout.IsOpen)
+				MainPolicy_Flyout.ShowAt(MainPolicySettingsCard);
+	}
 
+	private void MainPolicySettingsCard_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!MainPolicy_Flyout.IsOpen)
+			MainPolicy_Flyout.ShowAt(MainPolicySettingsCard);
+	}
+
+	private void MainPolicyBrowseButton_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!MainPolicy_Flyout.IsOpen)
+			MainPolicy_Flyout.ShowAt(MainPolicyBrowseButton);
+	}
+
+	private void OtherPoliciesSettingsCard_Holding(object sender, HoldingRoutedEventArgs e)
+	{
+		if (e.HoldingState is HoldingState.Started)
+			if (!OtherPolicies_Flyout.IsOpen)
+				OtherPolicies_Flyout.ShowAt(OtherPoliciesSettingsCard);
+	}
+
+	private void OtherPoliciesSettingsCard_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!OtherPolicies_Flyout.IsOpen)
+			OtherPolicies_Flyout.ShowAt(OtherPoliciesSettingsCard);
+	}
+
+	private void OtherPoliciesBrowseButton_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!OtherPolicies_Flyout.IsOpen)
+			OtherPolicies_Flyout.ShowAt(OtherPoliciesBrowseButton);
+	}
 }

--- a/AppControl Manager/Pages/Simulation.xaml
+++ b/AppControl Manager/Pages/Simulation.xaml
@@ -63,29 +63,95 @@
                     </StackPanel>
                 </Button>
 
-                <!-- Select XML File Button and TextBox for File Path -->
-                <Button Click="SelectXmlFileButton_Click" ToolTipService.ToolTip="Browse for the App Control policy XML file">
-                    <StackPanel Orientation="Horizontal">
-                        <FontIcon Glyph="&#xEC50;" />
-                        <TextBlock Text="Select XML File" Margin="5,0,0,0"/>
-                    </StackPanel>
+                <!-- Select XML File Button -->
+                <Button Click="SelectXmlFileButton_Click" x:Name="SelectXmlFileButton"
+                 Holding="SelectXmlFileButton_Holding" RightTapped="SelectXmlFileButton_RightTapped" ToolTipService.ToolTip="Browse for the App Control policy XML file">
+
+                    <Button.Flyout>
+                        <Flyout x:Name="SelectXmlFileButton_Flyout">
+
+                            <controls:WrapPanel Orientation="Vertical" HorizontalSpacing="15" VerticalSpacing="15">
+
+                                <Button Content="Clear" Click="SelectXmlFileButton_Flyout_Clear_Click" />
+
+                                <TextBlock Text="View the XML file you selected." TextWrapping="WrapWholeWords" />
+
+                                <TextBox x:Name="SelectXmlFileButton_SelectedFilesTextBox"
+                                    TextWrapping="Wrap" AcceptsReturn="True" IsSpellCheckEnabled="False"
+                                    MinWidth="400" IsReadOnly="True" />
+
+                            </controls:WrapPanel>
+
+                        </Flyout>
+                    </Button.Flyout>
+
+                    <Button.Content>
+                        <StackPanel Orientation="Horizontal">
+                            <FontIcon Glyph="&#xEC50;" />
+                            <TextBlock Text="Select XML File" Margin="5,0,0,0"/>
+                        </StackPanel>
+                    </Button.Content>
                 </Button>
-                <TextBox x:Name="XmlFilePathTextBox" IsReadOnly="True" PlaceholderText="XML File Path..." VerticalAlignment="Center" MaxWidth="300" />
 
                 <!-- Select Files Button -->
-                <Button Click="SelectFilesButton_Click" ToolTipService.ToolTip="Browse for files to include in the simulation">
-                    <StackPanel Orientation="Horizontal">
-                        <FontIcon Glyph="&#xEC50;" />
-                        <TextBlock Text="Select Files" Margin="5,0,0,0"/>
-                    </StackPanel>
+                <Button Click="SelectFilesButton_Click" x:Name="SelectFilesButton" RightTapped="SelectFilesButton_RightTapped" Holding="SelectFilesButton_Holding" ToolTipService.ToolTip="Browse for files to include in the simulation">
+
+                    <Button.Flyout>
+                        <Flyout x:Name="SelectFilesButton_Flyout">
+
+                            <controls:WrapPanel Orientation="Vertical" HorizontalSpacing="15" VerticalSpacing="15">
+
+                                <Button Content="Clear" Click="SelectFilesButton_Flyout_Clear_Click" />
+
+                                <TextBlock Text="View the files you selected." TextWrapping="WrapWholeWords" />
+
+                                <TextBox x:Name="SelectFilesButton_SelectedFilesTextBox"
+                                    TextWrapping="Wrap" AcceptsReturn="True" IsSpellCheckEnabled="False"
+                                    MinWidth="400" IsReadOnly="True" />
+
+                            </controls:WrapPanel>
+
+                        </Flyout>
+                    </Button.Flyout>
+
+
+                    <Button.Content>
+                        <StackPanel Orientation="Horizontal">
+                            <FontIcon Glyph="&#xEC50;" />
+                            <TextBlock Text="Select Files" Margin="5,0,0,0"/>
+                        </StackPanel>
+                    </Button.Content>
                 </Button>
 
                 <!-- Select Folders Button -->
-                <Button Click="SelectFoldersButton_Click" ToolTipService.ToolTip="Browse for a folder to include in the simulation">
-                    <StackPanel Orientation="Horizontal">
-                        <FontIcon Glyph="&#xED25;" />
-                        <TextBlock Text="Select Folders" Margin="5,0,0,0"/>
-                    </StackPanel>
+                <Button Click="SelectFoldersButton_Click" x:Name="SelectFoldersButton"
+                 Holding="SelectFoldersButton_Holding" RightTapped="SelectFoldersButton_RightTapped" ToolTipService.ToolTip="Browse for a folder to include in the simulation">
+
+                    <Button.Flyout>
+                        <Flyout x:Name="SelectFoldersButton_Flyout">
+
+                            <controls:WrapPanel Orientation="Vertical" HorizontalSpacing="15" VerticalSpacing="15">
+
+                                <Button Content="Clear" Click="SelectFoldersButton_Flyout_Clear_Click" />
+
+                                <TextBlock Text="View the folders you selected." TextWrapping="WrapWholeWords" />
+
+                                <TextBox x:Name="SelectFoldersButton_SelectedFilesTextBox"
+                                    TextWrapping="Wrap" AcceptsReturn="True" IsSpellCheckEnabled="False"
+                                    MinWidth="400" IsReadOnly="True" />
+
+                            </controls:WrapPanel>
+
+                        </Flyout>
+                    </Button.Flyout>
+
+
+                    <Button.Content>
+                        <StackPanel Orientation="Horizontal">
+                            <FontIcon Glyph="&#xED25;" />
+                            <TextBlock Text="Select Folders" Margin="5,0,0,0"/>
+                        </StackPanel>
+                    </Button.Content>
                 </Button>
 
 

--- a/AppControl Manager/Pages/Simulation.xaml.cs
+++ b/AppControl Manager/Pages/Simulation.xaml.cs
@@ -10,9 +10,11 @@ using AppControlManager.Main;
 using AppControlManager.Others;
 using CommunityToolkit.WinUI.Controls;
 using CommunityToolkit.WinUI.UI.Controls;
+using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Navigation;
 using Windows.ApplicationModel.DataTransfer;
 
@@ -155,7 +157,7 @@ public sealed partial class Simulation : Page
 			xmlFilePath = selectedFile;
 
 			// Update the TextBox with the selected XML file path
-			XmlFilePathTextBox.Text = selectedFile;
+			SelectXmlFileButton_SelectedFilesTextBox.Text = selectedFile;
 		}
 	}
 
@@ -168,18 +170,27 @@ public sealed partial class Simulation : Page
 		if (selectedFiles is { Count: > 0 })
 		{
 			filePaths = [.. selectedFiles];
+
+			foreach (string file in selectedFiles)
+			{
+				SelectFilesButton_SelectedFilesTextBox.Text += file + Environment.NewLine;
+			}
 		}
 	}
 
 	// Event handler for the Select Folders button
 	private void SelectFoldersButton_Click(object sender, RoutedEventArgs e)
 	{
+		List<string>? selectedFolders = FileDialogHelper.ShowMultipleDirectoryPickerDialog();
 
-		string? selectedFolder = FileDialogHelper.ShowDirectoryPickerDialog();
-
-		if (!string.IsNullOrEmpty(selectedFolder))
+		if (selectedFolders is { Count: > 0 })
 		{
-			folderPaths.Add(selectedFolder);
+			foreach (string folder in selectedFolders)
+			{
+				folderPaths.Add(folder);
+
+				SelectFoldersButton_SelectedFilesTextBox.Text += folder + Environment.NewLine;
+			}
 		}
 	}
 
@@ -424,5 +435,61 @@ public sealed partial class Simulation : Page
 		Clipboard.SetContent(dataPackage);
 	}
 
+	private void SelectXmlFileButton_Holding(object sender, HoldingRoutedEventArgs e)
+	{
+		if (e.HoldingState is HoldingState.Started)
+			if (!SelectXmlFileButton_Flyout.IsOpen)
+				SelectXmlFileButton_Flyout.ShowAt(SelectXmlFileButton);
+	}
+
+	private void SelectXmlFileButton_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!SelectXmlFileButton_Flyout.IsOpen)
+			SelectXmlFileButton_Flyout.ShowAt(SelectXmlFileButton);
+	}
+
+	private void SelectXmlFileButton_Flyout_Clear_Click(object sender, RoutedEventArgs e)
+	{
+		SelectXmlFileButton_SelectedFilesTextBox.Text = null;
+		xmlFilePath = null;
+	}
+
+	private void SelectFilesButton_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!SelectFilesButton_Flyout.IsOpen)
+			SelectFilesButton_Flyout.ShowAt(SelectFilesButton);
+	}
+
+	private void SelectFilesButton_Holding(object sender, HoldingRoutedEventArgs e)
+	{
+		if (e.HoldingState is HoldingState.Started)
+			if (!SelectFilesButton_Flyout.IsOpen)
+				SelectFilesButton_Flyout.ShowAt(SelectFilesButton);
+	}
+
+	private void SelectFilesButton_Flyout_Clear_Click(object sender, RoutedEventArgs e)
+	{
+		SelectFilesButton_SelectedFilesTextBox.Text = null;
+		filePaths.Clear();
+	}
+
+	private void SelectFoldersButton_Flyout_Clear_Click(object sender, RoutedEventArgs e)
+	{
+		SelectFoldersButton_SelectedFilesTextBox.Text = null;
+		folderPaths.Clear();
+	}
+
+	private void SelectFoldersButton_Holding(object sender, HoldingRoutedEventArgs e)
+	{
+		if (e.HoldingState is HoldingState.Started)
+			if (!SelectFoldersButton_Flyout.IsOpen)
+				SelectFoldersButton_Flyout.ShowAt(SelectFoldersButton);
+	}
+
+	private void SelectFoldersButton_RightTapped(object sender, RightTappedRoutedEventArgs e)
+	{
+		if (!SelectFoldersButton_Flyout.IsOpen)
+			SelectFoldersButton_Flyout.ShowAt(SelectFoldersButton);
+	}
 
 }

--- a/AppControl Manager/app.manifest
+++ b/AppControl Manager/app.manifest
@@ -2,7 +2,7 @@
 <!-- INFO: https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests -->
 <!-- INFO (for legacy UWP but its info can be used for better understanding): https://learn.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/root-elements -->
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.8.6.0" name="AppControlManager"/>
+  <assemblyIdentity version="1.8.7.0" name="AppControlManager"/>
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>

--- a/Wiki posts/AppControl Manager/Configure Policy Rule Options.md
+++ b/Wiki posts/AppControl Manager/Configure Policy Rule Options.md
@@ -15,3 +15,11 @@ Use this page in [AppControl Manager](https://github.com/HotCakeX/Harden-Windows
 Additionally, this page offers policy templates. These are pre-configured set of rule options suitable for each use case. Use the drop down menu to select one and apply it to an XML policy file.
 
 <br>
+
+## Configuration Details
+
+* **Apply The Changes**: Press this button to apply the changes you made to the policy rule options.
+
+* **Retrieve Rules States**: **By default, when you select an XML policy file, the checkboxes representing the rule options will be checked or unchecked according to the rule options in that file.** If you want to retrieve the rule options from the XML policy file again, maybe after modifying it manually, press this button.
+
+<br>


### PR DESCRIPTION
* Added flyouts with buttons to the EVTX file path selector buttons in the [Create Policy From Event Logs](https://github.com/HotCakeX/Harden-Windows-Security/wiki/Create-Policy-From-Event-Logs) page. Now whenever you select EVTX files, a small flyout will open, displaying the path you selected and offers a **Clear** button so you can clear the selected path if you want. This is aligned with the rest of the browse button behaviors throughout the AppControl Manager's UI.

* Added the same flyout feature to the [MDE Advanced Hunting page](https://github.com/HotCakeX/Harden-Windows-Security/wiki/Create-Policy-From-MDE-Advanced-Hunting) for the browse for CSV button.

* ✨In the AppControl Manager, all buttons that allow you to browse for files and folders already feature flyouts—small pop-up areas that display the selected files or folders. Previously, these flyouts would only appear after a left-click or tap on the browse buttons, which would first launch the file/folder picker and then display the flyout. In this update, the flyouts can now also be triggered by right-clicking the buttons or, on touch-enabled devices, by tapping and holding the buttons. This enhancement improves your experience by making it easier to view your selected content without needing to click the browse button again to launch the file/folder picker.

* Version bump from `1.8.6.0` to `1.8.7.0`

* Added JSON source generation support for the Intune class, making it Native AOT/Trim friendly and faster.

* The [Simulation](https://github.com/HotCakeX/Harden-Windows-Security/wiki/Simulation) page's folder picker now supports picking multiple folders. Previously it only supported picking 1 folder.

* The [Configure Policy Rule Options](https://github.com/HotCakeX/Harden-Windows-Security/wiki/Configure-Policy-Rule-Options) page now automatically shows you the available rule options in the XML file you select by checking/unchecking any boxes in the UI, they are dynamically updated to reflect the XML file's rule options. 
   * The buttons were also simplified and there are no longer any Add/Remove/Select All buttons. They were replaced by "Apply the changes" and "Retrieve Rules Status" buttons.

   * Additionally, the entire row containing each checkbox is now clickable, making interaction easier. 

   * When using a template, checkboxes update automatically in real time, reflecting the latest changes instantly. These enhancements significantly improve usability and efficiency.

<br>
