### PR TITLE
Improved build process and added ARM64 support

### DIFF
--- a/.github/workflows/Build AppControl Manager MSIX Package.yml
+++ b/.github/workflows/Build AppControl Manager MSIX Package.yml
@@ -21,8 +21,7 @@ jobs:
         shell: pwsh
         run: |
           # Retrieve the latest Winget release information
-          [string]$WingetRepoURL = 'https://api.github.com/repos/microsoft/winget-cli/releases'
-          $WingetReleases = Invoke-RestMethod -Uri $WingetRepoURL
+          $WingetReleases = Invoke-RestMethod -Uri 'https://api.github.com/repos/microsoft/winget-cli/releases'
           $LatestRelease = $WingetReleases | Select-Object -First 1
           # Direct links to the latest Winget release assets
           [string]$WingetURL = $LatestRelease.assets.browser_download_url | Where-Object -FilterScript { $_.EndsWith('.msixbundle') } | Select-Object -First 1
@@ -55,66 +54,258 @@ jobs:
       - name: Installing the necessary programs
         run: |
           winget source update
-          winget install --id Microsoft.DotNet.SDK.9 --exact --accept-package-agreements --accept-source-agreements --uninstall-previous --force --source winget
-          winget install --id Microsoft.VisualStudio.2022.BuildTools --exact --accept-package-agreements --accept-source-agreements --uninstall-previous --force --source winget
-          winget install --id Microsoft.WindowsSDK.10.0.26100 --exact --accept-package-agreements --accept-source-agreements --uninstall-previous --force --source winget
-          # https://github.com/microsoft/winget-cli/issues/1705
-          winget install --id Microsoft.AppInstaller --exact --accept-package-agreements --accept-source-agreements --uninstall-previous --force --source winget
-          winget install --id Microsoft.VCRedist.2015+.x64 --exact --accept-package-agreements --accept-source-agreements --uninstall-previous --force --source winget
 
-      - name: Building the AppControl Manager
+          Write-Host -Object "`nInstalling .NET SDK" -ForegroundColor Magenta
+          $null = winget install --id Microsoft.DotNet.SDK.9 --exact --accept-package-agreements --accept-source-agreements --uninstall-previous --force --source winget
+          if ($LASTEXITCODE -ne 0) { throw [System.InvalidOperationException]::New('Failed to install .NET SDK') }
+
+          Write-Host -Object "`nInstalling Visual Studio Build Tools" -ForegroundColor Magenta
+          $null = winget install --id Microsoft.VisualStudio.2022.BuildTools --exact --accept-package-agreements --accept-source-agreements --uninstall-previous --force --source winget --override '--force --wait --passive --add Microsoft.VisualStudio.Workload.ManagedDesktop --add Microsoft.VisualStudio.Workload.MSBuildTools --add Microsoft.VisualStudio.Workload.UniversalBuildTools --add Microsoft.VisualStudio.ComponentGroup.WindowsAppSDK.Cs --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.v141.x86.x64 --add Microsoft.VisualStudio.Component.Windows11SDK.26100 --includeRecommended'
+          if ($LASTEXITCODE -ne 0) { throw [System.InvalidOperationException]::New('Failed to install Visual Studio Build Tools') }
+
+          Write-Host -Object "`nInstalling Visual C++ Redistributable" -ForegroundColor Magenta
+          $null = winget install --id Microsoft.VCRedist.2015+.x64 --exact --accept-package-agreements --accept-source-agreements --uninstall-previous --force --source winget
+
+      - name: Building And Packaging the AppControl Manager
         shell: pwsh
         working-directory: './AppControl Manager'
         # Setting up working directory to ensure dotnet build will see the global.json file in the "AppControl Manager" sub-directory
-
-      # https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-build
-      # https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-command-line-reference
-      # https://learn.microsoft.com/en-us/visualstudio/msbuild/common-msbuild-project-properties
         run: |
-          Write-Host -Object "`nChecking .NET info`n`n"
+          [System.String]$AppControlManagerDirectory = $PWD.Path
+
+          Write-Host -Object "`nChecking .NET info`n`n" -ForegroundColor Magenta
           dotnet --info
-          Write-Host -Object "`nListing installed .NET SDKs`n`n"
+          Write-Host -Object "`nListing installed .NET SDKs`n`n" -ForegroundColor Magenta
           dotnet --list-sdks
-          dotnet build "AppControl Manager.sln" --configuration Release --verbosity normal /p:Platform=x64
-       
-      - name: Generating the MSIX Package
-        working-directory: './AppControl Manager'
-        run: dotnet msbuild "AppControl Manager.sln" /p:Configuration=Release /p:AppxPackageDir="MSIXOutput\" /p:GenerateAppxPackageOnBuild=true /p:Platform=x64 -v:normal
 
