### PR TITLE
AppControl Manager v1.8.8.0

### DIFF
--- a/AppControl Manager/AppControl Manager.csproj
+++ b/AppControl Manager/AppControl Manager.csproj
@@ -91,7 +91,7 @@
     <AssemblyName>AppControlManager</AssemblyName>
     <PublishAot>False</PublishAot>
     <ErrorReport>send</ErrorReport>
-    <FileVersion>1.8.7.0</FileVersion>
+    <FileVersion>1.8.8.0</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/AppControl Manager/IntelGathering/GetMDEAdvancedHuntingLogsData.cs
+++ b/AppControl Manager/IntelGathering/GetMDEAdvancedHuntingLogsData.cs
@@ -18,7 +18,6 @@ internal static class GetMDEAdvancedHuntingLogsData
 	internal static HashSet<FileIdentity> Retrieve(List<MDEAdvancedHuntingData> data)
 	{
 
-
 		// HashSet to store the output, ensures the data are unique and signed data are prioritized over unsigned data
 		FileIdentitySignatureBasedHashSet fileIdentities = new();
 
@@ -89,8 +88,8 @@ internal static class GetMDEAdvancedHuntingLogsData
 					SHA256Hash = possibleCodeIntegrityAuditEvent.SHA256,
 					SHA1FlatHash = possibleCodeIntegrityAuditEvent.Sha1FlatHash,
 					SHA256FlatHash = possibleCodeIntegrityAuditEvent.Sha256FlatHash,
-					USN = GetLongValue(possibleCodeIntegrityAuditEvent.USN),
-					SISigningScenario = GetIntValue(possibleCodeIntegrityAuditEvent.SiSigningScenario) ?? 1,
+					USN = possibleCodeIntegrityAuditEvent.USN,
+					SISigningScenario = possibleCodeIntegrityAuditEvent.SiSigningScenario ?? 1,
 					PolicyName = possibleCodeIntegrityAuditEvent.PolicyName,
 					PolicyID = possibleCodeIntegrityAuditEvent.PolicyID,
 					PolicyHash = possibleCodeIntegrityAuditEvent.PolicyHash,
@@ -130,13 +129,13 @@ internal static class GetMDEAdvancedHuntingLogsData
 						FileSignerInfo signerInfo = new()
 						{
 
-							TotalSignatureCount = GetIntValue(correlatedEvent.TotalSignatureCount),
-							Signature = GetIntValue(correlatedEvent.Signature),
+							TotalSignatureCount = correlatedEvent.TotalSignatureCount,
+							Signature = correlatedEvent.Signature,
 							Hash = correlatedEvent.Hash,
 							SignatureType = GetSignatureType(GetIntValue(correlatedEvent.SignatureType)),
 							ValidatedSigningLevel = GetValidatedRequestedSigningLevel(GetIntValue(correlatedEvent.ValidatedSigningLevel)),
 							VerificationError = GetVerificationError(GetIntValue(correlatedEvent.VerificationError)),
-							Flags = GetIntValue(correlatedEvent.Flags),
+							Flags = correlatedEvent.Flags,
 							NotValidBefore = GetEventDataDateTimeValue(correlatedEvent.NotValidBefore),
 							NotValidAfter = GetEventDataDateTimeValue(correlatedEvent.NotValidAfter),
 							PublisherName = PublisherName,
@@ -196,8 +195,8 @@ internal static class GetMDEAdvancedHuntingLogsData
 					SHA256Hash = possibleCodeIntegrityBlockEvent.SHA256,
 					SHA1FlatHash = possibleCodeIntegrityBlockEvent.Sha1FlatHash,
 					SHA256FlatHash = possibleCodeIntegrityBlockEvent.Sha256FlatHash,
-					USN = GetLongValue(possibleCodeIntegrityBlockEvent.USN),
-					SISigningScenario = GetIntValue(possibleCodeIntegrityBlockEvent.SiSigningScenario) ?? 1,
+					USN = possibleCodeIntegrityBlockEvent.USN,
+					SISigningScenario = possibleCodeIntegrityBlockEvent.SiSigningScenario ?? 1,
 					PolicyName = possibleCodeIntegrityBlockEvent.PolicyName,
 					PolicyID = possibleCodeIntegrityBlockEvent.PolicyID,
 					PolicyHash = possibleCodeIntegrityBlockEvent.PolicyHash,
@@ -237,13 +236,13 @@ internal static class GetMDEAdvancedHuntingLogsData
 						FileSignerInfo signerInfo = new()
 						{
 
-							TotalSignatureCount = GetIntValue(correlatedEvent.TotalSignatureCount),
-							Signature = GetIntValue(correlatedEvent.Signature),
+							TotalSignatureCount = correlatedEvent.TotalSignatureCount,
+							Signature = correlatedEvent.Signature,
 							Hash = correlatedEvent.Hash,
 							SignatureType = GetSignatureType(GetIntValue(correlatedEvent.SignatureType)),
 							ValidatedSigningLevel = GetValidatedRequestedSigningLevel(GetIntValue(correlatedEvent.ValidatedSigningLevel)),
 							VerificationError = GetVerificationError(GetIntValue(correlatedEvent.VerificationError)),
-							Flags = GetIntValue(correlatedEvent.Flags),
+							Flags = correlatedEvent.Flags,
 							NotValidBefore = GetEventDataDateTimeValue(correlatedEvent.NotValidBefore),
 							NotValidAfter = GetEventDataDateTimeValue(correlatedEvent.NotValidAfter),
 							PublisherName = PublisherName,
@@ -303,8 +302,8 @@ internal static class GetMDEAdvancedHuntingLogsData
 					SHA256Hash = possibleAppLockerAuditEvent.SHA256,
 					SHA1FlatHash = possibleAppLockerAuditEvent.Sha1FlatHash,
 					SHA256FlatHash = possibleAppLockerAuditEvent.Sha256FlatHash,
-					USN = GetLongValue(possibleAppLockerAuditEvent.USN),
-					SISigningScenario = GetIntValue(possibleAppLockerAuditEvent.SiSigningScenario) ?? 1,
+					USN = possibleAppLockerAuditEvent.USN,
+					SISigningScenario = possibleAppLockerAuditEvent.SiSigningScenario ?? 1,
 					PolicyName = possibleAppLockerAuditEvent.PolicyName,
 					PolicyID = possibleAppLockerAuditEvent.PolicyID,
 					PolicyHash = possibleAppLockerAuditEvent.PolicyHash,
@@ -344,13 +343,13 @@ internal static class GetMDEAdvancedHuntingLogsData
 						FileSignerInfo signerInfo = new()
 						{
 
-							TotalSignatureCount = GetIntValue(correlatedEvent.TotalSignatureCount),
-							Signature = GetIntValue(correlatedEvent.Signature),
+							TotalSignatureCount = correlatedEvent.TotalSignatureCount,
+							Signature = correlatedEvent.Signature,
 							Hash = correlatedEvent.Hash,
 							SignatureType = GetSignatureType(GetIntValue(correlatedEvent.SignatureType)),
 							ValidatedSigningLevel = GetValidatedRequestedSigningLevel(GetIntValue(correlatedEvent.ValidatedSigningLevel)),
 							VerificationError = GetVerificationError(GetIntValue(correlatedEvent.VerificationError)),
-							Flags = GetIntValue(correlatedEvent.Flags),
+							Flags = correlatedEvent.Flags,
 							NotValidBefore = GetEventDataDateTimeValue(correlatedEvent.NotValidBefore),
 							NotValidAfter = GetEventDataDateTimeValue(correlatedEvent.NotValidAfter),
 							PublisherName = PublisherName,
@@ -408,8 +407,8 @@ internal static class GetMDEAdvancedHuntingLogsData
 					SHA256Hash = possibleAppLockerBlockEvent.SHA256,
 					SHA1FlatHash = possibleAppLockerBlockEvent.Sha1FlatHash,
 					SHA256FlatHash = possibleAppLockerBlockEvent.Sha256FlatHash,
-					USN = GetLongValue(possibleAppLockerBlockEvent.USN),
-					SISigningScenario = GetIntValue(possibleAppLockerBlockEvent.SiSigningScenario) ?? 1,
+					USN = possibleAppLockerBlockEvent.USN,
+					SISigningScenario = possibleAppLockerBlockEvent.SiSigningScenario ?? 1,
 					PolicyName = possibleAppLockerBlockEvent.PolicyName,
 					PolicyID = possibleAppLockerBlockEvent.PolicyID,
 					PolicyHash = possibleAppLockerBlockEvent.PolicyHash,
@@ -449,13 +448,13 @@ internal static class GetMDEAdvancedHuntingLogsData
 						FileSignerInfo signerInfo = new()
 						{
 
-							TotalSignatureCount = GetIntValue(correlatedEvent.TotalSignatureCount),
-							Signature = GetIntValue(correlatedEvent.Signature),
+							TotalSignatureCount = correlatedEvent.TotalSignatureCount,
+							Signature = correlatedEvent.Signature,
 							Hash = correlatedEvent.Hash,
 							SignatureType = GetSignatureType(GetIntValue(correlatedEvent.SignatureType)),
 							ValidatedSigningLevel = GetValidatedRequestedSigningLevel(GetIntValue(correlatedEvent.ValidatedSigningLevel)),
 							VerificationError = GetVerificationError(GetIntValue(correlatedEvent.VerificationError)),
-							Flags = GetIntValue(correlatedEvent.Flags),
+							Flags = correlatedEvent.Flags,
 							NotValidBefore = GetEventDataDateTimeValue(correlatedEvent.NotValidBefore),
 							NotValidAfter = GetEventDataDateTimeValue(correlatedEvent.NotValidAfter),
 							PublisherName = PublisherName,
@@ -480,9 +479,7 @@ internal static class GetMDEAdvancedHuntingLogsData
 				// Add the entire event package to the output list
 				_ = fileIdentities.Add(eventData);
 
-
 			}
-
 		}
 
 
@@ -508,7 +505,6 @@ internal static class GetMDEAdvancedHuntingLogsData
 		return null;
 	}
 
-
 	/// <summary>
 	/// Method to safely get an integer value from string
 	/// </summary>
@@ -519,29 +515,23 @@ internal static class GetMDEAdvancedHuntingLogsData
 		return data is not null && int.TryParse(data, NumberStyles.Integer, CultureInfo.InvariantCulture, out int result) ? result : null;
 	}
 
-
-
 	/// <summary>
-	/// Converts string to DateTime
+	/// Safely converts string to DateTime
 	/// </summary>
 	private static DateTime? GetEventDataDateTimeValue(string? data)
 	{
 		return data is not null && DateTime.TryParse(data, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out DateTime result) ? result : null;
 	}
 
-
-
-	private static long? GetLongValue(string? data)
-	{
-		return data is not null && long.TryParse(data, NumberStyles.Integer, CultureInfo.InvariantCulture, out long result) ? result : null;
-	}
-
+	/// <summary>
+	/// Safely converts string to GUID
+	/// </summary>
+	/// <param name="data"></param>
+	/// <returns></returns>
 	private static Guid? GetGuidValue(string? data)
 	{
 		return data is not null && Guid.TryParse(data, out Guid guid) ? guid : null;
 	}
-
-
 
 	/// <summary>
 	/// Resolves the Validated/Requested Signing Level int to friendly string
@@ -562,7 +552,6 @@ internal static class GetMDEAdvancedHuntingLogsData
 		}
 	}
 
