### PR TITLE
Made bootstrapper script compatible with ConstLang

### DIFF
--- a/Harden-Windows-Security.ps1
+++ b/Harden-Windows-Security.ps1
@@ -4,26 +4,25 @@ Function P {
     $ErrorActionPreference = 'Stop'
     Set-ExecutionPolicy -ExecutionPolicy 'Unrestricted' -Scope 'Process' -Force
     [string]$PSDownloadURLMSIX = 'https://github.com/PowerShell/PowerShell/releases/download/v7.4.6/PowerShell-7.4.6-win.msixbundle'
-    [string]$PSMSIXDownloadPath = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), 'PowerShell.msixbundle')
+    [string]$PSMSIXDownloadPath = Join-Path -Path $env:TEMP -ChildPath 'PowerShell.msixbundle'
     try {
         if ($PSVersionTable.PSEdition -eq 'Desktop' -and !(Get-Command -Name 'pwsh.exe' -ErrorAction Ignore)) {
-            $User = Get-LocalUser | Where-Object -FilterScript { $_.SID -eq ([System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value) }
             Write-Verbose -Message 'Trying to Install PowerShell Core because it could not be found on the system' -Verbose
-            if ($User.PrincipalSource -eq 'MicrosoftAccount' -and (Get-Command -Name 'winget.exe' -ErrorAction Ignore)) {
+            if ((Get-LocalUser -Name ([System.Environment]::UserName)).PrincipalSource -eq 'MicrosoftAccount' -and (Get-Command -Name 'winget.exe' -ErrorAction Ignore)) {
                 # https://apps.microsoft.com/detail/9mz1snwt0n5d
                 Write-Verbose -Message 'Microsoft account detected, using Microsoft Store source for PowerShell installation through Winget'
                 $null = Winget install --id 9MZ1SNWT0N5D --accept-package-agreements --accept-source-agreements --source msstore
                 if ($LASTEXITCODE -ne 0) { throw "Failed to Install PowerShell Core using Winget: $LASTEXITCODE" }
             }
             else {
-                if ([System.IO.File]::Exists($PSMSIXDownloadPath)) { [System.IO.File]::Delete($PSMSIXDownloadPath) }
+                if (Test-Path -Path $PSMSIXDownloadPath -PathType Leaf) { Remove-Item -Path $PSMSIXDownloadPath -Force }
                 Write-Verbose -Message 'Local account detected or winget is not installed, cannot install PowerShell Core from Microsoft Store using Winget and msstore as the source. Downloading and Installing PowerShell directly from the official Microsoft GitHub repository using MSIX file'
                 Invoke-WebRequest -Uri $PSDownloadURLMSIX -OutFile $PSMSIXDownloadPath
                 Add-AppxPackage -Path $PSMSIXDownloadPath
             }
         }
     }
-    finally { if ([System.IO.File]::Exists($PSMSIXDownloadPath)) { [System.IO.File]::Delete($PSMSIXDownloadPath) } }
+    finally { if (Test-Path -Path $PSMSIXDownloadPath -PathType Leaf) { Remove-Item -Path $PSMSIXDownloadPath -Force } }
     pwsh.exe -NoProfile -NoLogo -NoExit -Command {
         Set-ExecutionPolicy -ExecutionPolicy 'Unrestricted' -Scope 'Process' -Force
         if (!(Get-Module -ListAvailable -Name 'Harden-Windows-Security-Module' -ErrorAction Ignore)) {
@@ -41,16 +40,18 @@ Function AppControl {
     .PARAMETER MSIXPath
         The path to the AppControlManager MSIX file. If not provided, the latest MSIX file will be downloaded from the GitHub. It must have the version number and architecture in its file name as provided on GitHub or produced by Visual Studio.
     .PARAMETER SignTool
-       The path to the Microsoft's Signtool.exe If not provided, the function automatically downloads the latest SignTool.exe from the Microsoft website in Nuget and will use it for the signing operations.
+       The path to the Microsoft's Signtool.exe; If not provided, the function automatically downloads the latest SignTool.exe from the Microsoft website in Nuget and will use it for the signing operations.
     #>
     [CmdletBinding()]
-    param (
-        [Parameter(Mandatory = $false)][string]$MSIXPath, [Parameter(Mandatory = $False)][string]$SignTool
-    )
-    $ErrorActionPreference = 'Stop'
-    if (!([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
-        Write-Warning -Message 'Please run this function as an Administrator'; return
+    param ([Parameter(Mandatory = $false)][string]$MSIXPath, [Parameter(Mandatory = $False)][string]$SignTool)
+    if ($ExecutionContext.SessionState.LanguageMode -eq 'ConstrainedLanguage') { Write-Host -Object 'Constrained Language Mode detected. Ensure you have Administrator privileges.' -ForegroundColor Magenta }
+    else {
+        # We cannot use .NET methods in ConstrainedLanguage mode
+        if (!([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+            Write-Warning -Message 'Please run this function as an Administrator'; return
+        }
     }
+    $ErrorActionPreference = 'Stop'
     Write-Verbose -Message 'Detecting the CPU Arch'
     switch ($Env:PROCESSOR_ARCHITECTURE) {
         'AMD64' { [string]$CPUArch = 'x64'; break }
@@ -58,16 +59,15 @@ Function AppControl {
         default { Throw [System.PlatformNotSupportedException] 'Only AMD64 and ARM64 architectures are supported.' }
     }
     [string]$CommonName = 'SelfSignedCertForAppControlManager'
-    [string]$WorkingDir = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), $CommonName)
-    [string]$CertificateOutputPath = [System.IO.Path]::Combine($WorkingDir, "$CommonName.cer")
+    [string]$WorkingDir = Join-Path -Path $env:TEMP -ChildPath $CommonName
+    [string]$CertificateOutputPath = Join-Path -Path $WorkingDir -ChildPath "$CommonName.cer"
     [string]$HashingAlgorithm = 'Sha512'
-
     # Pattern for AppControl Manager version and architecture extraction from file path and download link URL
     [regex]$RegexPattern = '_(?<Version>\d+\.\d+\.\d+\.\d+)_(?<Architecture>x64|arm64)\.msix$'
 
     Write-Verbose -Message 'Creating the working directory in the TEMP directory'
-    if ([System.IO.Directory]::Exists($WorkingDir)) { [System.IO.Directory]::Delete($WorkingDir, $true) }
-    $null = [System.IO.Directory]::CreateDirectory($WorkingDir)
+    if (Test-Path -Path $WorkingDir -PathType Container) { Remove-Item -Path $WorkingDir -Recurse -Force }
+    $null = New-Item -Path $WorkingDir -ItemType Directory -Force
 
     try {
         Write-Verbose -Message "Checking if a certificate with the common name '$CommonName' already exists."
@@ -80,7 +80,6 @@ Function AppControl {
                 }
             }
         }
-
         Write-Verbose -Message 'Building the certificate'
         [System.Collections.Hashtable]$Params = @{
             Subject           = "CN=$CommonName"
@@ -114,7 +113,7 @@ Function AppControl {
 
         # Download the MSIX package if user did not provide the path to it
         if ([string]::IsNullOrWhiteSpace($MSIXPath)) {
-            [string]$MSIXPath = [System.IO.Path]::Combine($WorkingDir, 'AppControl.Manager.msix')
+            [string]$MSIXPath = Join-Path -Path $WorkingDir -ChildPath 'AppControl.Manager.msix'
 
             # Download link for the latest version of AppControl manger is retrieved from this text file
             [string]$MSIXPackageDownloadURL = Invoke-RestMethod -Uri 'https://raw.githubusercontent.com/HotCakeX/Harden-Windows-Security/refs/heads/main/AppControl%20Manager/DownloadURL.txt'
@@ -123,10 +122,10 @@ Function AppControl {
             $null = Invoke-WebRequest -Uri $MSIXPackageDownloadURL -OutFile $MSIXPath
 
             # Get the version and architecture of the installing MSIX package app from the download URL
-            $RegexMatch = $RegexPattern.Match($MSIXPackageDownloadURL)
+            [System.Text.RegularExpressions.Match]$RegexMatch = $RegexPattern.Match($MSIXPackageDownloadURL)
             if ($RegexMatch.Success) {
-                $InstallingAppVersion = $RegexMatch.Groups['Version'].Value
-                $InstallingAppArchitecture = $RegexMatch.Groups['Architecture'].Value
+                [string]$InstallingAppVersion = $RegexMatch.Groups['Version'].Value
+                [string]$InstallingAppArchitecture = $RegexMatch.Groups['Architecture'].Value
             }
             else {
                 throw 'Could not get the version of the installing app from the MSIX download URL.'
@@ -134,10 +133,10 @@ Function AppControl {
         }
         else {
             # Get the version and architecture of the installing MSIX package app from the User provided file path
-            $RegexMatch = $RegexPattern.Match($MSIXPath)
+            [System.Text.RegularExpressions.Match]$RegexMatch = $RegexPattern.Match($MSIXPath)
             if ($RegexMatch.Success) {
-                $InstallingAppVersion = $RegexMatch.Groups['Version'].Value
-                $InstallingAppArchitecture = $RegexMatch.Groups['Architecture'].Value
+                [string]$InstallingAppVersion = $RegexMatch.Groups['Version'].Value
+                [string]$InstallingAppArchitecture = $RegexMatch.Groups['Architecture'].Value
             }
             else {
                 throw 'Could not get the version of the installing app from the -MSIX parameter value that you provided.'
@@ -171,7 +170,7 @@ Function AppControl {
             # The cmdlet won't add duplicates
             Add-MpPreference -AttackSurfaceReductionOnlyExclusions (($InstallingAppLocationToAdd + 'AppControlManager.exe'), ($InstallingAppLocationToAdd + 'AppControlManager.dll')) -ErrorAction Stop
 
-            $ValidateAdminCodeSignaturesRegName = 'ValidateAdminCodeSignatures'
+            [string]$ValidateAdminCodeSignaturesRegName = 'ValidateAdminCodeSignatures'
             $ValidateAdminCodeSignaturesRegValue = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System' -Name $ValidateAdminCodeSignaturesRegName -ErrorAction SilentlyContinue
             # This will cause the "A referral was returned from the server." error to show up when AppControl Manager tries to start.
             if ($ValidateAdminCodeSignaturesRegValue.$ValidateAdminCodeSignaturesRegName -eq 1) {
@@ -183,5 +182,5 @@ Function AppControl {
         Write-Verbose -Message "Installing AppControl Manager MSIX Package version '$InstallingAppVersion' with architecture '$InstallingAppArchitecture'"
         Add-AppPackage -Path $MSIXPath -ForceUpdateFromAnyVersion -DeferRegistrationWhenPackagesAreInUse
     }
-    finally { [System.IO.Directory]::Delete($WorkingDir, $true) } # Cleaning up the working directory in the TEMP directory
+    finally { Remove-Item -Path $WorkingDir -Recurse -Force } # Cleaning up the working directory in the TEMP directory
 }


### PR DESCRIPTION
The bootstrapper script is now fully compatible and able to run in locked down environments where PowerShell Constrained Language Mode is in effect, meaning there is an AppControl Policy that performs Script Enforcement.

Now you can seamlessly install the Harden Windows Security module and the AppControl Manager in those environments.