-      - name: Capturing the Generated MSIX file Path
-        shell: pwsh
-        run: |
-          [string]$MSIXPath = (Get-ChildItem -File -Path '.\AppControl Manager\MSIXOutput\AppControl Manage*\AppControl Manager*.msix').FullName
-          [string]$MSIXName = (Get-ChildItem -File -Path '.\AppControl Manager\MSIXOutput\AppControl Manage*\AppControl Manager*.msix').Name
-          [XML]$CSProjXMLContent = Get-Content -Path '.\AppControl Manager\AppControl Manager.csproj' -Force
+          Function Find-mspdbcmf {
+              [string]$VisualStudioPath = . 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' -prerelease -latest -property resolvedInstallationPath
+
+              [string]$BasePath = [System.IO.Path]::Combine($VisualStudioPath, 'VC', 'Tools', 'MSVC')
+
+              # Get all subdirectories under the base path
+              [System.String[]]$VersionDirs = [System.IO.Directory]::GetDirectories($BasePath)
+
+              # Initialize the highest version with a minimal version value.
+              [System.Version]$HighestVersion = [System.Version]::New('0.0.0.0')
+              [System.String]$HighestVersionFolder = $null
+
+              # Loop through each directory to find the highest version folder.
+              foreach ($Dir in $VersionDirs) {
+                  # Extract the folder name
+                  [System.String]$FolderName = [System.IO.Path]::GetFileName($Dir)
+                  [System.Version]$CurrentVersion = $null
+                  # Try parsing the folder name as a Version.
+                  if ([System.Version]::TryParse($FolderName, [ref] $CurrentVersion)) {
+                      # Compare versions
+                      if ($CurrentVersion.CompareTo($HighestVersion) -gt 0) {
+                          $HighestVersion = $CurrentVersion
+                          $HighestVersionFolder = $FolderName
+                      }
+                  }
+              }
+
+              # If no valid version folder is found
+              if (!$HighestVersionFolder) {
+                  throw [System.IO.DirectoryNotFoundException]::New("No valid version directories found in $BasePath")
+              }
+
+              # Combine the base path, the highest version folder, the architecture folder, and the file name.
+              [System.String]$mspdbcmfPath = [System.IO.Path]::Combine($BasePath, $HighestVersionFolder, 'bin', 'Hostx64', 'x64', 'mspdbcmf.exe')
+
+              if (![System.IO.File]::Exists($mspdbcmfPath)) {
+                  throw [System.IO.FileNotFoundException]::New("mspdbcmf.exe not found at $mspdbcmfPath")
+              }
+
+              return $mspdbcmfPath
+          }
+
+          [string]$mspdbcmfPath = Find-mspdbcmf
+
+          # https://github.com/Microsoft/vswhere/wiki/Start-Developer-Command-Prompt#using-powershell
+          $installationPath = . 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' -prerelease -latest -property installationPath
+          if ($installationPath -and (Test-Path -Path "$installationPath\Common7\Tools\vsdevcmd.bat" -PathType Leaf)) {
+              & "${env:COMSPEC}" /s /c "`"$installationPath\Common7\Tools\vsdevcmd.bat`" -no_logo && set" | ForEach-Object -Process {
+                  $name, $value = $_ -split '=', 2
+                  Set-Content -Path env:\"$name" -Value $value -Force
+                  Write-Host -Object "Setting environment variable: $name=$value"
+              }
+          }
+
+          # https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-build
+          # https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-command-line-reference
+          # https://learn.microsoft.com/en-us/visualstudio/msbuild/common-msbuild-project-properties
+
+          # Generate for X64 architecture
+          dotnet build 'AppControl Manager.sln' --configuration Release --verbosity minimal /p:Platform=x64
+          dotnet msbuild 'AppControl Manager.sln' /p:Configuration=Release /p:AppxPackageDir="MSIXOutputX64\" /p:GenerateAppxPackageOnBuild=true /p:Platform=x64 -v:minimal /p:MsPdbCmfExeFullpath=$mspdbcmfPath -bl:X64MSBuildLog.binlog
+          # Generate for ARM64 architecture
+          dotnet build 'AppControl Manager.sln' --configuration Release --verbosity minimal /p:Platform=ARM64
+          dotnet msbuild 'AppControl Manager.sln' /p:Configuration=Release /p:AppxPackageDir="MSIXOutputARM64\" /p:GenerateAppxPackageOnBuild=true /p:Platform=ARM64 -v:minimal /p:MsPdbCmfExeFullpath=$mspdbcmfPath -bl:ARM64MSBuildLog.binlog
+
+          Function Get-MSIXFile {
+              Param(
+                  [System.String]$BasePath,
+                  [System.String]$FolderPattern,
+                  [System.String]$FileNamePattern,
+                  [System.String]$ErrorMessageFolder,
+                  [System.String]$ErrorMessageFile
+              )
+              # Get all subdirectories in the base path matching the folder pattern
+              [System.String[]]$Folders = [System.IO.Directory]::GetDirectories($BasePath)
+              [System.String]$DetectedFolder = $null
+              foreach ($Folder in $Folders) {
+                  if ([System.Text.RegularExpressions.Regex]::IsMatch($Folder, $FolderPattern)) {
+                      $DetectedFolder = $Folder
+                      break
+                  }
+              }
+
+              if (!$DetectedFolder) {
+                  Throw [System.InvalidOperationException]::New($ErrorMessageFolder)
+              }
+
+              # Get the full path of the first file matching the file name pattern inside the found folder
+              [System.String[]]$Files = [System.IO.Directory]::GetFiles($DetectedFolder)
+              [System.String]$DetectedFile = $null
+              foreach ($File in $Files) {
+                  if ([System.Text.RegularExpressions.Regex]::IsMatch($File, $FileNamePattern)) {
+                      $DetectedFile = $File
+                      break
+                  }
+              }
+
+              if (!$DetectedFile) {
+                  Throw [System.InvalidOperationException]::New($ErrorMessageFile)
+              }
+              return $DetectedFile
+          }
+
+          #region Finding X64 outputs
+          [System.String]$FinalMSIXX64Path = Get-MSIXFile -BasePath ([System.IO.Path]::Combine($PWD.Path, 'MSIXOutputX64')) -FolderPattern 'AppControl Manager_\d+\.\d+\.\d+\.\d+_Test' -FileNamePattern 'AppControl Manager_\d+\.\d+\.\d+\.\d+_x64\.msix' -ErrorMessageFolder 'Could not find the directory for X64 MSIX file' -ErrorMessageFile 'Could not find the X64 MSIX file'
+          [System.String]$FinalMSIXX64Name = [System.IO.Path]::GetFileName($FinalMSIXX64Path)
+          [System.String]$FinalMSIXX64SymbolPath = Get-MSIXFile -BasePath ([System.IO.Path]::Combine($PWD.Path, 'MSIXOutputX64')) -FolderPattern 'AppControl Manager_\d+\.\d+\.\d+\.\d+_Test' -FileNamePattern 'AppControl Manager_\d+\.\d+\.\d+\.\d+_x64\.msixsym' -ErrorMessageFolder 'Could not find the directory for X64 symbol file' -ErrorMessageFile 'Could not find the X64 symbol file'
+          [System.String]$FinalMSIXX64SymbolName = [System.IO.Path]::GetFileName($FinalMSIXX64SymbolPath)
+          #endregion
+
+          #region Finding ARM64 outputs
+          [System.String]$FinalMSIXARM64Path = Get-MSIXFile -BasePath ([System.IO.Path]::Combine($PWD.Path, 'MSIXOutputARM64')) -FolderPattern 'AppControl Manager_\d+\.\d+\.\d+\.\d+_Test' -FileNamePattern 'AppControl Manager_\d+\.\d+\.\d+\.\d+_arm64\.msix' -ErrorMessageFolder 'Could not find the directory for ARM64 MSIX file' -ErrorMessageFile 'Could not find the ARM64 MSIX file'
+          [System.String]$FinalMSIXARM64Name = [System.IO.Path]::GetFileName($FinalMSIXARM64Path)
+          [System.String]$FinalMSIXARM64SymbolPath = Get-MSIXFile -BasePath ([System.IO.Path]::Combine($PWD.Path, 'MSIXOutputARM64')) -FolderPattern 'AppControl Manager_\d+\.\d+\.\d+\.\d+_Test' -FileNamePattern 'AppControl Manager_\d+\.\d+\.\d+\.\d+_arm64\.msixsym' -ErrorMessageFolder 'Could not find the directory for ARM64 symbol file' -ErrorMessageFile 'Could not find the ARM64 symbol file'
+          [System.String]$FinalMSIXARM64SymbolName = [System.IO.Path]::GetFileName($FinalMSIXARM64SymbolPath)
+          #endregion
+
+          #region Detect and Validate File Versions
+          [System.Text.RegularExpressions.Regex]$versionRegexX64 = [System.Text.RegularExpressions.Regex]::New('AppControl Manager_(\d+\.\d+\.\d+\.\d+)_x64\.msix')
+          [System.Text.RegularExpressions.Regex]$versionRegexARM64 = [System.Text.RegularExpressions.Regex]::New('AppControl Manager_(\d+\.\d+\.\d+\.\d+)_arm64\.msix')
+
+          [System.Text.RegularExpressions.Match]$MatchX64 = $versionRegexX64.Match($FinalMSIXX64Name)
+          [System.Text.RegularExpressions.Match]$MatchARM64 = $versionRegexARM64.Match($FinalMSIXARM64Name)
+
+          if (!$MatchX64.Success) {
+              Throw [System.InvalidOperationException]::New('Could not detect version from X64 file name')
+          }
+
+          if (!$MatchARM64.Success) {
+              Throw [System.InvalidOperationException]::New('Could not detect version from ARM64 file name')
+          }
+
+          [System.String]$versionX64 = $MatchX64.Groups[1].Value
+          [System.String]$versionARM64 = $MatchARM64.Groups[1].Value
+
+          if ($versionX64 -ne $versionARM64) {
+              Throw [System.InvalidOperationException]::New('The versions in X64 and ARM64 files do not match')
+          }
+
+          # Craft the file name for the MSIX Bundle file
+          [System.String]$FinalBundleFileName = "AppControl Manager_$versionX64.msixbundle"
+          #endregion
+
+          # Creating the directory where the MSIX packages will be copied to
+          [System.String]$MSIXBundleOutput = [System.IO.Directory]::CreateDirectory([System.IO.Path]::Combine($AppControlManagerDirectory, 'MSIXBundleOutput')).FullName
+
+          [System.IO.File]::Copy($FinalMSIXX64Path, [System.IO.Path]::Combine($MSIXBundleOutput, $FinalMSIXX64Name), $true)
+          [System.IO.File]::Copy($FinalMSIXARM64Path, [System.IO.Path]::Combine($MSIXBundleOutput, $FinalMSIXARM64Name), $true)
+
+          # The path to the final MSIX Bundle file
+          [System.String]$MSIXBundle = [System.IO.Path]::Combine($MSIXBundleOutput, $FinalBundleFileName)
+
+          Function Get-MakeAppxPath {
+              [System.String]$BasePath = 'C:\Program Files (x86)\Windows Kits\10\bin'
+
+              # Get all subdirectories under the base path
+              [System.String[]]$VersionDirs = [System.IO.Directory]::GetDirectories($BasePath)
+
+              # Initialize the highest version with a minimal version value.
+              [System.Version]$HighestVersion = [System.Version]::New('0.0.0.0')
+              [System.String]$HighestVersionFolder = $null
+
+              # Loop through each directory to find the highest version folder.
+              foreach ($Dir in $VersionDirs) {
+                  # Extract the folder name
+                  [System.String]$FolderName = [System.IO.Path]::GetFileName($Dir)
+                  [System.Version]$CurrentVersion = $null
+                  # Try parsing the folder name as a Version.
+                  if ([System.Version]::TryParse($FolderName, [ref] $CurrentVersion)) {
+                      # Compare versions
+                      if ($CurrentVersion.CompareTo($HighestVersion) -gt 0) {
+                          $HighestVersion = $CurrentVersion
+                          $HighestVersionFolder = $FolderName
+                      }
+                  }
+              }
+
+              # If no valid version folder is found
+              if (!$HighestVersionFolder) {
+                  throw [System.IO.DirectoryNotFoundException]::New("No valid version directories found in $BasePath")
+              }
+
+              [string]$CPUArch = @{AMD64 = 'x64'; ARM64 = 'arm64' }[$Env:PROCESSOR_ARCHITECTURE]
+              if ([System.String]::IsNullOrWhiteSpace($CPUArch)) { throw [System.PlatformNotSupportedException]::New('Only AMD64 and ARM64 architectures are supported.') }
+
+              # Combine the base path, the highest version folder, the architecture folder, and the file name.
+              [System.String]$MakeAppxPath = [System.IO.Path]::Combine($BasePath, $HighestVersionFolder, $CPUArch, 'makeappx.exe')
+
+              return $MakeAppxPath
+          }
+
+          [System.String]$MakeAppxPath = Get-MakeAppxPath
+
+          if ([System.string]::IsNullOrWhiteSpace($MakeAppxPath)) {
+              throw [System.IO.FileNotFoundException]::New('Could not find the makeappx.exe')
+          }
+
+          # https://learn.microsoft.com/en-us/windows/win32/appxpkg/make-appx-package--makeappx-exe-#to-create-a-package-bundle-using-a-directory-structure
+          . $MakeAppxPath bundle /d $MSIXBundleOutput /p $MSIXBundle /o /v
+
+          if ($LASTEXITCODE -ne 0) { Throw [System.InvalidOperationException]::New("MakeAppx failed creating the MSIXBundle. Exit Code: $LASTEXITCODE") }
+
+          #Endregion
+
+          [XML]$CSProjXMLContent = Get-Content -Path '.\AppControl Manager.csproj' -Force
           [string]$MSIXVersion = $CSProjXMLContent.Project.PropertyGroup.FileVersion
           [string]$MSIXVersion = $MSIXVersion.Trim() # It would have trailing whitespaces
-          if ([string]::IsNullOrWhiteSpace($MSIXPath) -or [string]::IsNullOrWhiteSpace($MSIXName) -or [string]::IsNullOrWhiteSpace($MSIXVersion)) { throw "Couldn't find the generated MSIX package" }
+          if ([string]::IsNullOrWhiteSpace($FinalMSIXX64Path) -or [string]::IsNullOrWhiteSpace($FinalMSIXX64Name) -or [string]::IsNullOrWhiteSpace($MSIXVersion)) { throw "Necessary info could not be found" }
           # Write the MSIXPath, MSIXName and MSIXVersion to GITHUB_ENV to set it as an environment variable for the entire workflow
-          Add-Content -Path $env:GITHUB_ENV -Value "MSIX_PATH=$MSIXPath"
-          Add-Content -Path $env:GITHUB_ENV -Value "MSIX_NAME=$MSIXName"
-          Add-Content -Path $env:GITHUB_ENV -Value "MSIX_VERSION=$MSIXVersion"
+          Add-Content -Path $env:GITHUB_ENV -Value "MSIX_PATH=$FinalMSIXX64Path"
+          Add-Content -Path $env:GITHUB_ENV -Value "MSIX_NAME=$FinalMSIXX64Name"
+          Add-Content -Path $env:GITHUB_ENV -Value "PACKAGE_VERSION=$MSIXVersion"
 
-      - name: Generating Artifact Attestation
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: ${{ env.MSIX_PATH }}
+          # Saving the details for the MSIX Bundle file
+          Add-Content -Path $env:GITHUB_ENV -Value "MSIXBundle_PATH=$MSIXBundle"
+          Add-Content -Path $env:GITHUB_ENV -Value "MSIXBundle_NAME=$FinalBundleFileName"
 
-      - name: Generating SBOM
-        uses: anchore/sbom-action@v0
-        with:
-          dependency-snapshot: true
-          upload-release-assets: false
-          upload-artifact: true
-          output-file: ./HardenWindowsSecurityRepoSBOM.spdx
-          artifact-name: HardenWindowsSecurityRepoSBOM.spdx
+          # Saving the details of the log files
+          Add-Content -Path $env:GITHUB_ENV -Value "X64MSBuildLog_PATH=X64MSBuildLog.binlog"
+          Add-Content -Path $env:GITHUB_ENV -Value "ARM64MSBuildLog_PATH=ARM64MSBuildLog.binlog"
 
-      - name: Generating SBOM attestation
-        uses: actions/attest-sbom@v2
-        with:
-          subject-path: ${{ env.MSIX_PATH }}
-          sbom-path: ./HardenWindowsSecurityRepoSBOM.spdx
-          show-summary: true
+          # Saving the details of the X64 symbol file
+          Add-Content -Path $env:GITHUB_ENV -Value "X64Symbol_PATH=$FinalMSIXX64SymbolPath"
+          Add-Content -Path $env:GITHUB_ENV -Value "X64Symbol_NAME=$FinalMSIXX64SymbolName"
+
+          # Saving the details of the ARM64 symbol file
+          Add-Content -Path $env:GITHUB_ENV -Value "ARM64Symbol_PATH=$FinalMSIXARM64SymbolPath"
+          Add-Content -Path $env:GITHUB_ENV -Value "ARM64Symbol_NAME=$FinalMSIXARM64SymbolName"
 
       - name: Finding the Latest Draft Release
         id: find_draft_release
@@ -153,6 +344,99 @@ jobs:
           }
           Write-Host -Object "Uploaded package to draft release: $Response.name"
 
+      - name: Uploading the MSIXBundle to the Draft Release
+        shell: pwsh
+        run: |
+          [string]$DraftReleaseId = $env:DRAFT_RELEASE_ID
+          [string]$FilePath = "${{ env.MSIXBundle_PATH }}"
+          [string]$FileName = "${{ env.MSIXBundle_NAME }}"
+          [string]$UploadUrl = "https://uploads.github.com/repos/${{ github.repository }}/releases/$DraftReleaseId/assets?name=$FileName"
+          # Upload the package to the draft release
+          $Response = Invoke-RestMethod -Uri $UploadUrl -Method Put -InFile $FilePath -Headers @{
+            "Authorization" = "token ${{ secrets.GITHUB_TOKEN }}"
+            "Content-Type" = "application/octet-stream"
+          }
+          Write-Host -Object "Uploaded package to draft release: $Response.name"
+
+      - name: Uploading the Logs to the Draft Release
+        working-directory: './AppControl Manager'
+        shell: pwsh
+        run: |
+          [string]$DraftReleaseId = $env:DRAFT_RELEASE_ID
+          [string]$FilePath = "${{ env.X64MSBuildLog_PATH }}"
+          [string]$FileName = "X64MSBuildLog.binlog"
+          [string]$UploadUrl = "https://uploads.github.com/repos/${{ github.repository }}/releases/$DraftReleaseId/assets?name=$FileName"
+          # Upload the log to the draft release
+          $Response = Invoke-RestMethod -Uri $UploadUrl -Method Put -InFile $FilePath -Headers @{
+            "Authorization" = "token ${{ secrets.GITHUB_TOKEN }}"
+            "Content-Type" = "application/octet-stream"
+          }
+          Write-Host -Object "Uploaded log to draft release: $Response.name"
+
+      - name: Uploading the Logs to the Draft Release
+        working-directory: './AppControl Manager'
+        shell: pwsh
+        run: |
+          [string]$DraftReleaseId = $env:DRAFT_RELEASE_ID
+          [string]$FilePath = "${{ env.ARM64MSBuildLog_PATH }}"
+          [string]$FileName = "ARM64MSBuildLog.binlog"
+          [string]$UploadUrl = "https://uploads.github.com/repos/${{ github.repository }}/releases/$DraftReleaseId/assets?name=$FileName"
+          # Upload the log to the draft release
+          $Response = Invoke-RestMethod -Uri $UploadUrl -Method Put -InFile $FilePath -Headers @{
+            "Authorization" = "token ${{ secrets.GITHUB_TOKEN }}"
+            "Content-Type" = "application/octet-stream"
+          }
+          Write-Host -Object "Uploaded log to draft release: $Response.name"
+
+      - name: Uploading the X64 Symbol to the Draft Release
+        shell: pwsh
+        run: |
+          [string]$DraftReleaseId = $env:DRAFT_RELEASE_ID
+          [string]$FilePath = "${{ env.X64Symbol_PATH }}"
+          [string]$FileName = "${{ env.X64Symbol_NAME }}"
+          [string]$UploadUrl = "https://uploads.github.com/repos/${{ github.repository }}/releases/$DraftReleaseId/assets?name=$FileName"
+          # Upload the X64 Symbol to the draft release
+          $Response = Invoke-RestMethod -Uri $UploadUrl -Method Put -InFile $FilePath -Headers @{
+            "Authorization" = "token ${{ secrets.GITHUB_TOKEN }}"
+            "Content-Type" = "application/octet-stream"
+          }
+          Write-Host -Object "Uploaded X64 Symbol to draft release: $Response.name"
+
+      - name: Uploading the ARM64 Symbol to the Draft Release
+        shell: pwsh
+        run: |
+          [string]$DraftReleaseId = $env:DRAFT_RELEASE_ID
+          [string]$FilePath = "${{ env.ARM64Symbol_PATH }}"
+          [string]$FileName = "${{ env.ARM64Symbol_NAME }}"
+          [string]$UploadUrl = "https://uploads.github.com/repos/${{ github.repository }}/releases/$DraftReleaseId/assets?name=$FileName"
+          # Upload the ARM64 Symbol to the draft release
+          $Response = Invoke-RestMethod -Uri $UploadUrl -Method Put -InFile $FilePath -Headers @{
+            "Authorization" = "token ${{ secrets.GITHUB_TOKEN }}"
+            "Content-Type" = "application/octet-stream"
+          }
+          Write-Host -Object "Uploaded ARM64 Symbol to draft release: $Response.name"
+
+      - name: Generating Artifact Attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: "${{ env.MSIX_PATH }}, ${{ env.MSIXBundle_PATH }}, ${{ env.X64MSBuildLog_PATH }}, ${{ env.ARM64MSBuildLog_PATH }}, ${{ env.X64Symbol_PATH }}, ${{ env.ARM64MSBuildLog_PATH }}"
+
+      - name: Generating SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          dependency-snapshot: true
+          upload-release-assets: true
+          upload-artifact: true
+          output-file: ./HardenWindowsSecurityRepoSBOM.spdx
+          artifact-name: HardenWindowsSecurityRepoSBOM.spdx
+
+      - name: Generating SBOM attestation
+        uses: actions/attest-sbom@v2
+        with:
+          subject-path: "${{ env.MSIX_PATH }}, ${{ env.MSIXBundle_PATH }}, ${{ env.X64MSBuildLog_PATH }}, ${{ env.ARM64MSBuildLog_PATH }}, ${{ env.X64Symbol_PATH }}, ${{ env.ARM64MSBuildLog_PATH }}"
+          sbom-path: ./HardenWindowsSecurityRepoSBOM.spdx
+          show-summary: true
+
       - name: Uploading the SBOM file to the Draft Release
         shell: pwsh
         run: |
@@ -167,33 +451,40 @@ jobs:
           }
           Write-Host -Object "Uploaded the SBOM file to the draft release: $Response.name"
 
-      - name: Updating The MSIX Download Link and Version via Pull Request
+      - name: Updating The MSIX/MSIXBundle Download Links and Version via Pull Request
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           [string]$MSIXName = "${{ env.MSIX_NAME }}"
+          [string]$MSIXBundleName = "${{ env.MSIXBundle_NAME }}"
 
           # Spaces in files added to the GitHub assets will be replaced with dots, so we need to do the same when constructing the download link
           [string]$AdjustedMSIXName = $MSIXName.Replace('AppControl Manager', 'AppControl.Manager')
+          [string]$AdjustedMSIXBundleName = $MSIXBundleName.Replace('AppControl Manager', 'AppControl.Manager')
 
           [string]$DRAFT_RELEASE_TAG = "${{ env.DRAFT_RELEASE_TAG }}"
           [string]$GitHubRepository = "${{ github.repository }}"
-          [string]$MSIX_VERSION = "${{ env.MSIX_VERSION }}"
+          [string]$PACKAGE_VERSION = "${{ env.PACKAGE_VERSION }}"
 
           # Construct the download URL using the draft release tag and MSIX file name
           [string]$DownloadURL = "https://github.com/$GitHubRepository/releases/download/$DRAFT_RELEASE_TAG/$AdjustedMSIXName"
+          [string]$DownloadURLForMSIXBundle = "https://github.com/$GitHubRepository/releases/download/$DRAFT_RELEASE_TAG/$AdjustedMSIXBundleName"
 
           # Path to the files that will be updated
           [string]$DownloadURLFilePath = '.\AppControl Manager\DownloadURL.txt'
+          [string]$DownloadURLFilePathForMSIXBundle = '.\AppControl Manager\DownloadURLForMSIXBundle.txt'
           [string]$VersionFilePath = '.\AppControl Manager\version.txt'
 
           # Update the file content with the new URL
           Set-Content -Path $DownloadURLFilePath -Value $DownloadURL -Force
           Write-Host -Object "Updated DownloadURL.txt with download URL: $DownloadURL"
 
-          Set-Content -Path $VersionFilePath -Value $MSIX_VERSION -Force
-          Write-Host -Object "Updated version.txt with version: $MSIX_VERSION"
+          Set-Content -Path $DownloadURLFilePathForMSIXBundle -Value $DownloadURLForMSIXBundle -Force
+          Write-Host -Object "Updated DownloadURLForMSIXBundle.txt with download URL: $DownloadURLForMSIXBundle"
+
+          Set-Content -Path $VersionFilePath -Value $PACKAGE_VERSION -Force
+          Write-Host -Object "Updated version.txt with version: $PACKAGE_VERSION"
 
           # Configure Git for committing changes
           git config --global user.email 'spynetgirl@outlook.com'
@@ -203,10 +494,11 @@ jobs:
           [string]$NewBranchName = 'AppControl-Manager-DownloadLink-Version-Update'
           git checkout -b $NewBranchName
 
-          [string]$CommitMessageAndPRTitle = "AppControl-Manager-DownloadLink-Version-Update-Version-$MSIX_VERSION"
+          [string]$CommitMessageAndPRTitle = "AppControl-Manager-DownloadLink-Version-Update-Version-$PACKAGE_VERSION"
 
           # Stage and commit the change
           git add $DownloadURLFilePath
+          git add $DownloadURLFilePathForMSIXBundle
           git add $VersionFilePath
           git commit -m $CommitMessageAndPRTitle
 
@@ -218,11 +510,14 @@ jobs:
           ``````
           $DownloadURL
           ``````
+          And DownloadURLForMSIXBundle.txt to
+          ``````
+          $DownloadURLForMSIXBundle
+          ``````
           And version.txt to
           ``````
-          $MSIX_VERSION
+          $PACKAGE_VERSION
           ``````
-          For the file: $AdjustedMSIXName
 
           "@
 

--- a/.github/workflows/Build AppControl Manager MSIX Package.yml
+++ b/.github/workflows/Build AppControl Manager MSIX Package.yml
@@ -475,7 +475,7 @@ jobs:
 
           # Path to the files that will be updated
           [string]$DownloadURLFilePath = '.\AppControl Manager\DownloadURL.txt'
-          [string]$DownloadURLFilePathForMSIXBundle = '.\AppControl Manager\DownloadURLForMSIXBundle.txt'
+          [string]$DownloadURLFilePathForMSIXBundle = '.\AppControl Manager\MSIXBundleDownloadURL.txt'
           [string]$VersionFilePath = '.\AppControl Manager\version.txt'
 
           # Update the file content with the new URL
@@ -483,7 +483,7 @@ jobs:
           Write-Host -Object "Updated DownloadURL.txt with download URL: $DownloadURL"
 
           Set-Content -Path $DownloadURLFilePathForMSIXBundle -Value $DownloadURLForMSIXBundle -Force
-          Write-Host -Object "Updated DownloadURLForMSIXBundle.txt with download URL: $DownloadURLForMSIXBundle"
+          Write-Host -Object "Updated MSIXBundleDownloadURL.txt with download URL: $DownloadURLForMSIXBundle"
 
           Set-Content -Path $VersionFilePath -Value $PACKAGE_VERSION -Force
           Write-Host -Object "Updated version.txt with version: $PACKAGE_VERSION"
@@ -512,7 +512,7 @@ jobs:
           ``````
           $DownloadURL
           ``````
-          And DownloadURLForMSIXBundle.txt to
+          And MSIXBundleDownloadURL.txt to
           ``````
           $DownloadURLForMSIXBundle
           ``````

--- a/.github/workflows/Build AppControl Manager MSIX Package.yml
+++ b/.github/workflows/Build AppControl Manager MSIX Package.yml
@@ -71,6 +71,7 @@ jobs:
         working-directory: './AppControl Manager'
         # Setting up working directory to ensure dotnet build will see the global.json file in the "AppControl Manager" sub-directory
         run: |
+          $global:ErrorActionPreference = 'Stop'
           [System.String]$AppControlManagerDirectory = $PWD.Path
 
           Write-Host -Object "`nChecking .NET info`n`n" -ForegroundColor Magenta
@@ -79,7 +80,8 @@ jobs:
           dotnet --list-sdks
 
           Function Find-mspdbcmf {
-              [string]$VisualStudioPath = . 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' -prerelease -latest -property resolvedInstallationPath
+              # "-products *" is necessary to detect BuildTools too
+              [string]$VisualStudioPath = . 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' -prerelease -latest -property resolvedInstallationPath -products *
 
               [string]$BasePath = [System.IO.Path]::Combine($VisualStudioPath, 'VC', 'Tools', 'MSVC')
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,8 @@ AppControl Manager/.vs/
 AppControl Manager/bin/
 AppControl Manager/obj/
 AppControl Manager/MSIXOutput
+AppControl Manager/MSIXOutputX64
+AppControl Manager/MSIXOutputARM64
+AppControl Manager/MSIXBundleOutput
 AppControl Manager/Generated Files/
 AppControl Manager/AppControl Manager.csproj.user

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ Harden-Windows-Security Module/Harden Windows Security.csproj.user
 AppControl Manager/.vs/
 AppControl Manager/bin/
 AppControl Manager/obj/
-AppControl Manager/MSIXOutput
 AppControl Manager/MSIXOutputX64
 AppControl Manager/MSIXOutputARM64
 AppControl Manager/MSIXBundleOutput

--- a/AppControl Manager/AppControl Manager.csproj
+++ b/AppControl Manager/AppControl Manager.csproj
@@ -89,6 +89,7 @@
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
     <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
     <AssemblyName>AppControlManager</AssemblyName>
+    <!-- https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/optimizing -->
     <PublishAot>False</PublishAot>
     <ErrorReport>send</ErrorReport>
     <FileVersion>1.8.8.0</FileVersion>

--- a/AppControl Manager/AppControl Manager.csproj
+++ b/AppControl Manager/AppControl Manager.csproj
@@ -81,7 +81,7 @@
 
 
     <!-- Defining custom directory in the root directory to be created if it doesn't exist. MSIX package after packing will be stored there -->
-    <AppxPackageDir>MSIXOutput\</AppxPackageDir>
+    <AppxPackageDir>MSIXOutputX64\</AppxPackageDir>
     <AppxSymbolPackageEnabled>True</AppxSymbolPackageEnabled>
     <GenerateTestArtifacts>True</GenerateTestArtifacts>
     <AppxBundle>Always</AppxBundle>
@@ -92,7 +92,7 @@
     <!-- https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/optimizing -->
     <PublishAot>False</PublishAot>
     <ErrorReport>send</ErrorReport>
-    <FileVersion>1.8.8.0</FileVersion>
+    <FileVersion>1.8.9.0</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
@@ -113,7 +113,8 @@
 
   </PropertyGroup>
 
-  <ItemGroup>
+  <!-- ARM64 doesn't support source generated XML de(serialization) -->
+  <ItemGroup Condition="'$(RuntimeIdentifier)' != 'win-arm64'">
     <DotNetCliToolReference Include="Microsoft.XmlSerializer.Generator" Version="9.0.1" />
   </ItemGroup>
 
@@ -144,7 +145,7 @@
     <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.1.240916" />
     <PackageReference Include="CommunityToolkit.WinUI.Lottie" Version="8.1.240821" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.DataGrid" Version="7.1.2" />
-    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.3.1" />
+    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.3.2" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.67.2" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.162">
       <PrivateAssets>all</PrivateAssets>
@@ -152,7 +153,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250108002" />
-    <PackageReference Include="Microsoft.XmlSerializer.Generator" Version="9.0.1" />
+    <!-- ARM64 doesn't support source generated XML de(serialization) -->
+    <PackageReference Include="Microsoft.XmlSerializer.Generator" Version="9.0.1" Condition="'$(RuntimeIdentifier)' != 'win-arm64'" />
     <PackageReference Include="System.Diagnostics.EventLog" Version="9.0.1" />
     <PackageReference Include="System.Management" Version="9.0.1" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="9.0.1" />
@@ -255,9 +257,29 @@
     <Content Remove="DownloadURL.txt" />
     <None Remove="DownloadURL.txt" />
 
-    <Compile Remove="MSIXOutput\**" />
-    <Content Remove="MSIXOutput\**" />
-    <None Remove="MSIXOutput\**" />
+    <Compile Remove="MSIXBundleDownloadURL.txt" />
+    <Content Remove="MSIXBundleDownloadURL.txt" />
+    <None Remove="MSIXBundleDownloadURL.txt" />
+
+    <Compile Remove="ARM64MSBuildLog.binlog" />
+    <Content Remove="ARM64MSBuildLog.binlog" />
+    <None Remove="ARM64MSBuildLog.binlog" />
+
+    <Compile Remove="X64MSBuildLog.binlog" />
+    <Content Remove="X64MSBuildLog.binlog" />
+    <None Remove="X64MSBuildLog.binlog" />
+
+    <Compile Remove="MSIXOutputX64\**" />
+    <Content Remove="MSIXOutputX64\**" />
+    <None Remove="MSIXOutputX64\**" />
+
+    <Compile Remove="MSIXOutputARM64\**" />
+    <Content Remove="MSIXOutputARM64\**" />
+    <None Remove="MSIXOutputARM64\**" />
+
+    <Compile Remove="MSIXBundleOutput\**" />
+    <Content Remove="MSIXBundleOutput\**" />
+    <None Remove="MSIXBundleOutput\**" />
 
     <Compile Remove="Animated Icon Sources\**" />
     <Content Remove="Animated Icon Sources\**" />

--- a/AppControl Manager/MSIXBundleDownloadURL.txt
+++ b/AppControl Manager/MSIXBundleDownloadURL.txt
@@ -1,0 +1,1 @@
+https://github.com/HotCakeX/Harden-Windows-Security/releases/download/AppControlManager.v.1.8.8.0/AppControl.Manager_1.8.8.0_x64.msix

--- a/AppControl Manager/Package.appxmanifest
+++ b/AppControl Manager/Package.appxmanifest
@@ -11,7 +11,7 @@
   <Identity
     Name="AppControlManager"
     Publisher="CN=SelfSignedCertForAppControlManager"
-    Version="1.8.8.0" />
+    Version="1.8.9.0" />
 
   <mp:PhoneIdentity PhoneProductId="199a23ec-7cb6-4ab5-ab50-8baca348bc79" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/AppControl Manager/app.manifest
+++ b/AppControl Manager/app.manifest
@@ -2,7 +2,7 @@
 <!-- INFO: https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests -->
 <!-- INFO (for legacy UWP but its info can be used for better understanding): https://learn.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/root-elements -->
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.8.8.0" name="AppControlManager"/>
+  <assemblyIdentity version="1.8.9.0" name="AppControlManager"/>
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>

--- a/Wiki posts/AppControl Manager/AppControl Manager.md
+++ b/Wiki posts/AppControl Manager/AppControl Manager.md
@@ -244,13 +244,15 @@ It will create the MSIXBundle file containing the X64 and ARM64 MSIX packages. Y
 $global:ErrorActionPreference = 'Stop'
 # Start the stopwatch
 $Stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
-[System.String]$RepoUrl = 'https://github.com/HotCakeX/Harden-Windows-Security/archive/refs/heads/main.zip'
-[System.String]$ZipPath = [System.IO.Path]::Combine($env:TEMP, 'HardenWindowsSecurity.zip')
+[System.String]$BranchName = "main"
+[System.String]$RepoName = "Harden-Windows-Security"
+[System.String]$RepoUrl = "https://github.com/HotCakeX/$RepoName/archive/refs/heads/$BranchName.zip"
+[System.String]$ZipPath = [System.IO.Path]::Combine($env:TEMP, "$RepoName.zip")
 [System.String]$InitialWorkingDirectory = $PWD
 Invoke-WebRequest -Uri $RepoUrl -OutFile $ZipPath
 Expand-Archive -Path $ZipPath -DestinationPath $InitialWorkingDirectory -Force
 Remove-Item -Path $ZipPath -Force
-[System.String]$AppControlManagerDirectory = [System.IO.Path]::Combine($InitialWorkingDirectory, 'Harden-Windows-Security-main', 'AppControl Manager')
+[System.String]$AppControlManagerDirectory = [System.IO.Path]::Combine($InitialWorkingDirectory, "$RepoName-$BranchName", 'AppControl Manager')
 Set-Location -Path $AppControlManagerDirectory
 
 winget source update

--- a/Wiki posts/AppControl Manager/AppControl Manager.md
+++ b/Wiki posts/AppControl Manager/AppControl Manager.md
@@ -228,46 +228,284 @@ AppControl -MSIXPath "Path To the MSIX" -SignTool "Path to signtool.exe" -Verbos
 
 You can build the AppControl Manager application directly from the source code locally on your device without using any 3rd party tools in a completely automated way.
 
+It will create the MSIXBundle file containing the X64 and ARM64 MSIX packages. You can even optionally chain it with the [Bootstrapper script](https://github.com/HotCakeX/Harden-Windows-Security/blob/main/Harden-Windows-Security.ps1) to sign and install the application on your system at the end.
+
 <details>
 
 <summary>
-Click/Tap here to see the PowerShell code
+✨ Click/Tap here to see the PowerShell code ✨
 </summary>
 
 <br>
 
 ```powershell
+# Requires -Version 5.1
+# Requires -RunAsAdministrator
+$ErrorActionPreference = 'Stop'
+# Start the stopwatch
+$Stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 [System.String]$RepoUrl = 'https://github.com/HotCakeX/Harden-Windows-Security/archive/refs/heads/main.zip'
 [System.String]$ZipPath = [System.IO.Path]::Combine($env:TEMP, 'HardenWindowsSecurity.zip')
-[System.String]$ExtractPath = $PWD
+[System.String]$InitialWorkingDirectory = $PWD
 Invoke-WebRequest -Uri $RepoUrl -OutFile $ZipPath
-Expand-Archive -Path $ZipPath -DestinationPath $ExtractPath -Force
-[System.String]$PathToNavigateTo = [System.IO.Path]::Combine($ExtractPath, 'Harden-Windows-Security-main', 'AppControl Manager')
-Set-Location -Path $PathToNavigateTo
+Expand-Archive -Path $ZipPath -DestinationPath $InitialWorkingDirectory -Force
+[System.String]$AppControlManagerDirectory = [System.IO.Path]::Combine($InitialWorkingDirectory, 'Harden-Windows-Security-main', 'AppControl Manager')
+Set-Location -Path $AppControlManagerDirectory
 
 winget source update
 winget install --id Microsoft.DotNet.SDK.9 --exact --accept-package-agreements --accept-source-agreements --uninstall-previous --force --source winget
+
+if ($LASTEXITCODE -ne 0) { throw [System.InvalidOperationException]::New('Failed to install .NET SDK') }
 
 # Downloads the online installer and automatically runs it and installs the build tools
 # https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/set-up-your-development-environment
 # https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools
 # https://learn.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio
 # https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-community
-winget install --id Microsoft.VisualStudio.2022.BuildTools --exact --accept-package-agreements --accept-source-agreements --uninstall-previous --force --source winget --override '--force --wait --passive --add Microsoft.VisualStudio.Workload.ManagedDesktop --add Microsoft.VisualStudio.Workload.MSBuildTools --add Microsoft.VisualStudio.Workload.UniversalBuildTools --add Microsoft.VisualStudio.ComponentGroup.WindowsAppSDK.Cs --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.v141.x86.x64 --includeRecommended'
+winget install --id Microsoft.VisualStudio.2022.BuildTools --exact --accept-package-agreements --accept-source-agreements --uninstall-previous --force --source winget --override '--force --wait --passive --add Microsoft.VisualStudio.Workload.ManagedDesktop --add Microsoft.VisualStudio.Workload.MSBuildTools --add Microsoft.VisualStudio.Workload.UniversalBuildTools --add Microsoft.VisualStudio.ComponentGroup.WindowsAppSDK.Cs --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.v141.x86.x64 --add Microsoft.VisualStudio.Component.Windows11SDK.26100 --includeRecommended'
 
-# Downloads the online installer and automatically runs it and installs the full Windows SDK
-winget install --id Microsoft.WindowsSDK.10.0.26100 --exact --accept-package-agreements --accept-source-agreements --uninstall-previous --force --source winget
+if ($LASTEXITCODE -ne 0) { throw [System.InvalidOperationException]::New('Failed to install Visual Studio Build Tools') }
 
-winget install --id Microsoft.AppInstaller --exact --accept-package-agreements --accept-source-agreements --uninstall-previous --force --source winget
 winget install --id Microsoft.VCRedist.2015+.x64 --exact --accept-package-agreements --accept-source-agreements --uninstall-previous --force --source winget
-winget install --id Microsoft.VCRedist.2015+.x86 --exact --accept-package-agreements --accept-source-agreements --uninstall-previous --force --source winget
 
 # Refresh the environment variables so the current session detects the new dotnet installation
-$Env:Path = [System.Environment]::GetEnvironmentVariable('Path', [System.EnvironmentVariableTarget]::Machine) + ';' + 
+$Env:Path = [System.Environment]::GetEnvironmentVariable('Path', [System.EnvironmentVariableTarget]::Machine) + ';' +
 [System.Environment]::GetEnvironmentVariable('Path', [System.EnvironmentVariableTarget]::User)
 
-dotnet build 'AppControl Manager.sln' --configuration Release --verbosity normal /p:Platform=x64
-dotnet msbuild 'AppControl Manager.sln' /p:Configuration=Release /p:AppxPackageDir="MSIXOutput\" /p:GenerateAppxPackageOnBuild=true /p:Platform=x64 -v:normal
+Write-Host -Object "`nChecking .NET info`n`n" -ForegroundColor Magenta
+dotnet --info
+Write-Host -Object "`nListing installed .NET SDKs`n`n" -ForegroundColor Magenta
+dotnet --list-sdks
+
+Function Find-mspdbcmf {
+    [string]$VisualStudioPath = . 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' -prerelease -latest -property resolvedInstallationPath
+
+    [string]$BasePath = [System.IO.Path]::Combine($VisualStudioPath, 'VC', 'Tools', 'MSVC')
+
+    # Get all subdirectories under the base path
+    [System.String[]]$VersionDirs = [System.IO.Directory]::GetDirectories($BasePath)
+
+    # Initialize the highest version with a minimal version value.
+    [System.Version]$HighestVersion = [System.Version]::New('0.0.0.0')
+    [System.String]$HighestVersionFolder = $null
+
+    # Loop through each directory to find the highest version folder.
+    foreach ($Dir in $VersionDirs) {
+        # Extract the folder name
+        [System.String]$FolderName = [System.IO.Path]::GetFileName($Dir)
+        [System.Version]$CurrentVersion = $null
+        # Try parsing the folder name as a Version.
+        if ([System.Version]::TryParse($FolderName, [ref] $CurrentVersion)) {
+            # Compare versions
+            if ($CurrentVersion.CompareTo($HighestVersion) -gt 0) {
+                $HighestVersion = $CurrentVersion
+                $HighestVersionFolder = $FolderName
+            }
+        }
+    }
+
+    # If no valid version folder is found
+    if (!$HighestVersionFolder) {
+        throw [System.IO.DirectoryNotFoundException]::New("No valid version directories found in $BasePath")
+    }
+
+    # Combine the base path, the highest version folder, the architecture folder, and the file name.
+    [System.String]$mspdbcmfPath = [System.IO.Path]::Combine($BasePath, $HighestVersionFolder, 'bin', 'Hostx64', 'x64', 'mspdbcmf.exe')
+
+    if (![System.IO.File]::Exists($mspdbcmfPath)) {
+        throw [System.IO.FileNotFoundException]::New("mspdbcmf.exe not found at $mspdbcmfPath")
+    }
+
+    return $mspdbcmfPath
+}
+
+[string]$mspdbcmfPath = Find-mspdbcmf
+
+# https://github.com/Microsoft/vswhere/wiki/Start-Developer-Command-Prompt#using-powershell
+$installationPath = . 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' -prerelease -latest -property installationPath
+if ($installationPath -and (Test-Path -Path "$installationPath\Common7\Tools\vsdevcmd.bat" -PathType Leaf)) {
+    & "${env:COMSPEC}" /s /c "`"$installationPath\Common7\Tools\vsdevcmd.bat`" -no_logo && set" | ForEach-Object -Process {
+        $name, $value = $_ -split '=', 2
+        Set-Content -Path env:\"$name" -Value $value -Force
+        Write-Host -Object "Setting environment variable: $name=$value"
+    }
+}
+
+# https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-build
+# https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-command-line-reference
+# https://learn.microsoft.com/en-us/visualstudio/msbuild/common-msbuild-project-properties
+
+# Generate for X64 architecture
+dotnet build 'AppControl Manager.sln' --configuration Release --verbosity minimal /p:Platform=x64
+dotnet msbuild 'AppControl Manager.sln' /p:Configuration=Release /p:AppxPackageDir="MSIXOutputX64\" /p:GenerateAppxPackageOnBuild=true /p:Platform=x64 -v:minimal /p:MsPdbCmfExeFullpath=$mspdbcmfPath
+# Generate for ARM64 architecture
+dotnet build 'AppControl Manager.sln' --configuration Release --verbosity minimal /p:Platform=ARM64
+dotnet msbuild 'AppControl Manager.sln' /p:Configuration=Release /p:AppxPackageDir="MSIXOutputARM64\" /p:GenerateAppxPackageOnBuild=true /p:Platform=ARM64 -v:minimal /p:MsPdbCmfExeFullpath=$mspdbcmfPath
+
+Function Get-MSIXFile {
+    Param(
+        [System.String]$BasePath,
+        [System.String]$FolderPattern,
+        [System.String]$FileNamePattern,
+        [System.String]$ErrorMessageFolder,
+        [System.String]$ErrorMessageFile
+    )
+    # Get all subdirectories in the base path matching the folder pattern
+    [System.String[]]$Folders = [System.IO.Directory]::GetDirectories($BasePath)
+    [System.String]$DetectedFolder = $null
+    foreach ($Folder in $Folders) {
+        if ([System.Text.RegularExpressions.Regex]::IsMatch($Folder, $FolderPattern)) {
+            $DetectedFolder = $Folder
+            break
+        }
+    }
+
+    if (!$DetectedFolder) {
+        Throw [System.InvalidOperationException]::New($ErrorMessageFolder)
+    }
+
+    # Get the full path of the first file matching the file name pattern inside the found folder
+    [System.String[]]$Files = [System.IO.Directory]::GetFiles($DetectedFolder)
+    [System.String]$DetectedFile = $null
+    foreach ($File in $Files) {
+        if ([System.Text.RegularExpressions.Regex]::IsMatch($File, $FileNamePattern)) {
+            $DetectedFile = $File
+            break
+        }
+    }
+
+    if (!$DetectedFile) {
+        Throw [System.InvalidOperationException]::New($ErrorMessageFile)
+    }
+    return $DetectedFile
+}
+
+#region Finding X64 outputs
+[System.String]$FinalMSIXX64Path = Get-MSIXFile -BasePath ([System.IO.Path]::Combine($PWD.Path, 'MSIXOutputX64')) -FolderPattern 'AppControl Manager_\d+\.\d+\.\d+\.\d+_Test' -FileNamePattern 'AppControl Manager_\d+\.\d+\.\d+\.\d+_x64\.msix' -ErrorMessageFolder 'Could not find the directory for X64 MSIX file' -ErrorMessageFile 'Could not find the X64 MSIX file'
+[System.String]$FinalMSIXX64Name = [System.IO.Path]::GetFileName($FinalMSIXX64Path)
+[System.String]$FinalMSIXX64SymbolPath = Get-MSIXFile -BasePath ([System.IO.Path]::Combine($PWD.Path, 'MSIXOutputX64')) -FolderPattern 'AppControl Manager_\d+\.\d+\.\d+\.\d+_Test' -FileNamePattern 'AppControl Manager_\d+\.\d+\.\d+\.\d+_x64\.msixsym' -ErrorMessageFolder 'Could not find the directory for X64 symbol file' -ErrorMessageFile 'Could not find the X64 symbol file'
+[System.String]$FinalMSIXX64SymbolName = [System.IO.Path]::GetFileName($FinalMSIXX64SymbolPath)
+#endregion
+
+#region Finding ARM64 outputs
+[System.String]$FinalMSIXARM64Path = Get-MSIXFile -BasePath ([System.IO.Path]::Combine($PWD.Path, 'MSIXOutputARM64')) -FolderPattern 'AppControl Manager_\d+\.\d+\.\d+\.\d+_Test' -FileNamePattern 'AppControl Manager_\d+\.\d+\.\d+\.\d+_arm64\.msix' -ErrorMessageFolder 'Could not find the directory for ARM64 MSIX file' -ErrorMessageFile 'Could not find the ARM64 MSIX file'
+[System.String]$FinalMSIXARM64Name = [System.IO.Path]::GetFileName($FinalMSIXARM64Path)
+[System.String]$FinalMSIXARM64SymbolPath = Get-MSIXFile -BasePath ([System.IO.Path]::Combine($PWD.Path, 'MSIXOutputARM64')) -FolderPattern 'AppControl Manager_\d+\.\d+\.\d+\.\d+_Test' -FileNamePattern 'AppControl Manager_\d+\.\d+\.\d+\.\d+_arm64\.msixsym' -ErrorMessageFolder 'Could not find the directory for ARM64 symbol file' -ErrorMessageFile 'Could not find the ARM64 symbol file'
+[System.String]$FinalMSIXARM64SymbolName = [System.IO.Path]::GetFileName($FinalMSIXARM64SymbolPath)
+#endregion
+
+#region Detect and Validate File Versions
+[System.Text.RegularExpressions.Regex]$versionRegexX64 = [System.Text.RegularExpressions.Regex]::New('AppControl Manager_(\d+\.\d+\.\d+\.\d+)_x64\.msix')
+[System.Text.RegularExpressions.Regex]$versionRegexARM64 = [System.Text.RegularExpressions.Regex]::New('AppControl Manager_(\d+\.\d+\.\d+\.\d+)_arm64\.msix')
+
+[System.Text.RegularExpressions.Match]$MatchX64 = $versionRegexX64.Match($FinalMSIXX64Name)
+[System.Text.RegularExpressions.Match]$MatchARM64 = $versionRegexARM64.Match($FinalMSIXARM64Name)
+
+if (!$MatchX64.Success) {
+    Throw [System.InvalidOperationException]::New('Could not detect version from X64 file name')
+}
+
+if (!$MatchARM64.Success) {
+    Throw [System.InvalidOperationException]::New('Could not detect version from ARM64 file name')
+}
+
+[System.String]$versionX64 = $MatchX64.Groups[1].Value
+[System.String]$versionARM64 = $MatchARM64.Groups[1].Value
+
+if ($versionX64 -ne $versionARM64) {
+    Throw [System.InvalidOperationException]::New('The versions in X64 and ARM64 files do not match')
+}
+
+# Craft the file name for the MSIX Bundle file
+[System.String]$FinalBundleFileName = "AppControl Manager_$versionX64.msixbundle"
+#endregion
+
+# Creating the directory where the MSIX packages will be copied to
+[System.String]$MSIXBundleOutput = [System.IO.Directory]::CreateDirectory([System.IO.Path]::Combine($AppControlManagerDirectory, 'MSIXBundleOutput')).FullName
+
+[System.IO.File]::Copy($FinalMSIXX64Path, [System.IO.Path]::Combine($MSIXBundleOutput, $FinalMSIXX64Name), $true)
+[System.IO.File]::Copy($FinalMSIXARM64Path, [System.IO.Path]::Combine($MSIXBundleOutput, $FinalMSIXARM64Name), $true)
+
+# The path to the final MSIX Bundle file
+[System.String]$MSIXBundle = [System.IO.Path]::Combine($MSIXBundleOutput, $FinalBundleFileName)
+
+Function Get-MakeAppxPath {
+    [System.String]$BasePath = 'C:\Program Files (x86)\Windows Kits\10\bin'
+
+    # Get all subdirectories under the base path
+    [System.String[]]$VersionDirs = [System.IO.Directory]::GetDirectories($BasePath)
+
+    # Initialize the highest version with a minimal version value.
+    [System.Version]$HighestVersion = [System.Version]::New('0.0.0.0')
+    [System.String]$HighestVersionFolder = $null
+
+    # Loop through each directory to find the highest version folder.
+    foreach ($Dir in $VersionDirs) {
+        # Extract the folder name
+        [System.String]$FolderName = [System.IO.Path]::GetFileName($Dir)
+        [System.Version]$CurrentVersion = $null
+        # Try parsing the folder name as a Version.
+        if ([System.Version]::TryParse($FolderName, [ref] $CurrentVersion)) {
+            # Compare versions
+            if ($CurrentVersion.CompareTo($HighestVersion) -gt 0) {
+                $HighestVersion = $CurrentVersion
+                $HighestVersionFolder = $FolderName
+            }
+        }
+    }
+
+    # If no valid version folder is found
+    if (!$HighestVersionFolder) {
+        throw [System.IO.DirectoryNotFoundException]::New("No valid version directories found in $BasePath")
+    }
+
+    [string]$CPUArch = @{AMD64 = 'x64'; ARM64 = 'arm64' }[$Env:PROCESSOR_ARCHITECTURE]
+    if ([System.String]::IsNullOrWhiteSpace($CPUArch)) { throw [System.PlatformNotSupportedException]::New('Only AMD64 and ARM64 architectures are supported.') }
+
+    # Combine the base path, the highest version folder, the architecture folder, and the file name.
+    [System.String]$MakeAppxPath = [System.IO.Path]::Combine($BasePath, $HighestVersionFolder, $CPUArch, 'makeappx.exe')
+
+    return $MakeAppxPath
+}
+
+[System.String]$MakeAppxPath = Get-MakeAppxPath
+
+if ([System.string]::IsNullOrWhiteSpace($MakeAppxPath)) {
+    throw [System.IO.FileNotFoundException]::New('Could not find the makeappx.exe')
+}
+
+# https://learn.microsoft.com/en-us/windows/win32/appxpkg/make-appx-package--makeappx-exe-#to-create-a-package-bundle-using-a-directory-structure
+. $MakeAppxPath bundle /d $MSIXBundleOutput /p $MSIXBundle /o /v
+
+if ($LASTEXITCODE -ne 0) { Throw [System.InvalidOperationException]::New("MakeAppx failed creating the MSIXBundle. Exit Code: $LASTEXITCODE") }
+
+#Endregion
+
+Write-Host -Object "ARM64 MSIX File Path: $FinalMSIXARM64Path" -ForegroundColor Cyan
+Write-Host -Object "ARM64 MSIX File Name: $FinalMSIXARM64Name" -ForegroundColor Cyan
+
+Write-Host -Object "X64 MSIX File Path: $FinalMSIXX64Path" -ForegroundColor Green
+Write-Host -Object "X64 MSIX File Name: $FinalMSIXX64Name" -ForegroundColor Green
+
+Write-Host -Object "MSIX Bundle File Path: $MSIXBundle" -ForegroundColor Yellow
+Write-Host -Object "MSIX Bundle File Name: $FinalBundleFileName" -ForegroundColor Yellow
+
+$Stopwatch.Stop()
+
+$Elapsed = $Stopwatch.Elapsed
+[string]$Result = @"
+Execution Time:
+----------------------------
+Total Time   : $($Elapsed.ToString('g'))
+Hours        : $($Elapsed.Hours)
+Minutes      : $($Elapsed.Minutes)
+Seconds      : $($Elapsed.Seconds)
+Milliseconds : $($Elapsed.Milliseconds)
+----------------------------
+"@
+
+Write-Host -Object $Result -ForegroundColor Cyan
+
 ```
 
 <br>


### PR DESCRIPTION
* ✅ The GitHub releases for the AppControl Manager will include symbol files for debugging purposes for both X64 and ARM64 architectures. They will also include complete build logs [for end-user review](https://learn.microsoft.com/en-us/shows/visual-studio-toolbox/msbuild-structured-log-viewer). All of these additional files are securely attested and verified by the workflow.

* ✅ [The entire process is completely transparent.](https://github.com/HotCakeX/Harden-Windows-Security/blob/main/.github/workflows/Build%20AppControl%20Manager%20MSIX%20Package.yml)

* ✅ [Provided instructions](https://github.com/HotCakeX/Harden-Windows-Security/wiki/AppControl-Manager#how-to-build-the-appcontrol-manager-locally) for building the AppControl Manager locally on your own device directly from the source code using no 3rd party tools at all.

* ✅ The build process has also been improved in the GitHub workflow by uploading the generated files to the release first before running any other actions. This can improve security and ensure no action can run prior to package building and upload.

* ✅The [Bootstrapper](https://github.com/HotCakeX/Harden-Windows-Security/blob/main/Harden-Windows-Security.ps1) has been improved, reducing number of lines of codes in it and also added the ability to install MSIXBundle files which include ARM64 and X64 support for AppControl Manager.

* ✅ AppControl Manager version bump to `1.8.9.0`

* ✅ Updated Nuget dependency: `Microsoft.Graphics.Win2D`