-
 	/// <summary>
 	/// Resolves the VerificationError int to a friendly string
 	/// </summary>
@@ -580,7 +569,6 @@ internal static class GetMDEAdvancedHuntingLogsData
 			return null;
 		}
 	}
-
 
 	/// <summary>
 	/// Resolves the SignatureType int to a friendly string
@@ -600,8 +588,6 @@ internal static class GetMDEAdvancedHuntingLogsData
 		}
 	}
 
-
 	#endregion
-
 
 }

--- a/AppControl Manager/IntelGathering/MDEAdvancedHuntingData.cs
+++ b/AppControl Manager/IntelGathering/MDEAdvancedHuntingData.cs
@@ -1,71 +1,749 @@
-﻿
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
 namespace AppControlManager.IntelGathering;
 
-// an internal class to store the structure of the new CSV data
+// The following converters are needed for when parsing the MDE AH CSV file
+// The parsing from JSON string via MS Graph doesn't require it, but we use it for both
+
+public class NullableBoolJsonConverter : JsonConverter<bool?>
+{
+	public override bool? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+	{
+		// If the token is a boolean, return it directly.
+		if (reader.TokenType == JsonTokenType.True)
+		{
+			return true;
+		}
+		if (reader.TokenType == JsonTokenType.False)
+		{
+			return false;
+		}
+
+		// If the token is a string, attempt to parse it.
+		if (reader.TokenType == JsonTokenType.String)
+		{
+			string? strValue = reader.GetString();
+			if (bool.TryParse(strValue, out bool boolValue))
+			{
+				return boolValue;
+			}
+			// handle numeric strings "1" or "0", just for future proofing
+			if (strValue == "1")
+			{
+				return true;
+			}
+			if (strValue == "0")
+			{
+				return false;
+			}
+		}
+
+		// If the token is null, return null.
+		if (reader.TokenType == JsonTokenType.Null)
+		{
+			return null;
+		}
+
+		// return null if conversion is not possible.
+		return null;
+	}
+
+	public override void Write(Utf8JsonWriter writer, bool? value, JsonSerializerOptions options)
+	{
+		if (value.HasValue)
+		{
+			writer.WriteBooleanValue(value.Value);
+		}
+		else
+		{
+			writer.WriteNullValue();
+		}
+	}
+}
+
+
+public class NullableIntJsonConverter : JsonConverter<int?>
+{
+	public override int? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+	{
+		// If the token is a number, read it directly.
+		if (reader.TokenType == JsonTokenType.Number && reader.TryGetInt32(out int value))
+		{
+			return value;
+		}
+
+		// If the token is a string, try to parse it.
+		if (reader.TokenType == JsonTokenType.String)
+		{
+			string? stringValue = reader.GetString();
+			if (int.TryParse(stringValue, out value))
+			{
+				return value;
+			}
+		}
+
+		// For any other token, return null
+		return null;
+	}
+
+	public override void Write(Utf8JsonWriter writer, int? value, JsonSerializerOptions options)
+	{
+		if (value.HasValue)
+		{
+			writer.WriteNumberValue(value.Value);
+		}
+		else
+		{
+			writer.WriteNullValue();
+		}
+	}
+}
+
+
+public class NullableLongJsonConverter : JsonConverter<long?>
+{
+	public override long? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+	{
+		// If the token is a long number, try to read it directly.
+		if (reader.TokenType == JsonTokenType.Number && reader.TryGetInt64(out long value))
+		{
+			return value;
+		}
+
+		// If the token is a string, try to parse it.
+		if (reader.TokenType == JsonTokenType.String)
+		{
+			string? stringValue = reader.GetString();
+			if (long.TryParse(stringValue, out value))
+			{
+				return value;
+			}
+		}
+
+		// Otherwise, return null
+		return null;
+	}
+
+	public override void Write(Utf8JsonWriter writer, long? value, JsonSerializerOptions options)
+	{
+		if (value.HasValue)
+		{
+			writer.WriteNumberValue(value.Value);
+		}
+		else
+		{
+			writer.WriteNullValue();
+		}
+	}
+}
+
+
+// The top-level object because the JSON file contains a "results" array.
+internal sealed class MDEAdvancedHuntingDataRootObject
+{
+	[JsonInclude]
+	[JsonPropertyName("results")]
+	internal List<MDEAdvancedHuntingData> Results { get; set; } = [];
+}
+
+// A custom converter on the type so that we can automatically merge properties
+// from the nested AdditionalFields JSON.
+// So this class contains its own properties + properties of the AdditionalFields class
+[JsonConverter(typeof(MDEAdvancedHuntingDataConverter))]
 internal sealed class MDEAdvancedHuntingData
 {
+	// Main properties (from the top-level JSON object)
+	[JsonInclude]
+	[JsonPropertyName("Timestamp")]
 	internal string? Timestamp { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("DeviceId")]
 	internal string? DeviceId { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("DeviceName")]
 	internal string? DeviceName { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("ActionType")]
 	internal string? ActionType { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("FileName")]
 	internal string? FileName { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("FolderPath")]
 	internal string? FolderPath { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("SHA1")]
 	internal string? SHA1 { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("SHA256")]
 	internal string? SHA256 { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("InitiatingProcessSHA1")]
 	internal string? InitiatingProcessSHA1 { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("InitiatingProcessSHA256")]
 	internal string? InitiatingProcessSHA256 { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("InitiatingProcessMD5")]
 	internal string? InitiatingProcessMD5 { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("InitiatingProcessFileName")]
 	internal string? InitiatingProcessFileName { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("InitiatingProcessFileSize")]
 	internal string? InitiatingProcessFileSize { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("InitiatingProcessFolderPath")]
 	internal string? InitiatingProcessFolderPath { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("InitiatingProcessId")]
 	internal string? InitiatingProcessId { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("InitiatingProcessCommandLine")]
 	internal string? InitiatingProcessCommandLine { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("InitiatingProcessCreationTime")]
 	internal string? InitiatingProcessCreationTime { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("InitiatingProcessAccountDomain")]
 	internal string? InitiatingProcessAccountDomain { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("InitiatingProcessAccountName")]
 	internal string? InitiatingProcessAccountName { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("InitiatingProcessAccountSid")]
 	internal string? InitiatingProcessAccountSid { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("InitiatingProcessVersionInfoCompanyName")]
 	internal string? InitiatingProcessVersionInfoCompanyName { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("InitiatingProcessVersionInfoProductName")]
 	internal string? InitiatingProcessVersionInfoProductName { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("InitiatingProcessVersionInfoProductVersion")]
 	internal string? InitiatingProcessVersionInfoProductVersion { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("InitiatingProcessVersionInfoInternalFileName")]
 	internal string? InitiatingProcessVersionInfoInternalFileName { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("InitiatingProcessVersionInfoOriginalFileName")]
 	internal string? InitiatingProcessVersionInfoOriginalFileName { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("InitiatingProcessVersionInfoFileDescription")]
 	internal string? InitiatingProcessVersionInfoFileDescription { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("InitiatingProcessParentId")]
 	internal string? InitiatingProcessParentId { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("InitiatingProcessParentFileName")]
 	internal string? InitiatingProcessParentFileName { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("InitiatingProcessParentCreationTime")]
 	internal string? InitiatingProcessParentCreationTime { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("InitiatingProcessLogonId")]
 	internal string? InitiatingProcessLogonId { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("ReportId")]
 	internal string? ReportId { get; set; }
 
-	// Additional Fields JSON properties
+	// Additional fields merged from the AdditionalFields JSON string.
+	[JsonInclude]
+	[JsonPropertyName("PolicyID")]
 	internal string? PolicyID { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("PolicyName")]
 	internal string? PolicyName { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("RequestedSigningLevel")]
 	internal string? RequestedSigningLevel { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("ValidatedSigningLevel")]
 	internal string? ValidatedSigningLevel { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("ProcessName")]
 	internal string? ProcessName { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("StatusCode")]
 	internal string? StatusCode { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("Sha1FlatHash")]
 	internal string? Sha1FlatHash { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("Sha256FlatHash")]
 	internal string? Sha256FlatHash { get; set; }
-	internal string? USN { get; set; }
-	internal string? SiSigningScenario { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("USN")]
+	[JsonConverter(typeof(NullableLongJsonConverter))]
+	internal long? USN { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("SiSigningScenario")]
+	[JsonConverter(typeof(NullableIntJsonConverter))]
+	internal int? SiSigningScenario { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("PolicyHash")]
 	internal string? PolicyHash { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("PolicyGuid")]
 	internal string? PolicyGuid { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("UserWriteable")]
+	[JsonConverter(typeof(NullableBoolJsonConverter))]
 	internal bool? UserWriteable { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("OriginalFileName")]
 	internal string? OriginalFileName { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("InternalName")]
 	internal string? InternalName { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("FileDescription")]
 	internal string? FileDescription { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("FileVersion")]
 	internal string? FileVersion { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("EtwActivityId")]
 	internal string? EtwActivityId { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("IssuerName")]
 	internal string? IssuerName { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("IssuerTBSHash")]
 	internal string? IssuerTBSHash { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("NotValidAfter")]
 	internal string? NotValidAfter { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("NotValidBefore")]
 	internal string? NotValidBefore { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("PublisherName")]
 	internal string? PublisherName { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("PublisherTBSHash")]
 	internal string? PublisherTBSHash { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("SignatureType")]
 	internal string? SignatureType { get; set; }
-	internal string? TotalSignatureCount { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("TotalSignatureCount")]
+	[JsonConverter(typeof(NullableIntJsonConverter))]
+	internal int? TotalSignatureCount { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("VerificationError")]
 	internal string? VerificationError { get; set; }
-	internal string? Signature { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("Signature")]
+	[JsonConverter(typeof(NullableIntJsonConverter))]
+	internal int? Signature { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("Hash")]
 	internal string? Hash { get; set; }
-	internal string? Flags { get; set; }
-	internal string? PolicyBits { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("Flags")]
+	[JsonConverter(typeof(NullableIntJsonConverter))]
+	internal int? Flags { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("PolicyBits")]
+	[JsonConverter(typeof(NullableIntJsonConverter))]
+	internal int? PolicyBits { get; set; }
+}
+
+// This type represents the additional fields that are stored as a JSON string
+// inside the "AdditionalFields" property.
+internal sealed class AdditionalFields
+{
+	[JsonInclude]
+	[JsonPropertyName("PolicyID")]
+	internal string? PolicyID { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("PolicyName")]
+	internal string? PolicyName { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("RequestedSigningLevel")]
+	internal string? RequestedSigningLevel { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("ValidatedSigningLevel")]
+	internal string? ValidatedSigningLevel { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("ProcessName")]
+	internal string? ProcessName { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("StatusCode")]
+	internal string? StatusCode { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("Sha1FlatHash")]
+	internal string? Sha1FlatHash { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("Sha256FlatHash")]
+	internal string? Sha256FlatHash { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("USN")]
+	[JsonConverter(typeof(NullableLongJsonConverter))]
+	internal long? USN { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("SiSigningScenario")]
+	[JsonConverter(typeof(NullableIntJsonConverter))]
+	internal int? SiSigningScenario { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("PolicyHash")]
+	internal string? PolicyHash { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("PolicyGuid")]
+	internal string? PolicyGuid { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("UserWriteable")]
+	[JsonConverter(typeof(NullableBoolJsonConverter))]
+	internal bool? UserWriteable { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("OriginalFileName")]
+	internal string? OriginalFileName { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("InternalName")]
+	internal string? InternalName { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("FileDescription")]
+	internal string? FileDescription { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("FileVersion")]
+	internal string? FileVersion { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("EtwActivityId")]
+	internal string? EtwActivityId { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("IssuerName")]
+	internal string? IssuerName { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("IssuerTBSHash")]
+	internal string? IssuerTBSHash { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("NotValidAfter")]
+	internal string? NotValidAfter { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("NotValidBefore")]
+	internal string? NotValidBefore { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("PublisherName")]
+	internal string? PublisherName { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("PublisherTBSHash")]
+	internal string? PublisherTBSHash { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("SignatureType")]
+	internal string? SignatureType { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("TotalSignatureCount")]
+	[JsonConverter(typeof(NullableIntJsonConverter))]
+	internal int? TotalSignatureCount { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("VerificationError")]
+	internal string? VerificationError { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("Signature")]
+	[JsonConverter(typeof(NullableIntJsonConverter))]
+	internal int? Signature { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("Hash")]
+	internal string? Hash { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("Flags")]
+	[JsonConverter(typeof(NullableIntJsonConverter))]
+	internal int? Flags { get; set; }
+
+	[JsonInclude]
+	[JsonPropertyName("PolicyBits")]
+	[JsonConverter(typeof(NullableIntJsonConverter))]
+	internal int? PolicyBits { get; set; }
+}
+
+// Custom converter for MDEAdvancedHuntingData that reads both the top-level properties
+// and, if present, parses the AdditionalFields string (which is JSON) into an AdditionalFields instance.
+internal sealed class MDEAdvancedHuntingDataConverter : JsonConverter<MDEAdvancedHuntingData>
+{
+	public override MDEAdvancedHuntingData Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+	{
+		using JsonDocument document = JsonDocument.ParseValue(ref reader);
+		JsonElement root = document.RootElement;
+
+		MDEAdvancedHuntingData result = new()
+		{
+			// Main properties
+			Timestamp = GetStringOrNull(root, "Timestamp"),
+			DeviceId = GetStringOrNull(root, "DeviceId"),
+			DeviceName = GetStringOrNull(root, "DeviceName"),
+			ActionType = GetStringOrNull(root, "ActionType"),
+			FileName = GetStringOrNull(root, "FileName"),
+			FolderPath = GetStringOrNull(root, "FolderPath"),
+			SHA1 = GetStringOrNull(root, "SHA1"),
+			SHA256 = GetStringOrNull(root, "SHA256"),
+			InitiatingProcessSHA1 = GetStringOrNull(root, "InitiatingProcessSHA1"),
+			InitiatingProcessSHA256 = GetStringOrNull(root, "InitiatingProcessSHA256"),
+			InitiatingProcessMD5 = GetStringOrNull(root, "InitiatingProcessMD5"),
+			InitiatingProcessFileName = GetStringOrNull(root, "InitiatingProcessFileName"),
+			InitiatingProcessFileSize = GetStringOrNull(root, "InitiatingProcessFileSize"),
+			InitiatingProcessFolderPath = GetStringOrNull(root, "InitiatingProcessFolderPath"),
+			InitiatingProcessId = GetStringOrNull(root, "InitiatingProcessId"),
+			InitiatingProcessCommandLine = GetStringOrNull(root, "InitiatingProcessCommandLine"),
+			InitiatingProcessCreationTime = GetStringOrNull(root, "InitiatingProcessCreationTime"),
+			InitiatingProcessAccountDomain = GetStringOrNull(root, "InitiatingProcessAccountDomain"),
+			InitiatingProcessAccountName = GetStringOrNull(root, "InitiatingProcessAccountName"),
+			InitiatingProcessAccountSid = GetStringOrNull(root, "InitiatingProcessAccountSid"),
+			InitiatingProcessVersionInfoCompanyName = GetStringOrNull(root, "InitiatingProcessVersionInfoCompanyName"),
+			InitiatingProcessVersionInfoProductName = GetStringOrNull(root, "InitiatingProcessVersionInfoProductName"),
+			InitiatingProcessVersionInfoProductVersion = GetStringOrNull(root, "InitiatingProcessVersionInfoProductVersion"),
+			InitiatingProcessVersionInfoInternalFileName = GetStringOrNull(root, "InitiatingProcessVersionInfoInternalFileName"),
+			InitiatingProcessVersionInfoOriginalFileName = GetStringOrNull(root, "InitiatingProcessVersionInfoOriginalFileName"),
+			InitiatingProcessVersionInfoFileDescription = GetStringOrNull(root, "InitiatingProcessVersionInfoFileDescription"),
+			InitiatingProcessParentId = GetStringOrNull(root, "InitiatingProcessParentId"),
+			InitiatingProcessParentFileName = GetStringOrNull(root, "InitiatingProcessParentFileName"),
+			InitiatingProcessParentCreationTime = GetStringOrNull(root, "InitiatingProcessParentCreationTime"),
+			InitiatingProcessLogonId = GetStringOrNull(root, "InitiatingProcessLogonId"),
+			ReportId = GetStringOrNull(root, "ReportId")
+		};
+
+		// If the JSON element contains an AdditionalFields property,
+		// parse its string value (which is expected to be JSON) into an AdditionalFields instance
+		// using the source-generated context.
+		if (root.TryGetProperty("AdditionalFields", out JsonElement additionalFieldsElement))
+		{
+			if (additionalFieldsElement.ValueKind == JsonValueKind.String)
+			{
+				string? additionalJson = additionalFieldsElement.GetString();
+				if (!string.IsNullOrWhiteSpace(additionalJson))
+				{
+					AdditionalFields? additional = JsonSerializer.Deserialize(
+						additionalJson,
+						MDEAdvancedHuntingJSONSerializationContext.Default.AdditionalFields);
+					if (additional is not null)
+					{
+						result.PolicyID = additional.PolicyID;
+						result.PolicyName = additional.PolicyName;
+						result.RequestedSigningLevel = additional.RequestedSigningLevel;
+						result.ValidatedSigningLevel = additional.ValidatedSigningLevel;
+						result.ProcessName = additional.ProcessName;
+						result.StatusCode = additional.StatusCode;
+						result.Sha1FlatHash = additional.Sha1FlatHash;
+						result.Sha256FlatHash = additional.Sha256FlatHash;
+						result.USN = additional.USN;
+						result.SiSigningScenario = additional.SiSigningScenario;
+						result.PolicyHash = additional.PolicyHash;
+						result.PolicyGuid = additional.PolicyGuid;
+						result.UserWriteable = additional.UserWriteable;
+						result.OriginalFileName = additional.OriginalFileName;
+						result.InternalName = additional.InternalName;
+						result.FileDescription = additional.FileDescription;
+						result.FileVersion = additional.FileVersion;
+						result.EtwActivityId = additional.EtwActivityId;
+						result.IssuerName = additional.IssuerName;
+						result.IssuerTBSHash = additional.IssuerTBSHash;
+						result.NotValidAfter = additional.NotValidAfter;
+						result.NotValidBefore = additional.NotValidBefore;
+						result.PublisherName = additional.PublisherName;
+						result.PublisherTBSHash = additional.PublisherTBSHash;
+						result.SignatureType = additional.SignatureType;
+						result.TotalSignatureCount = additional.TotalSignatureCount;
+						result.VerificationError = additional.VerificationError;
+						result.Signature = additional.Signature;
+						result.Hash = additional.Hash;
+						result.Flags = additional.Flags;
+						result.PolicyBits = additional.PolicyBits;
+					}
+				}
+			}
+		}
+
+		return result;
+	}
+
+	public override void Write(Utf8JsonWriter writer, MDEAdvancedHuntingData value, JsonSerializerOptions options)
+	{
+		writer.WriteStartObject();
+
+		// Write main properties
+		writer.WriteString("Timestamp", value.Timestamp);
+		writer.WriteString("DeviceId", value.DeviceId);
+		writer.WriteString("DeviceName", value.DeviceName);
+		writer.WriteString("ActionType", value.ActionType);
+		writer.WriteString("FileName", value.FileName);
+		writer.WriteString("FolderPath", value.FolderPath);
+		writer.WriteString("SHA1", value.SHA1);
+		writer.WriteString("SHA256", value.SHA256);
+		writer.WriteString("InitiatingProcessSHA1", value.InitiatingProcessSHA1);
+		writer.WriteString("InitiatingProcessSHA256", value.InitiatingProcessSHA256);
+		writer.WriteString("InitiatingProcessMD5", value.InitiatingProcessMD5);
+		writer.WriteString("InitiatingProcessFileName", value.InitiatingProcessFileName);
+		writer.WriteString("InitiatingProcessFileSize", value.InitiatingProcessFileSize);
+		writer.WriteString("InitiatingProcessFolderPath", value.InitiatingProcessFolderPath);
+		writer.WriteString("InitiatingProcessId", value.InitiatingProcessId);
+		writer.WriteString("InitiatingProcessCommandLine", value.InitiatingProcessCommandLine);
+		writer.WriteString("InitiatingProcessCreationTime", value.InitiatingProcessCreationTime);
+		writer.WriteString("InitiatingProcessAccountDomain", value.InitiatingProcessAccountDomain);
+		writer.WriteString("InitiatingProcessAccountName", value.InitiatingProcessAccountName);
+		writer.WriteString("InitiatingProcessAccountSid", value.InitiatingProcessAccountSid);
+		writer.WriteString("InitiatingProcessVersionInfoCompanyName", value.InitiatingProcessVersionInfoCompanyName);
+		writer.WriteString("InitiatingProcessVersionInfoProductName", value.InitiatingProcessVersionInfoProductName);
+		writer.WriteString("InitiatingProcessVersionInfoProductVersion", value.InitiatingProcessVersionInfoProductVersion);
+		writer.WriteString("InitiatingProcessVersionInfoInternalFileName", value.InitiatingProcessVersionInfoInternalFileName);
+		writer.WriteString("InitiatingProcessVersionInfoOriginalFileName", value.InitiatingProcessVersionInfoOriginalFileName);
+		writer.WriteString("InitiatingProcessVersionInfoFileDescription", value.InitiatingProcessVersionInfoFileDescription);
+		writer.WriteString("InitiatingProcessParentId", value.InitiatingProcessParentId);
+		writer.WriteString("InitiatingProcessParentFileName", value.InitiatingProcessParentFileName);
+		writer.WriteString("InitiatingProcessParentCreationTime", value.InitiatingProcessParentCreationTime);
+		writer.WriteString("InitiatingProcessLogonId", value.InitiatingProcessLogonId);
+		writer.WriteString("ReportId", value.ReportId);
+
+		// Create an AdditionalFields instance from the additional properties.
+		AdditionalFields additional = new()
+		{
+			PolicyID = value.PolicyID,
+			PolicyName = value.PolicyName,
+			RequestedSigningLevel = value.RequestedSigningLevel,
+			ValidatedSigningLevel = value.ValidatedSigningLevel,
+			ProcessName = value.ProcessName,
+			StatusCode = value.StatusCode,
+			Sha1FlatHash = value.Sha1FlatHash,
+			Sha256FlatHash = value.Sha256FlatHash,
+			USN = value.USN,
+			SiSigningScenario = value.SiSigningScenario,
+			PolicyHash = value.PolicyHash,
+			PolicyGuid = value.PolicyGuid,
+			UserWriteable = value.UserWriteable,
+			OriginalFileName = value.OriginalFileName,
+			InternalName = value.InternalName,
+			FileDescription = value.FileDescription,
+			FileVersion = value.FileVersion,
+			EtwActivityId = value.EtwActivityId,
+			IssuerName = value.IssuerName,
+			IssuerTBSHash = value.IssuerTBSHash,
+			NotValidAfter = value.NotValidAfter,
+			NotValidBefore = value.NotValidBefore,
+			PublisherName = value.PublisherName,
+			PublisherTBSHash = value.PublisherTBSHash,
+			SignatureType = value.SignatureType,
+			TotalSignatureCount = value.TotalSignatureCount,
+			VerificationError = value.VerificationError,
+			Signature = value.Signature,
+			Hash = value.Hash,
+			Flags = value.Flags,
+			PolicyBits = value.PolicyBits
+		};
+
+		// Serialize the AdditionalFields object using the source-generated context.
+		string additionalFieldsJson = JsonSerializer.Serialize(
+			additional,
+			MDEAdvancedHuntingJSONSerializationContext.Default.AdditionalFields);
+		writer.WriteString("AdditionalFields", additionalFieldsJson);
+
+		writer.WriteEndObject();
+	}
+
+	private static string? GetStringOrNull(JsonElement element, string propertyName)
+	{
+		if (element.TryGetProperty(propertyName, out JsonElement prop))
+		{
+			return prop.ValueKind == JsonValueKind.String ? prop.GetString() : prop.ToString();
+		}
+		return null;
+	}
+}
+
+// This partial class tells System.Text.Json which types to generate serialization code for.
+[JsonSerializable(typeof(MDEAdvancedHuntingDataRootObject))]
+[JsonSerializable(typeof(AdditionalFields))]
+[JsonSourceGenerationOptions(WriteIndented = true)]
+internal sealed partial class MDEAdvancedHuntingJSONSerializationContext : JsonSerializerContext
+{
 }

--- a/AppControl Manager/Package.appxmanifest
+++ b/AppControl Manager/Package.appxmanifest
@@ -11,7 +11,7 @@
   <Identity
     Name="AppControlManager"
     Publisher="CN=SelfSignedCertForAppControlManager"
-    Version="1.8.7.0" />
+    Version="1.8.8.0" />
 
   <mp:PhoneIdentity PhoneProductId="199a23ec-7cb6-4ab5-ab50-8baca348bc79" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/AppControl Manager/Pages/AllowNewApps/AllowNewAppsEventLogsDataGrid.xaml
+++ b/AppControl Manager/Pages/AllowNewApps/AllowNewAppsEventLogsDataGrid.xaml
@@ -77,7 +77,7 @@
         </Border>
 
         <!-- DataGrid for FileIdentity Outputs -->
-        <Border Grid.Row="1" Style="{StaticResource GridCardStyle}" Margin="0,0,0,25" Padding="5">
+        <Border Grid.Row="1" Style="{StaticResource GridCardStyle}" Margin="0,0,0,10" Padding="5">
             <tk7controls:DataGrid
             ItemsSource="{x:Bind local:AllowNewAppsStart.Instance.EventLogsFileIdentities, Mode=OneWay}"
             x:Name="FileIdentitiesDataGrid"

--- a/AppControl Manager/Pages/AllowNewApps/AllowNewAppsLocalFilesDataGrid.xaml
+++ b/AppControl Manager/Pages/AllowNewApps/AllowNewAppsLocalFilesDataGrid.xaml
@@ -76,7 +76,7 @@
         </Border>
 
         <!-- DataGrid for FileIdentity Outputs -->
-        <Border Grid.Row="1" Style="{StaticResource GridCardStyle}" Margin="0,0,0,25" Padding="5">
+        <Border Grid.Row="1" Style="{StaticResource GridCardStyle}" Margin="0,0,0,10" Padding="5">
             <tk7controls:DataGrid
             ItemsSource="{x:Bind local:AllowNewAppsStart.Instance.LocalFilesFileIdentities, Mode=OneWay}"
             x:Name="FileIdentitiesDataGrid"

--- a/AppControl Manager/Pages/AllowNewApps/AllowNewAppsStart.xaml
+++ b/AppControl Manager/Pages/AllowNewApps/AllowNewAppsStart.xaml
@@ -37,7 +37,7 @@
 
             </Grid.Resources>
 
-            <controls:WrapPanel Grid.Row="0" VerticalSpacing="15" HorizontalSpacing="15" Orientation="Horizontal" Margin="6,5,6,5">
+            <controls:WrapPanel Grid.Row="0" VerticalSpacing="15" HorizontalSpacing="15" Orientation="Horizontal" Margin="6,0,6,5">
 
                 <TextBlock TextWrapping="WrapWholeWords" Style="{StaticResource BodyTextBlockStyle}">
 

--- a/AppControl Manager/Pages/BuildNewCertificate.xaml
+++ b/AppControl Manager/Pages/BuildNewCertificate.xaml
@@ -47,7 +47,7 @@
 
             </Grid.Resources>
 
-            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Horizontal" Margin="6,5,6,5">
+            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Horizontal" Margin="6,0,6,5">
 
                 <TextBlock TextWrapping="WrapWholeWords" Style="{StaticResource BodyTextBlockStyle}">
 

--- a/AppControl Manager/Pages/ConfigurePolicyRuleOptions.xaml
+++ b/AppControl Manager/Pages/ConfigurePolicyRuleOptions.xaml
@@ -33,7 +33,7 @@
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
-            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Horizontal" Margin="6,5,6,5">
+            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Horizontal" Margin="6,0,6,5">
 
                 <TextBlock TextWrapping="WrapWholeWords" Style="{StaticResource BodyTextBlockStyle}">
 

--- a/AppControl Manager/Pages/CreateDenyPolicy.xaml
+++ b/AppControl Manager/Pages/CreateDenyPolicy.xaml
@@ -96,7 +96,7 @@
             </Grid.Resources>
 
 
-            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,10,6,10">
+            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,0,6,10">
 
                 <TextBlock TextWrapping="WrapWholeWords" Style="{StaticResource BodyTextBlockStyle}">
 

--- a/AppControl Manager/Pages/CreateDenyPolicyFilesAndFoldersScanResults.xaml
+++ b/AppControl Manager/Pages/CreateDenyPolicyFilesAndFoldersScanResults.xaml
@@ -31,7 +31,7 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Horizontal" Margin="6,10,6,10">
+        <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Horizontal" Margin="6,0,6,10">
 
             <TextBlock TextWrapping="WrapWholeWords" Style="{StaticResource BodyTextBlockStyle}">
 
@@ -88,7 +88,7 @@
         </Border>
 
         <!-- DataGrid for FileIdentity Outputs -->
-        <Border Grid.Row="2" Style="{StaticResource GridCardStyle}" Margin="0,0,0,25" Padding="5">
+        <Border Grid.Row="2" Style="{StaticResource GridCardStyle}" Margin="0,0,0,10" Padding="5">
             <tk7controls:DataGrid
          ItemsSource="{x:Bind local:CreateDenyPolicy.Instance.filesAndFoldersScanResults, Mode=OneWay}"
          x:Name="FileIdentitiesDataGrid"

--- a/AppControl Manager/Pages/CreatePolicy.xaml
+++ b/AppControl Manager/Pages/CreatePolicy.xaml
@@ -35,7 +35,7 @@
             </Grid.RowDefinitions>
 
 
-            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,10,6,10">
+            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,0,6,10">
 
                 <TextBlock TextWrapping="WrapWholeWords" Style="{StaticResource BodyTextBlockStyle}">
 

--- a/AppControl Manager/Pages/CreateSupplementalPolicy.xaml
+++ b/AppControl Manager/Pages/CreateSupplementalPolicy.xaml
@@ -98,7 +98,7 @@
             </Grid.Resources>
 
 
-            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,10,6,10">
+            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,0,6,10">
 
                 <TextBlock TextWrapping="WrapWholeWords" Style="{StaticResource BodyTextBlockStyle}">
 

--- a/AppControl Manager/Pages/CreateSupplementalPolicyFilesAndFoldersScanResults.xaml
+++ b/AppControl Manager/Pages/CreateSupplementalPolicyFilesAndFoldersScanResults.xaml
@@ -88,7 +88,7 @@
         </Border>
 
         <!-- DataGrid for FileIdentity Outputs -->
-        <Border Grid.Row="2" Style="{StaticResource GridCardStyle}" Margin="0,0,0,25" Padding="5">
+        <Border Grid.Row="2" Style="{StaticResource GridCardStyle}" Margin="0,0,0,10" Padding="5">
             <tk7controls:DataGrid
                 ItemsSource="{x:Bind local:CreateSupplementalPolicy.Instance.filesAndFoldersScanResults, Mode=OneWay}"
                 x:Name="FileIdentitiesDataGrid"

--- a/AppControl Manager/Pages/Deployment.xaml
+++ b/AppControl Manager/Pages/Deployment.xaml
@@ -47,7 +47,7 @@
 
             </Grid.Resources>
 
-            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,10,6,10">
+            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,0,6,10">
 
                 <TextBlock TextWrapping="WrapWholeWords" Style="{StaticResource BodyTextBlockStyle}">
                     <Span>

--- a/AppControl Manager/Pages/Deployment.xaml.cs
+++ b/AppControl Manager/Pages/Deployment.xaml.cs
@@ -650,7 +650,7 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 
 			IntuneSignInButton.IsEnabled = false;
 
-			await Intune.SignIn();
+			await MicrosoftGraph.SignIn(MicrosoftGraph.AuthenticationContext.Intune);
 
 			StatusInfoBar.Message = "Successfully signed into Intune";
 			StatusInfoBar.Severity = InfoBarSeverity.Success;
@@ -715,7 +715,7 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 
 			IntuneSignOutButton.IsEnabled = false;
 
-			await Intune.SignOut();
+			await MicrosoftGraph.SignOut(MicrosoftGraph.AuthenticationContext.Intune);
 
 			signOutSuccessful = true;
 
@@ -754,8 +754,8 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 
 	private async void RefreshIntuneGroupsButton_Click(object sender, RoutedEventArgs e)
 	{
-		await Intune.FetchGroups();
-		Dictionary<string, string> groups = Intune.GetGroups();
+		await MicrosoftGraph.FetchGroups();
+		Dictionary<string, string> groups = MicrosoftGraph.GetGroups();
 
 		// Update the ComboBox with group names
 		IntuneGroupsComboBox.ItemsSource = groups.Keys;
@@ -798,7 +798,7 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 		});
 
 
-		await Intune.UploadPolicyToIntune(file, groupID, policyName, policyID);
+		await MicrosoftGraph.UploadPolicyToIntune(file, groupID, policyName, policyID);
 	}
 
 
@@ -809,7 +809,7 @@ public sealed partial class Deployment : Page, Sidebar.IAnimatedIconsManager
 	/// <param name="e"></param>
 	private void IntuneCancelSignInButton_Click(object sender, RoutedEventArgs e)
 	{
-		Intune.CancelSignIn();
+		MicrosoftGraph.CancelSignIn();
 	}
 
 	private void BrowseForXMLPolicyFilesButton_RightTapped(object sender, RightTappedRoutedEventArgs e)

--- a/AppControl Manager/Pages/EventLogsPolicyCreation.xaml
+++ b/AppControl Manager/Pages/EventLogsPolicyCreation.xaml
@@ -113,7 +113,7 @@ MinWidth="400" IsReadOnly="True" />
         </Grid.Resources>
 
 
-        <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,10,6,10">
+        <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,0,6,10">
 
             <TextBlock TextWrapping="WrapWholeWords" Style="{StaticResource BodyTextBlockStyle}">
 
@@ -156,7 +156,7 @@ MinWidth="400" IsReadOnly="True" />
                     <SplitButton.Content>
                         <StackPanel Orientation="Horizontal">
                             <FontIcon Glyph="&#xECCD;" />
-                            <TextBlock Text="Create Policy" Margin="5,0,0,0" />
+                            <TextBlock Text="Create Policy for Selected Base" Margin="5,0,0,0" />
                         </StackPanel>
                     </SplitButton.Content>
 
@@ -185,7 +185,7 @@ MinWidth="400" IsReadOnly="True" />
   Spacing="8">
                                 <controls:Segmented x:Name="segmentedControl"
               HorizontalAlignment="Stretch"
-              SelectedIndex="0">
+              SelectedIndex="1" SelectionChanged="SegmentedControl_SelectionChanged">
                                     <controls:SegmentedItem Content="Add To Policy"
                       Tag="AddToPolicy" Width="160" Icon="{ui:FontIcon Glyph=&#xEB49;}" />
                                     <controls:SegmentedItem Content="Base Policy File"
@@ -351,7 +351,7 @@ MinWidth="400" IsReadOnly="True" />
 
 
         <!-- DataGrid for FileIdentity Outputs -->
-        <Border Grid.Row="2" Style="{StaticResource GridCardStyle}" Margin="0,0,0,25" Padding="5">
+        <Border Grid.Row="2" Style="{StaticResource GridCardStyle}" Margin="0,0,0,10" Padding="5">
             <tk7controls:DataGrid
         ItemsSource="{x:Bind FileIdentities, Mode=OneWay}"
         x:Name="FileIdentitiesDataGrid"

--- a/AppControl Manager/Pages/GetCIHashes.xaml
+++ b/AppControl Manager/Pages/GetCIHashes.xaml
@@ -17,7 +17,7 @@
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
-            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,10,6,10">
+            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,0,6,10">
 
                 <TextBlock TextWrapping="WrapWholeWords" Style="{StaticResource BodyTextBlockStyle}">
 

--- a/AppControl Manager/Pages/GetSecurePolicySettings.xaml
+++ b/AppControl Manager/Pages/GetSecurePolicySettings.xaml
@@ -31,7 +31,7 @@
 
             </Grid.Resources>
 
-            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,10,6,10">
+            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,0,6,10">
 
                 <TextBlock TextWrapping="WrapWholeWords"  Style="{StaticResource BodyTextBlockStyle}">
 

--- a/AppControl Manager/Pages/Logs.xaml
+++ b/AppControl Manager/Pages/Logs.xaml
@@ -17,7 +17,7 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Horizontal" Margin="6,10,6,10">
+        <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Horizontal" Margin="6,0,6,10">
 
             <TextBlock TextWrapping="WrapWholeWords" Style="{StaticResource BodyTextBlockStyle}">
 

--- a/AppControl Manager/Pages/MDEAHPolicyCreation.xaml
+++ b/AppControl Manager/Pages/MDEAHPolicyCreation.xaml
@@ -55,6 +55,8 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
@@ -70,7 +72,7 @@
 
         </Grid.Resources>
 
-        <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,10,6,10">
+        <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,0,6,0">
 
             <TextBlock TextWrapping="WrapWholeWords" Style="{StaticResource BodyTextBlockStyle}">
 
@@ -89,14 +91,40 @@
 
         </controls:WrapPanel>
 
+
+        <InfoBar x:Name="MainInfoBar" Grid.Row="1" Visibility="Collapsed" />
+
+
+        <controls:WrapPanel Grid.Row="2" Orientation="Horizontal" VerticalAlignment="Center" HorizontalSpacing="10" VerticalSpacing="10">
+
+            <ProgressRing x:Name="ScanLogsProgressRing" Visibility="Collapsed" IsActive="False"/>
+
+            <SelectorBar x:Name="MenuSelectorBar" SelectionChanged="MenuSelectorBar_SelectionChanged" HorizontalAlignment="Left" VerticalAlignment="Center">
+                <SelectorBarItem x:Name="SelectorBarItemMain" Text="Local" IsSelected="True"/>
+                <SelectorBarItem x:Name="SelectorBarItemCloud" Text="Cloud"/>
+                <SelectorBarItem x:Name="SelectorBarItemCreate" Text="Create"/>
+            </SelectorBar>
+
+            <TextBox PlaceholderText="Total logs: 0"
+                x:Name="TotalCountOfTheFilesTextBox"
+                IsReadOnly="True"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Center"
+                VerticalContentAlignment="Center" ToolTipService.ToolTip="The total number of the logs"/>
+
+            <TextBox x:Name="SearchBox" PlaceholderText="Search the data..." TextChanged="SearchBox_TextChanged" VerticalAlignment="Center" VerticalContentAlignment="Center" ToolTipService.ToolTip="Search the data" />
+
+            <CalendarDatePicker x:Name="FilterByDateCalendarPicker" PlaceholderText="Filter logs by date" ToolTipService.ToolTip="Will only show logs that are newer than the selected date"/>
+
+
+        </controls:WrapPanel>
+
         <Border
-  Grid.Row="1"
+  Grid.Row="3" Visibility="{x:Bind IsLocalSelected, Mode=OneWay}"
   Margin="0,10,0,10"
   Style="{StaticResource GridCardStyle}" Padding="8">
 
             <controls:WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalSpacing="10" VerticalSpacing="10">
-
-                <ProgressRing x:Name="ScanLogsProgressRing" Visibility="Collapsed" IsActive="False" />
 
                 <!-- Scan MDE Advanced Hunting button -->
                 <Button x:Name="ScanLogs" IsEnabled="False" ToolTipService.ToolTip="Once you select MDE Advanced Hunting logs, you can use this button to scan them and display their results in the grid below" Style="{StaticResource AccentButtonStyle}" Click="ScanLogs_Click" >
@@ -109,12 +137,88 @@
                     </Button.Content>
                 </Button>
 
+                <Button x:Name="BrowseForLogs" ToolTipService.ToolTip="Browse for Advanced Hunting Logs" Click="BrowseForLogs_Click"
+                        Holding="BrowseForLogs_Holding" RightTapped="BrowseForLogs_RightTapped">
+
+                    <Button.Flyout>
+                        <Flyout x:Name="BrowseForLogs_Flyout">
+
+                            <controls:WrapPanel Orientation="Vertical" HorizontalSpacing="15" VerticalSpacing="15">
+
+                                <Button Content="Clear" Click="BrowseForLogs_Flyout_Clear_Click" />
+
+                                <TextBlock Text="View the log files you selected." TextWrapping="WrapWholeWords" />
+
+                                <TextBox x:Name="BrowseForLogs_SelectedFilesTextBox"
+                                    TextWrapping="Wrap" AcceptsReturn="True" IsSpellCheckEnabled="False"
+                                    MinWidth="400" IsReadOnly="True" />
+
+                            </controls:WrapPanel>
+
+                        </Flyout>
+                    </Button.Flyout>
+
+                    <Button.Content>
+                        <StackPanel Orientation="Horizontal">
+                            <FontIcon Glyph="&#xEC50;" />
+                            <TextBlock Text="Browse for MDE Advanced Hunting logs" Margin="5,0,0,0" />
+                        </StackPanel>
+                    </Button.Content>
+                </Button>
+
+
+            </controls:WrapPanel>
+        </Border>
+
+
+        <Border Grid.Row="3" Visibility="{x:Bind IsCloudSelected, Mode=OneWay}"
+              Margin="0,10,0,10" Style="{StaticResource GridCardStyle}" Padding="8">
+
+            <controls:WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalSpacing="10" VerticalSpacing="10">
+
+                <Button Content="Sign In" x:Name="MSGraphSignInButton" Click="MSGraphSignInButton_Click"/>
+
+                <Button Content="Sign Out" IsEnabled="False" x:Name="MSGraphSignOutButton" Click="MSGraphSignOutButton_Click"/>
+
+                <Button Content="Cancel Sign In" x:Name="MSGraphCancelSignInButton" IsEnabled="False" Click="MSGraphCancelSignInButton_Click"/>
+
+                <Button Content="Device Name" x:Name="MSGraphDeviceNameButton">
+                    <Button.Flyout>
+                        <Flyout>
+                            <Flyout.FlyoutPresenterStyle>
+                                <Style TargetType="FlyoutPresenter">
+                                    <Setter Property="CornerRadius" Value="8" />
+                                    <Setter Property="MaxWidth" Value="1234" />
+                                </Style>
+                            </Flyout.FlyoutPresenterStyle>
+
+                            <controls:WrapPanel Orientation="Vertical" HorizontalSpacing="3" VerticalSpacing="8">
+                                <TextBox Width="300" Header="Optional: Choose a device name to filter the logs before retrieval" PlaceholderText="Device Name..." x:Name="DeviceNameTextBox"/>
+                            </controls:WrapPanel>
+                        </Flyout>
+                    </Button.Flyout>
+                </Button>
+
+
+                <Button Content="Retrieve The Logs" x:Name="RetrieveTheLogsButton" IsEnabled="False" Click="RetrieveTheLogsButton_Click"/>
+
+            </controls:WrapPanel>
+
+        </Border>
+
+
+        <Border Grid.Row="3" Visibility="{x:Bind IsCreateSelected, Mode=OneWay}"
+       Margin="0,10,0,10" Style="{StaticResource GridCardStyle}" Padding="8">
+
+            <controls:WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalSpacing="10" VerticalSpacing="10">
+
+
                 <SplitButton x:Name="CreatePolicyButton" ToolTipService.ToolTip="Create the supplemental policy based on the MDE Advanced Hunting logs" Click="CreatePolicyButton_Click">
 
                     <SplitButton.Content>
                         <StackPanel Orientation="Horizontal">
                             <FontIcon Glyph="&#xECCD;" />
-                            <TextBlock Text="Create Policy" Margin="5,0,0,0" />
+                            <TextBlock Text="Create Policy for Selected Base" Margin="5,0,0,0" />
                         </StackPanel>
                     </SplitButton.Content>
 
@@ -143,7 +247,7 @@ Orientation="Vertical"
 Spacing="8">
                                 <controls:Segmented x:Name="segmentedControl"
             HorizontalAlignment="Stretch"
-            SelectedIndex="0">
+            SelectedIndex="1" SelectionChanged="SegmentedControl_SelectionChanged">
                                     <controls:SegmentedItem Content="Add To Policy"
                     Tag="AddToPolicy" Width="160" Icon="{ui:FontIcon Glyph=&#xEB49;}" />
                                     <controls:SegmentedItem Content="Base Policy File"
@@ -206,36 +310,6 @@ Spacing="8">
 
                 </SplitButton>
 
-
-                <Button x:Name="BrowseForLogs" ToolTipService.ToolTip="Browse for Advanced Hunting Logs" Click="BrowseForLogs_Click"
-                        Holding="BrowseForLogs_Holding" RightTapped="BrowseForLogs_RightTapped">
-
-                    <Button.Flyout>
-                        <Flyout x:Name="BrowseForLogs_Flyout">
-
-                            <controls:WrapPanel Orientation="Vertical" HorizontalSpacing="15" VerticalSpacing="15">
-
-                                <Button Content="Clear" Click="BrowseForLogs_Flyout_Clear_Click" />
-
-                                <TextBlock Text="View the log files you selected." TextWrapping="WrapWholeWords" />
-
-                                <TextBox x:Name="BrowseForLogs_SelectedFilesTextBox"
-                                    TextWrapping="Wrap" AcceptsReturn="True" IsSpellCheckEnabled="False"
-                                    MinWidth="400" IsReadOnly="True" />
-
-                            </controls:WrapPanel>
-
-                        </Flyout>
-                    </Button.Flyout>
-
-                    <Button.Content>
-                        <StackPanel Orientation="Horizontal">
-                            <FontIcon Glyph="&#xEC50;" />
-                            <TextBlock Text="Browse for MDE Advanced Hunting logs" Margin="5,0,0,0" />
-                        </StackPanel>
-                    </Button.Content>
-                </Button>
-
                 <DropDownButton Content="Actions" ToolTipService.ToolTip="Multiple actions to take on the logs">
                     <DropDownButton.Flyout>
 
@@ -275,15 +349,6 @@ Spacing="8">
                     </DropDownButton.Flyout>
                 </DropDownButton>
 
-
-                <TextBox PlaceholderText="Total logs: 0"
-               x:Name="TotalCountOfTheFilesTextBox"
-               IsReadOnly="True"
-               VerticalAlignment="Center"
-               VerticalContentAlignment="Center" ToolTipService.ToolTip="The total number of the logs"/>
-
-                <TextBox x:Name="SearchBox" Width="300" PlaceholderText="Search data..." TextChanged="SearchBox_TextChanged" VerticalAlignment="Center" VerticalContentAlignment="Center" ToolTipService.ToolTip="Search the data" />
-
                 <Button Content="Policy Name">
                     <Button.Flyout>
                         <Flyout>
@@ -301,21 +366,20 @@ Spacing="8">
                     </Button.Flyout>
                 </Button>
 
-                <CalendarDatePicker x:Name="FilterByDateCalendarPicker" PlaceholderText="Filter logs by date" ToolTipService.ToolTip="Will only show logs that are newer than the selected date" />
-
-
                 <ComboBox SelectionChanged="ScanLevelComboBox_SelectionChanged" x:Name="ScanLevelComboBox" ToolTipService.ToolTip="Pick a level based on which the selected logs will be scanned" PlaceholderText="Scan level">
                     <ComboBoxItem>FilePublisher</ComboBoxItem>
                     <ComboBoxItem>Publisher</ComboBoxItem>
                     <ComboBoxItem>Hash</ComboBoxItem>
                 </ComboBox>
 
+
             </controls:WrapPanel>
+
         </Border>
 
 
         <!-- DataGrid for FileIdentity Outputs -->
-        <Border Grid.Row="2" Style="{StaticResource GridCardStyle}" Margin="0,0,0,25" Padding="5">
+        <Border Grid.Row="4" Style="{StaticResource GridCardStyle}" Margin="0,0,0,10" Padding="5">
             <tk7controls:DataGrid
       ItemsSource="{x:Bind FileIdentities, Mode=OneWay}"
       x:Name="FileIdentitiesDataGrid"

--- a/AppControl Manager/Pages/MergePolicies.xaml
+++ b/AppControl Manager/Pages/MergePolicies.xaml
@@ -36,7 +36,7 @@
             </Grid.RowDefinitions>
 
 
-            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,10,6,10">
+            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,0,6,10">
 
                 <TextBlock TextWrapping="WrapWholeWords" Style="{StaticResource BodyTextBlockStyle}">
 

--- a/AppControl Manager/Pages/Settings.xaml
+++ b/AppControl Manager/Pages/Settings.xaml
@@ -33,7 +33,7 @@
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
-            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Horizontal" Margin="6,10,6,10">
+            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Horizontal" Margin="6,0,6,10">
 
                 <TextBlock TextWrapping="WrapWholeWords" Style="{StaticResource BodyTextBlockStyle}">
 

--- a/AppControl Manager/Pages/Simulation.xaml
+++ b/AppControl Manager/Pages/Simulation.xaml
@@ -32,7 +32,7 @@
         </Grid.Resources>
 
 
-        <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,10,6,10">
+        <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,0,6,10">
 
             <TextBlock TextWrapping="WrapWholeWords" Style="{StaticResource BodyTextBlockStyle}">
 
@@ -240,7 +240,7 @@
         </Border>
 
         <!-- DataGrid for Simulation Outputs -->
-        <Border Grid.Row="2" Style="{StaticResource GridCardStyle}" Margin="0,0,0,25" Padding="5">
+        <Border Grid.Row="2" Style="{StaticResource GridCardStyle}" Margin="0,0,0,10" Padding="5">
             <tk7controls:DataGrid
                 x:Name="SimulationDataGrid"
                 ItemsSource="{x:Bind SimulationOutputs, Mode=OneWay}"

--- a/AppControl Manager/Pages/StrictKernelPolicyScanResults.xaml
+++ b/AppControl Manager/Pages/StrictKernelPolicyScanResults.xaml
@@ -31,7 +31,7 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Horizontal" Margin="6,10,6,10">
+        <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Horizontal" Margin="6,0,6,10">
 
             <TextBlock TextWrapping="WrapWholeWords" Style="{StaticResource BodyTextBlockStyle}">
 
@@ -88,7 +88,7 @@
         </Border>
 
         <!-- DataGrid for FileIdentity Outputs -->
-        <Border Grid.Row="2" Style="{StaticResource GridCardStyle}" Margin="0,0,0,25" Padding="5">
+        <Border Grid.Row="2" Style="{StaticResource GridCardStyle}" Margin="0,0,0,10" Padding="5">
             <tk7controls:DataGrid
                 ItemsSource="{x:Bind local:CreateSupplementalPolicy.Instance.ScanResults, Mode=OneWay}"
                 x:Name="FileIdentitiesDataGrid"

--- a/AppControl Manager/Pages/Update.xaml
+++ b/AppControl Manager/Pages/Update.xaml
@@ -34,7 +34,7 @@
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
-            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,10,6,10">
+            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,0,6,10">
 
                 <TextBlock TextWrapping="WrapWholeWords" Style="{StaticResource BodyTextBlockStyle}">
 

--- a/AppControl Manager/Pages/ValidatePolicy.xaml
+++ b/AppControl Manager/Pages/ValidatePolicy.xaml
@@ -33,7 +33,7 @@
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
-            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Horizontal" Margin="5,5,5,10">
+            <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Horizontal" Margin="5,0,5,10">
 
                 <TextBlock TextWrapping="WrapWholeWords" Style="{StaticResource BodyTextBlockStyle}">
 

--- a/AppControl Manager/Pages/ViewFileCertificates.xaml
+++ b/AppControl Manager/Pages/ViewFileCertificates.xaml
@@ -46,7 +46,7 @@
 
         </Grid.Resources>
 
-        <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="5,5,5,5">
+        <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="5,0,5,5">
 
             <TextBlock TextWrapping="WrapWholeWords" Style="{StaticResource BodyTextBlockStyle}">
 

--- a/AppControl Manager/app.manifest
+++ b/AppControl Manager/app.manifest
@@ -2,7 +2,7 @@
 <!-- INFO: https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests -->
 <!-- INFO (for legacy UWP but its info can be used for better understanding): https://learn.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/root-elements -->
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.8.7.0" name="AppControlManager"/>
+  <assemblyIdentity version="1.8.8.0" name="AppControlManager"/>
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>


### PR DESCRIPTION
* [The AppControl Manager](https://github.com/HotCakeX/Harden-Windows-Security/wiki/AppControl-Manager) now seamlessly integrates **Microsoft Defender for Endpoint Advanced Hunting**, allowing you to perform queries directly within the app. You can retrieve and analyze hunting results with advanced filtering and sorting options. From there, you can effortlessly create App Control policies and [deploy them via Intune](https://github.com/HotCakeX/Harden-Windows-Security/wiki/How-To-Upload-App-Control-Policies-To-Intune-Using-AppControl-Manager)—***all without ever leaving the app***.

* Bumped version to 1.8.8.0

* Improved the toolbar menus in Event logs page and MDE Advanced Hunting page.

* Adjusted the margin of the titles in the pages to reduce the empty spaces.
