### PR TITLE
Improved translation capability of AppControl Manager

### DIFF
--- a/AppControl Manager/Pages/AllowNewApps/AllowNewApps.xaml
+++ b/AppControl Manager/Pages/AllowNewApps/AllowNewApps.xaml
@@ -6,7 +6,6 @@
     xmlns:local="using:AppControlManager.Pages"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ui="using:CommunityToolkit.WinUI"
     mc:Ignorable="d">
 
     <Grid>

--- a/AppControl Manager/Pages/AllowNewApps/AllowNewAppsEventLogsDataGrid.xaml
+++ b/AppControl Manager/Pages/AllowNewApps/AllowNewAppsEventLogsDataGrid.xaml
@@ -7,7 +7,6 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    xmlns:ui="using:CommunityToolkit.WinUI"
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     xmlns:tk7controls="using:CommunityToolkit.WinUI.UI.Controls">
 

--- a/AppControl Manager/Pages/AllowNewApps/AllowNewAppsLocalFilesDataGrid.xaml
+++ b/AppControl Manager/Pages/AllowNewApps/AllowNewAppsLocalFilesDataGrid.xaml
@@ -7,7 +7,6 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    xmlns:ui="using:CommunityToolkit.WinUI"
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     xmlns:tk7controls="using:CommunityToolkit.WinUI.UI.Controls">
 

--- a/AppControl Manager/Pages/AllowNewApps/AllowNewAppsStart.xaml
+++ b/AppControl Manager/Pages/AllowNewApps/AllowNewAppsStart.xaml
@@ -6,10 +6,7 @@
     xmlns:local="using:AppControlManager.Pages"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ui="using:CommunityToolkit.WinUI"
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
-    xmlns:tk7controls="using:CommunityToolkit.WinUI.UI.Controls"
-    xmlns:animations="using:CommunityToolkit.WinUI.Animations"
     xmlns:animatedvisuals="using:AnimatedVisuals"
     mc:Ignorable="d">
 
@@ -39,11 +36,8 @@
                 <HyperlinkButton Margin="0,-8,0,8" x:Uid="GuideButtonAtTop" NavigateUri="https://github.com/HotCakeX/Harden-Windows-Security/wiki/Allow-New-Apps" />
 
                 <StackPanel Orientation="Horizontal" Spacing="15" Margin="0,-6,0,10">
-
-                    <Button x:Name="ResetStepsButton" Click="ResetStepsButton_Click" Style="{StaticResource AccentButtonStyle}" Content="Reset Steps" ToolTipService.ToolTip="Will reset the steps and if the base policy is deployed in Audit mode, will redeploy it in Enforced mode." />
-
+                    <Button x:Name="ResetStepsButton" Click="ResetStepsButton_Click" Style="{StaticResource AccentButtonStyle}" x:Uid="ResetStepsButton" />
                     <ProgressRing IsActive="False" x:Name="ResetProgressRing"/>
-
                 </StackPanel>
 
             </controls:WrapPanel>
@@ -64,14 +58,14 @@
                             <ProgressRing x:Name="Step1ProgressRing" IsActive="False" Margin=" 0,0,15,0"/>
                         </controls:WrapPanel>
 
-                        <TextBlock Text="Select the required info such as a deployed policy XML file and a name for the Supplemental policy that will be created" TextWrapping="WrapWholeWords" />
+                        <TextBlock x:Uid="AllowNewAppsStep1Text" TextWrapping="WrapWholeWords" />
                     </controls:WrapPanel>
 
                     <controls:WrapPanel Grid.Row="1" Orientation="Horizontal" VerticalSpacing="15" HorizontalSpacing="15">
 
                         <TextBox x:Name="SupplementalPolicyNameTextBox" Header="Supplemental Policy Name" PlaceholderText="Enter a name for the Supplemental Policy" />
                         <Button x:Name="BrowseForXMLPolicyButton" Click="BrowseForXMLPolicyButton_Click" Margin="0,27,0,0"
-                               RightTapped="BrowseForXMLPolicyButton_RightTapped" Holding="BrowseForXMLPolicyButton_Holding" ToolTipService.ToolTip="Click/Tap to choose a XML policy file from your device.">
+                               RightTapped="BrowseForXMLPolicyButton_RightTapped" Holding="BrowseForXMLPolicyButton_Holding" ToolTipService.ToolTip="Click/Tap to choose a Base policy XML file from your device.">
 
                             <Button.Flyout>
                                 <Flyout x:Name="BrowseForXMLPolicyButton_FlyOut">
@@ -100,20 +94,18 @@
                                         </AnimatedIcon.Source>
                                     </AnimatedIcon>
 
-                                    <TextBlock Text="Browse for a policy XML file" />
+                                    <TextBlock x:Uid="BrowseForBasePolicyTextBlock" />
 
                                 </controls:WrapPanel>
                             </Button.Content>
 
                         </Button>
 
-
                         <NumberBox x:Name="LogSizeNumberBox"
-    Header="Enter a number for Log Size in MB"
-SpinButtonPlacementMode="Inline"
-SmallChange="1"
-LargeChange="10" Minimum="2" Maximum="1000000" ValueChanged="LogSizeNumberBox_ValueChanged" ToolTipService.ToolTip="This is the Maximum Capacity of the Code Integrity Operational Log Size" />
-
+                            x:Uid="LogSizeNumberBox"
+                            SpinButtonPlacementMode="Inline"
+                            SmallChange="1"
+                            LargeChange="10" Minimum="2" Maximum="1000000" ValueChanged="LogSizeNumberBox_ValueChanged" />
 
                         <Button x:Name="GoToStep2Button" Click="GoToStep2Button_Click" Margin="0,27,0,0" Content="Go to step 2" ToolTipService.ToolTip="Start deploying the selected policy in Audit mode and go to step 2" Style="{StaticResource AccentButtonStyle}"/>
 
@@ -140,7 +132,7 @@ LargeChange="10" Minimum="2" Maximum="1000000" ValueChanged="LogSizeNumberBox_Va
                             <ProgressRing x:Name="Step2ProgressRing" IsActive="False" Margin=" 0,0,15,0"/>
                         </controls:WrapPanel>
 
-                        <TextBlock Text="Now install your new app or run a pre-installed app that was being blocked. You can optionally browse for folders to scan such as the location where the app is installed. Once you're done, use the button below to go to Step 3." TextWrapping="WrapWholeWords" />
+                        <TextBlock x:Uid="AllowNewAppsStep2Text" TextWrapping="WrapWholeWords" />
                     </controls:WrapPanel>
 
                     <controls:WrapPanel Grid.Row="1" Orientation="Horizontal" VerticalSpacing="8" HorizontalSpacing="8">
@@ -193,25 +185,22 @@ LargeChange="10" Minimum="2" Maximum="1000000" ValueChanged="LogSizeNumberBox_Va
                             <ProgressRing x:Name="Step3ProgressRing" IsActive="False" Margin=" 0,0,15,0"/>
                         </controls:WrapPanel>
 
-                        <TextBlock Text="Use the Event logs and local files tab to confirm or select the detected files in order to include them in the final Supplemental policy." TextWrapping="WrapWholeWords" />
+                        <TextBlock x:Uid="AllowNewAppsStep3Text" TextWrapping="WrapWholeWords" />
                     </controls:WrapPanel>
 
                     <controls:WrapPanel Grid.Row="1" Orientation="Horizontal" VerticalSpacing="8" HorizontalSpacing="8">
 
-                        <ToggleButton x:Name="DeployToggleButton" Checked="DeployToggleButton_Checked" Unchecked="DeployToggleButton_Unchecked" ToolTipService.ToolTip="The Supplemental policy will be automatically deployed on the system after creation." IsChecked="True" Content="Deploy" />
+                        <ToggleButton x:Name="DeployToggleButton" Checked="DeployToggleButton_Checked" Unchecked="DeployToggleButton_Unchecked" IsChecked="True" x:Uid="DeployAfterCreationButton" />
 
-                        <ComboBox SelectedIndex="0" SelectionChanged="ScanLevelComboBox_SelectionChanged" x:Name="ScanLevelComboBox" ToolTipService.ToolTip="Pick a level based on which the selected logs and files will be scanned" Header="Scan level" Margin="0,0,0,27">
+                        <ComboBox SelectedIndex="0" SelectionChanged="ScanLevelComboBox_SelectionChanged" x:Name="ScanLevelComboBox" x:Uid="ScanLevelComboBox" Header="Scan level" Margin="0,0,0,27">
                             <ComboBoxItem>FilePublisher</ComboBoxItem>
                             <ComboBoxItem>Publisher</ComboBoxItem>
                             <ComboBoxItem>Hash</ComboBoxItem>
                         </ComboBox>
 
-                        <Button x:Name="CreatePolicyButton" Click="CreatePolicyButton_Click" ToolTipService.ToolTip="Start creating the policy with the logs and files you selected" Content="Create Policy" Style="{StaticResource AccentButtonStyle}"/>
-
+                        <Button x:Name="CreatePolicyButton" Click="CreatePolicyButton_Click" x:Uid="AllowNewAppsCreatePolicyButton" Style="{StaticResource AccentButtonStyle}"/>
                     </controls:WrapPanel>
-
                     <InfoBar x:Name="Step3InfoBar" Severity="Informational" IsOpen="False" IsClosable='False' Margin="0,20,0,0" Grid.Row="2"/>
-
                 </Grid>
             </Border>
 

--- a/AppControl Manager/Pages/BuildNewCertificate.xaml
+++ b/AppControl Manager/Pages/BuildNewCertificate.xaml
@@ -8,7 +8,6 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="using:CommunityToolkit.WinUI"
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
-    xmlns:tk7controls="using:CommunityToolkit.WinUI.UI.Controls"
     xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     mc:Ignorable="d">
 

--- a/AppControl Manager/Pages/ConfigurePolicyRuleOptions.xaml
+++ b/AppControl Manager/Pages/ConfigurePolicyRuleOptions.xaml
@@ -35,8 +35,8 @@
 
 
             <Button Grid.Row="1" Margin="0,0,0,20" x:Name="PickPolicyFileButton" Click="PickPolicyFileButton_Click"
-     HorizontalAlignment="Center" RightTapped="PickPolicyFileButton_RightTapped" Holding="PickPolicyFileButton_Holding"
-    ToolTipService.ToolTip="Click/Tap to choose a XML policy file from your device.">
+                     HorizontalAlignment="Center" RightTapped="PickPolicyFileButton_RightTapped" Holding="PickPolicyFileButton_Holding"
+                     x:Uid="PickPolicyFileButton">
 
                 <Button.Flyout>
                     <Flyout x:Name="PickPolicyFileButton_FlyOut">
@@ -65,7 +65,7 @@
                             </AnimatedIcon.Source>
                         </AnimatedIcon>
 
-                        <TextBlock Text="Browse for a policy XML file" />
+                        <TextBlock x:Uid="BrowseForPolicyTextBlock" />
 
                     </controls:WrapPanel>
                 </Button.Content>

--- a/AppControl Manager/Pages/CreateDenyPolicy.xaml
+++ b/AppControl Manager/Pages/CreateDenyPolicy.xaml
@@ -9,7 +9,6 @@
     xmlns:ui="using:CommunityToolkit.WinUI"
     xmlns:others="using:AppControlManager.Others"
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
-    xmlns:tk7controls="using:CommunityToolkit.WinUI.UI.Controls"
     xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     mc:Ignorable="d">
 
@@ -185,7 +184,7 @@
                         <controls:SettingsCard Description="Select the level based on which the detected files will be scanned."
                         Header="Select Scan Level" Click="ScanLevelComboBoxSettingsCard_Click" x:Name="ScanLevelComboBoxSettingsCard" IsClickEnabled="True" IsActionIconVisible="False">
 
-                            <ComboBox x:Name="ScanLevelComboBox" SelectionChanged="ScanLevelComboBox_SelectionChanged" ToolTipService.ToolTip="Pick a level based on which the selected files will be scanned"
+                            <ComboBox x:Name="ScanLevelComboBox" SelectionChanged="ScanLevelComboBox_SelectionChanged" x:Uid="ScanLevelComboBox"
                                   SelectedIndex="0">
                                 <ComboBoxItem>File Publisher</ComboBoxItem>
                                 <ComboBoxItem>Publisher</ComboBoxItem>

--- a/AppControl Manager/Pages/CreateDenyPolicyFilesAndFoldersScanResults.xaml
+++ b/AppControl Manager/Pages/CreateDenyPolicyFilesAndFoldersScanResults.xaml
@@ -7,7 +7,6 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    xmlns:ui="using:CommunityToolkit.WinUI"
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     xmlns:tk7controls="using:CommunityToolkit.WinUI.UI.Controls">
 

--- a/AppControl Manager/Pages/CreatePolicy.xaml
+++ b/AppControl Manager/Pages/CreatePolicy.xaml
@@ -34,7 +34,6 @@
 
             </controls:WrapPanel>
 
-
             <StackPanel HorizontalAlignment="Stretch" Spacing="{StaticResource SettingsCardSpacing}" Grid.Row="1" Margin="0,40,0,0">
 
                 <win:StackPanel.ChildrenTransitions>
@@ -43,7 +42,6 @@
                 </win:StackPanel.ChildrenTransitions>
 
                 <!-- Allow Microsoft -->
-
                 <controls:SettingsExpander x:Name="AllowMicrosoftSettings"
                            Description="This policy will allow any program and file that is signed by Microsoft certificates to be able to run and everything else will be blocked."
                            Header="Create Allow Microsoft Policy"
@@ -69,19 +67,18 @@
                             <controls:WrapPanel Orientation="Horizontal">
 
                                 <NumberBox x:Name="AllowMicrosoftLogSizeInput"
-                                    Header="Enter a number for Log Size in MB"
+                                    x:Uid="LogSizeNumberBox"
                                     Value="2"
                                     SpinButtonPlacementMode="Inline"
                                     SmallChange="1"
                                     IsEnabled="False"
-                                    LargeChange="10" Minimum="2" Maximum="1000000" Margin="0,0,30,0" ToolTipService.ToolTip="This is the Maximum Capacity of the Code Integrity Operational Log Size" />
+                                    LargeChange="10" Minimum="2" Maximum="1000000" Margin="0,0,30,0" />
 
                                 <ToggleSwitch x:Name="AllowMicrosoftLogSizeInputEnabled" IsEnabled="False" Toggled="AllowMicrosoftLogSizeInputEnabled_Toggled" />
 
                             </controls:WrapPanel>
 
                         </controls:SettingsCard>
-
 
                         <controls:SettingsCard x:Uid="RequireEVSignersRuleOption">
                             <ToggleSwitch x:Name="AllowMicrosoftRequireEVSigners" />
@@ -100,9 +97,7 @@
                 </controls:SettingsExpander>
 
 
-
                 <!-- Default Windows -->
-
                 <controls:SettingsExpander x:Name="DefaultWindowsSettings"
                            Description="This policy will allow files that come by default with Windows OS to run (including Office products) and everything else will be blocked."
                            Header="Create Default Windows Policy"
@@ -128,19 +123,18 @@
                             <controls:WrapPanel Orientation="Horizontal">
 
                                 <NumberBox x:Name="DefaultWindowsLogSizeInput"
-                                    Header="Enter a number for Log Size in MB"
+                                    x:Uid="LogSizeNumberBox"
                                     IsEnabled="False"
                                     Value="2"
                                     SpinButtonPlacementMode="Inline"
                                     SmallChange="1"
-                                    LargeChange="10" Minimum="2" Maximum="1000000" Margin="0,0,30,0" ToolTipService.ToolTip="This is the Maximum Capacity of the Code Integrity Operational Log Size" />
+                                    LargeChange="10" Minimum="2" Maximum="1000000" Margin="0,0,30,0" />
 
                                 <ToggleSwitch x:Name="DefaultWindowsLogSizeInputEnabled" IsEnabled="False" Toggled="DefaultWindowsLogSizeInputEnabled_Toggled" />
 
                             </controls:WrapPanel>
 
                         </controls:SettingsCard>
-
 
                         <controls:SettingsCard x:Uid="RequireEVSignersRuleOption">
                             <ToggleSwitch x:Name="DefaultWindowsRequireEVSigners" />
@@ -159,9 +153,7 @@
                 </controls:SettingsExpander>
 
 
-
                 <!-- Signed and Reputable -->
-
                 <controls:SettingsExpander x:Name="SignedAndReputableSettings"
                            Description="This policy will allow any program and file that is signed by Microsoft certificates to be able to run. It will also use the Global Intelligence of the Microsoft's Intelligent Security Graph to automatically authorize reputable and signed files to run. Anything else will be blocked."
                            Header="Create Signed And Reputable Policy"
@@ -176,7 +168,6 @@
 
                     </controls:WrapPanel>
 
-
                     <controls:SettingsExpander.Items>
 
                         <controls:SettingsCard x:Uid="AuditRuleOptionSettingsCard">
@@ -188,12 +179,12 @@
                             <controls:WrapPanel Orientation="Horizontal">
 
                                 <NumberBox x:Name="SignedAndReputableLogSizeInput"
-                                    Header="Enter a number for Log Size in MB"
+                                    x:Uid="LogSizeNumberBox"
                                     IsEnabled="False"
                                     Value="2"
                                     SpinButtonPlacementMode="Inline"
                                     SmallChange="1"
-                                    LargeChange="10" Minimum="2" Maximum="1000000" Margin="0,0,30,0" ToolTipService.ToolTip="This is the Maximum Capacity of the Code Integrity Operational Log Size" />
+                                    LargeChange="10" Minimum="2" Maximum="1000000" Margin="0,0,30,0" />
 
                                 <ToggleSwitch x:Name="SignedAndReputableLogSizeInputEnabled" IsEnabled="False" Toggled="SignedAndReputableLogSizeInputEnabled_Toggled" />
 
@@ -219,7 +210,6 @@
 
 
                 <!-- Microsoft Recommended Driver Block Rules -->
-
                 <controls:SettingsExpander x:Name="RecommendedDriverBlockRulesSettings"
                            Description="This policy will create the Microsoft Recommended Driver Block Rules."
                            Header="Create Microsoft Recommended Driver Block Rules"
@@ -259,9 +249,7 @@
                 </controls:SettingsExpander>
 
 
-
                 <!-- Microsoft Recommended User Mode Block Rules -->
-
                 <controls:SettingsCard x:Name="RecommendedUserModeBlockRulesSettings"
                            Description="This policy will create the Microsoft Recommended User Mode Block Rules."
                            Header="Create Microsoft Recommended User Mode Block Rules"
@@ -280,7 +268,6 @@
 
 
                 <!-- Strict Kernel-mode policy -->
-
                 <controls:SettingsExpander x:Name="StrictKernelModePolicySection"
                      Description="This policy will only enforce Kernel-mode files and has no effect on user-mode files"
                      Header="Create Strict Kernel-mode Policy"
@@ -329,6 +316,5 @@
             </StackPanel>
 
         </Grid>
-
     </ScrollViewer>
 </Page>

--- a/AppControl Manager/Pages/CreateSupplementalPolicy.xaml
+++ b/AppControl Manager/Pages/CreateSupplementalPolicy.xaml
@@ -185,7 +185,8 @@
                             Header="Base Policy File" IsClickEnabled="True" Click="FilesAndFoldersBrowseForBasePolicySettingsCard_Click"
                             x:Name="FilesAndFoldersBrowseForBasePolicySettingsCard" Holding="FilesAndFoldersBrowseForBasePolicySettingsCard_Holding" RightTapped="FilesAndFoldersBrowseForBasePolicySettingsCard_RightTapped" IsActionIconVisible="False">
 
-                            <Button x:Name="FilesAndFoldersBrowseForBasePolicyButton" RightTapped="FilesAndFoldersBrowseForBasePolicyButton_RightTapped" Click="FilesAndFoldersBrowseForBasePolicyButton_Click">
+                            <Button x:Name="FilesAndFoldersBrowseForBasePolicyButton" RightTapped="FilesAndFoldersBrowseForBasePolicyButton_RightTapped"
+                                    x:Uid="PickPolicyFileButton" Click="FilesAndFoldersBrowseForBasePolicyButton_Click">
 
                                 <Button.Flyout>
                                     <Flyout x:Name="FilesAndFoldersBrowseForBasePolicyButton_FlyOut">
@@ -214,7 +215,7 @@
                                             </AnimatedIcon.Source>
                                         </AnimatedIcon>
 
-                                        <TextBlock Text="Browse" />
+                                        <TextBlock x:Uid="BrowseTextBlock" />
 
                                     </controls:WrapPanel>
                                 </Button.Content>
@@ -226,7 +227,7 @@
                         <controls:SettingsCard Description="Select the level based on which the detected files will be scanned."
                             Header="Select Scan Level" Click="ScanLevelComboBoxSettingsCard_Click" x:Name="ScanLevelComboBoxSettingsCard" IsClickEnabled="True" IsActionIconVisible="False">
 
-                            <ComboBox x:Name="ScanLevelComboBox" SelectionChanged="ScanLevelComboBox_SelectionChanged" ToolTipService.ToolTip="Pick a level based on which the selected files will be scanned"
+                            <ComboBox x:Name="ScanLevelComboBox" SelectionChanged="ScanLevelComboBox_SelectionChanged" x:Uid="ScanLevelComboBox"
                                  SelectedIndex="0">
                                 <ComboBoxItem>File Publisher</ComboBoxItem>
                                 <ComboBoxItem>Publisher</ComboBoxItem>
@@ -337,7 +338,8 @@
                                 Header="Base Policy File" IsClickEnabled="True" IsActionIconVisible="False" Click="CertificatesBrowseForBasePolicySettingsCard_Click"
                                                RightTapped="CertificatesBrowseForBasePolicySettingsCard_RightTapped" Holding="CertificatesBrowseForBasePolicySettingsCard_Holding">
 
-                            <Button x:Name="CertificatesBrowseForBasePolicyButton" RightTapped="CertificatesBrowseForBasePolicyButton_RightTapped" Click="CertificatesBrowseForBasePolicyButton_Click">
+                            <Button x:Name="CertificatesBrowseForBasePolicyButton" RightTapped="CertificatesBrowseForBasePolicyButton_RightTapped"
+                                    x:Uid="PickPolicyFileButton" Click="CertificatesBrowseForBasePolicyButton_Click">
 
                                 <Button.Flyout>
                                     <Flyout x:Name="CertificatesBrowseForBasePolicyButton_FlyOut">
@@ -366,7 +368,7 @@
                                             </AnimatedIcon.Source>
                                         </AnimatedIcon>
 
-                                        <TextBlock Text="Browse" />
+                                        <TextBlock x:Uid="BrowseTextBlock" />
 
                                     </controls:WrapPanel>
                                 </Button.Content>
@@ -429,7 +431,8 @@
                             Header="Base Policy File" IsClickEnabled="True" IsActionIconVisible="False" Click="ISGBrowseForBasePolicySettingsCard_Click"
                                                Holding="ISGBrowseForBasePolicySettingsCard_Holding" RightTapped="ISGBrowseForBasePolicySettingsCard_RightTapped">
 
-                            <Button x:Name="ISGBrowseForBasePolicyButton" Click="ISGBrowseForBasePolicyButton_Click" RightTapped="ISGBrowseForBasePolicyButton_RightTapped">
+                            <Button x:Name="ISGBrowseForBasePolicyButton" Click="ISGBrowseForBasePolicyButton_Click"
+                                    x:Uid="PickPolicyFileButton" RightTapped="ISGBrowseForBasePolicyButton_RightTapped">
 
                                 <Button.Flyout>
                                     <Flyout x:Name="ISGBrowseForBasePolicyButton_FlyOut">
@@ -458,7 +461,7 @@
                                             </AnimatedIcon.Source>
                                         </AnimatedIcon>
 
-                                        <TextBlock Text="Browse" />
+                                        <TextBlock x:Uid="BrowseTextBlock" />
 
                                     </controls:WrapPanel>
                                 </Button.Content>
@@ -532,7 +535,8 @@
                             Header="Base Policy File" IsClickEnabled="True" IsActionIconVisible="False" Click="StrictKernelModeBrowseForBasePolicySettingsCard_Click"
                                                RightTapped="StrictKernelModeBrowseForBasePolicySettingsCard_RightTapped" Holding="StrictKernelModeBrowseForBasePolicySettingsCard_Holding">
 
-                            <Button x:Name="StrictKernelModeBrowseForBasePolicyButton" RightTapped="StrictKernelModeBrowseForBasePolicyButton_RightTapped" Click="StrictKernelModeBrowseForBasePolicyButton_Click">
+                            <Button x:Name="StrictKernelModeBrowseForBasePolicyButton" RightTapped="StrictKernelModeBrowseForBasePolicyButton_RightTapped"
+                                    x:Uid="PickPolicyFileButton" Click="StrictKernelModeBrowseForBasePolicyButton_Click">
 
                                 <Button.Flyout>
                                     <Flyout x:Name="StrictKernelModeBrowseForBasePolicyButton_FlyOut">
@@ -561,7 +565,7 @@
                                             </AnimatedIcon.Source>
                                         </AnimatedIcon>
 
-                                        <TextBlock Text="Browse" />
+                                        <TextBlock x:Uid="BrowseTextBlock" />
 
                                     </controls:WrapPanel>
                                 </Button.Content>
@@ -630,7 +634,8 @@
                             Header="Base Policy File" IsClickEnabled="True" Click="PFNBrowseForBasePolicySettingsCard_Click" IsActionIconVisible="False"
                                                RightTapped="PFNBrowseForBasePolicySettingsCard_RightTapped" Holding="PFNBrowseForBasePolicySettingsCard_Holding">
 
-                            <Button x:Name="PFNBrowseForBasePolicyButton" RightTapped="PFNBrowseForBasePolicyButton_RightTapped" Click="PFNBrowseForBasePolicyButton_Click">
+                            <Button x:Name="PFNBrowseForBasePolicyButton" RightTapped="PFNBrowseForBasePolicyButton_RightTapped"
+                                    x:Uid="PickPolicyFileButton" Click="PFNBrowseForBasePolicyButton_Click">
 
                                 <Button.Flyout>
                                     <Flyout x:Name="PFNBrowseForBasePolicyButton_FlyOut">
@@ -659,7 +664,7 @@
                                             </AnimatedIcon.Source>
                                         </AnimatedIcon>
 
-                                        <TextBlock Text="Browse" />
+                                        <TextBlock x:Uid="BrowseTextBlock" />
 
                                     </controls:WrapPanel>
                                 </Button.Content>

--- a/AppControl Manager/Pages/CreateSupplementalPolicyFilesAndFoldersScanResults.xaml
+++ b/AppControl Manager/Pages/CreateSupplementalPolicyFilesAndFoldersScanResults.xaml
@@ -7,7 +7,6 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    xmlns:ui="using:CommunityToolkit.WinUI"
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     xmlns:tk7controls="using:CommunityToolkit.WinUI.UI.Controls">
 

--- a/AppControl Manager/Pages/Deployment.xaml
+++ b/AppControl Manager/Pages/Deployment.xaml
@@ -8,7 +8,6 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="using:CommunityToolkit.WinUI"
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
-    xmlns:tk7controls="using:CommunityToolkit.WinUI.UI.Controls"
     xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:animatedvisuals="using:AnimatedVisuals"
     mc:Ignorable="d">
@@ -116,7 +115,7 @@
                                         </AnimatedIcon.Source>
                                     </AnimatedIcon>
 
-                                    <TextBlock Text="Browse" />
+                                    <TextBlock x:Uid="BrowseTextBlock" />
 
                                 </controls:WrapPanel>
                             </Button.Content>
@@ -128,7 +127,7 @@
 
                                         <Button x:Uid="ClearButton" Click="BrowseForXMLPolicyFilesButton_Flyout_Clear_Click" />
 
-                                        <TextBlock Text="View the XML files you selected." TextWrapping="WrapWholeWords" />
+                                        <TextBlock x:Uid="ViewSelectedXMLFileTextBlock" TextWrapping="WrapWholeWords" />
 
                                         <TextBox x:Name="BrowseForXMLPolicyFilesButton_SelectedFilesTextBox"
                                             TextWrapping="Wrap" AcceptsReturn="True" IsSpellCheckEnabled="False"
@@ -184,7 +183,7 @@
                                         </AnimatedIcon.Source>
                                     </AnimatedIcon>
 
-                                    <TextBlock Text="Browse" />
+                                    <TextBlock x:Uid="BrowseTextBlock" />
 
                                 </controls:WrapPanel>
                             </Button.Content>
@@ -196,7 +195,7 @@
 
                                         <Button x:Uid="ClearButton" Click="BrowseForSignedXMLPolicyFilesButton_Flyout_Clear_Click" />
 
-                                        <TextBlock Text="View the XML files you selected." TextWrapping="WrapWholeWords" />
+                                        <TextBlock x:Uid="ViewSelectedXMLFileTextBlock" TextWrapping="WrapWholeWords" />
 
                                         <TextBox x:Name="BrowseForSignedXMLPolicyFilesButton_SelectedFilesTextBox"
                                             TextWrapping="Wrap" AcceptsReturn="True" IsSpellCheckEnabled="False"

--- a/AppControl Manager/Pages/EventLogsPolicyCreation.xaml
+++ b/AppControl Manager/Pages/EventLogsPolicyCreation.xaml
@@ -39,8 +39,8 @@
                     <TextBlock Text="View the Code Integrity EVTX files you selected." TextWrapping="WrapWholeWords" />
 
                     <TextBox x:Name="SelectedCodeIntegrityEVTXFilesFlyout_TextBox"
-TextWrapping="Wrap" AcceptsReturn="True" IsSpellCheckEnabled="False"
-MinWidth="400" IsReadOnly="True" />
+                        TextWrapping="Wrap" AcceptsReturn="True" IsSpellCheckEnabled="False"
+                        MinWidth="400" IsReadOnly="True" />
 
                 </controls:WrapPanel>
 
@@ -55,8 +55,8 @@ MinWidth="400" IsReadOnly="True" />
                     <TextBlock Text="View the AppLocker EVTX files you selected." TextWrapping="WrapWholeWords" />
 
                     <TextBox x:Name="SelectedAppLockerEVTXFilesFlyout_TextBox"
-TextWrapping="Wrap" AcceptsReturn="True" IsSpellCheckEnabled="False"
-MinWidth="400" IsReadOnly="True" />
+                        TextWrapping="Wrap" AcceptsReturn="True" IsSpellCheckEnabled="False"
+                        MinWidth="400" IsReadOnly="True" />
 
                 </controls:WrapPanel>
 
@@ -83,22 +83,19 @@ MinWidth="400" IsReadOnly="True" />
 
         </controls:WrapPanel>
 
-        <Border
-    Grid.Row="1"
-    Margin="0,10,0,10"
-    Style="{StaticResource GridCardStyle}" Padding="8">
+        <Border Grid.Row="1" Margin="0,10,0,10"
+            Style="{StaticResource GridCardStyle}" Padding="8">
 
             <controls:WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalSpacing="10" VerticalSpacing="10">
 
                 <ProgressRing x:Name="ScanLogsProgressRing" Visibility="Collapsed" IsActive="False" />
 
                 <!-- Scan button -->
-                <Button x:Name="ScanLogs" ToolTipService.ToolTip="Scan the system or the selected EVTX files for Code Integrity/AppLocker logs" Style="{StaticResource AccentButtonStyle}" Click="ScanLogs_Click" >
+                <Button x:Name="ScanLogs" x:Uid="ScanLogsButton" Style="{StaticResource AccentButtonStyle}" Click="ScanLogs_Click" >
                     <Button.Content>
                         <StackPanel Orientation="Horizontal">
                             <FontIcon Glyph="&#xEE6F;" />
-                            <TextBlock Text="Scan Logs" Margin="5,0,0,0" />
-
+                            <TextBlock x:Uid="ScanLogsTextBlock" Margin="5,0,0,0" />
                         </StackPanel>
                     </Button.Content>
                 </Button>
@@ -287,7 +284,7 @@ MinWidth="400" IsReadOnly="True" />
 
                 <CalendarDatePicker x:Name="FilterByDateCalendarPicker" PlaceholderText="Filter logs by date" ToolTipService.ToolTip="Will only show logs that are newer than the selected date" />
 
-                <ComboBox SelectionChanged="ScanLevelComboBox_SelectionChanged" x:Name="ScanLevelComboBox" ToolTipService.ToolTip="Pick a level based on which the selected logs will be scanned" PlaceholderText="Scan level" >
+                <ComboBox SelectionChanged="ScanLevelComboBox_SelectionChanged" x:Name="ScanLevelComboBox" x:Uid="ScanLevelComboBox" PlaceholderText="Scan level" >
                     <ComboBoxItem>FilePublisher</ComboBoxItem>
                     <ComboBoxItem>Publisher</ComboBoxItem>
                     <ComboBoxItem>Hash</ComboBoxItem>

--- a/AppControl Manager/Pages/EventLogsPolicyCreation.xaml.cs
+++ b/AppControl Manager/Pages/EventLogsPolicyCreation.xaml.cs
@@ -219,7 +219,6 @@ public sealed partial class EventLogsPolicyCreation : Page
 			ScanLogsProgressRing.IsActive = false;
 			ScanLogsProgressRing.Visibility = Visibility.Collapsed;
 
-
 			// Enable the Policy creator button again
 			CreatePolicyButton.IsEnabled = true;
 		}

--- a/AppControl Manager/Pages/GetCIHashes.xaml
+++ b/AppControl Manager/Pages/GetCIHashes.xaml
@@ -33,9 +33,9 @@
             <controls:WrapPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalSpacing="10" VerticalSpacing="15" Margin="15,0,15,0" Grid.Row="1">
 
                 <!-- Button to trigger file picker -->
-                <Button x:Name="PickFileButton" Content="Browse for a file" Click="PickFile_Click"
+                <Button x:Name="PickFileButton" Click="PickFile_Click"
             HorizontalAlignment="Center"
-            ToolTipService.ToolTip="Click/Tap to choose a file from your device."
+            x:Uid="FileBrowseButton"
             Style="{StaticResource AccentButtonStyle}"/>
 
                 <!-- Grid for SHA1 Page -->
@@ -109,7 +109,5 @@
             </controls:WrapPanel>
 
         </Grid>
-
     </ScrollViewer>
-
 </Page>

--- a/AppControl Manager/Pages/GetSecurePolicySettings.xaml
+++ b/AppControl Manager/Pages/GetSecurePolicySettings.xaml
@@ -61,7 +61,5 @@
             <InfoBar x:Name="InfoBar" IsOpen="False" Margin="0,20,0,0" Grid.Row="3"/>
 
         </Grid>
-
     </ScrollViewer>
-
 </Page>

--- a/AppControl Manager/Pages/GitHubDocumentation.xaml
+++ b/AppControl Manager/Pages/GitHubDocumentation.xaml
@@ -6,7 +6,6 @@
     xmlns:local="using:AppControlManager.Pages"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ui="using:CommunityToolkit.WinUI"
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     mc:Ignorable="d">
 
@@ -22,7 +21,7 @@
             <Button Click="BackButton_Click" IsEnabled="False" x:Name="BackButton">
                 <StackPanel Orientation="Horizontal">
                     <SymbolIcon Symbol="Back"/>
-                    <TextBlock Text="Back" Margin="5,0,0,0"/>
+                    <TextBlock x:Uid="WebViewBackButton" Margin="5,0,0,0"/>
                 </StackPanel>
             </Button>
 
@@ -30,7 +29,7 @@
             <Button Click="ForwardButton_Click" IsEnabled="False" x:Name="ForwardButton">
                 <StackPanel Orientation="Horizontal">
                     <SymbolIcon Symbol="Forward"/>
-                    <TextBlock Text="Forward" Margin="5,0,0,0"/>
+                    <TextBlock x:Uid="WebViewForwardButton" Margin="5,0,0,0"/>
                 </StackPanel>
             </Button>
 
@@ -38,7 +37,7 @@
             <Button Click="ReloadButton_Click">
                 <StackPanel Orientation="Horizontal">
                     <SymbolIcon Symbol="Refresh"/>
-                    <TextBlock Text="Reload" Margin="5,0,0,0"/>
+                    <TextBlock x:Uid="WebViewReloadButton" Margin="5,0,0,0"/>
                 </StackPanel>
             </Button>
 
@@ -47,7 +46,7 @@
                 <StackPanel Orientation="Horizontal">
                     <!-- Using FontIcon to show a "Home" symbol from Segoe MDL2 Assets -->
                     <FontIcon Glyph="" FontFamily="Segoe MDL2 Assets"/>
-                    <TextBlock Text="Home" Margin="5,0,0,0"/>
+                    <TextBlock x:Uid="WebViewHomeButton" Margin="5,0,0,0"/>
                 </StackPanel>
             </Button>
         </controls:WrapPanel>

--- a/AppControl Manager/Pages/Logs.xaml
+++ b/AppControl Manager/Pages/Logs.xaml
@@ -6,7 +6,6 @@
     xmlns:local="using:AppControlManager.Pages"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ui="using:CommunityToolkit.WinUI"
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     mc:Ignorable="d">
 

--- a/AppControl Manager/Pages/MDEAHPolicyCreation.xaml
+++ b/AppControl Manager/Pages/MDEAHPolicyCreation.xaml
@@ -353,7 +353,7 @@ Spacing="8">
                     </Button.Flyout>
                 </Button>
 
-                <ComboBox SelectionChanged="ScanLevelComboBox_SelectionChanged" x:Name="ScanLevelComboBox" ToolTipService.ToolTip="Pick a level based on which the selected logs will be scanned" PlaceholderText="Scan level">
+                <ComboBox SelectionChanged="ScanLevelComboBox_SelectionChanged" x:Name="ScanLevelComboBox" x:Uid="ScanLevelComboBox" PlaceholderText="Scan level">
                     <ComboBoxItem>FilePublisher</ComboBoxItem>
                     <ComboBoxItem>Publisher</ComboBoxItem>
                     <ComboBoxItem>Hash</ComboBoxItem>

--- a/AppControl Manager/Pages/MergePolicies.xaml
+++ b/AppControl Manager/Pages/MergePolicies.xaml
@@ -22,12 +22,11 @@
             <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Vertical" Margin="6,0,6,10">
 
                 <TextBlock TextWrapping="WrapWholeWords" Style="{StaticResource BodyTextBlockStyle}">
-
-<Span>
-    Merge <Italic>App Control for Business</Italic>
-        <Run Foreground="{ThemeResource SystemAccentColor}">policies</Run>
-    and deduplicate them. You can select <Bold>the same policy twice</Bold> in order to deduplicate its rules.
-</Span>
+                    <Span>
+                        Merge <Italic>App Control for Business</Italic>
+                            <Run Foreground="{ThemeResource SystemAccentColor}">policies</Run>
+                        and deduplicate them. You can select <Bold>the same policy twice</Bold> in order to deduplicate its rules.
+                    </Span>
                 </TextBlock>
 
                 <HyperlinkButton x:Uid="GuideButtonAtTop" NavigateUri="https://github.com/HotCakeX/Harden-Windows-Security/wiki/Merge-App-Control-Policies" />
@@ -138,7 +137,5 @@
 
             </StackPanel>
         </Grid>
-
     </ScrollViewer>
-
 </Page>

--- a/AppControl Manager/Pages/MicrosoftDocumentation.xaml
+++ b/AppControl Manager/Pages/MicrosoftDocumentation.xaml
@@ -6,7 +6,6 @@
     xmlns:local="using:AppControlManager.Pages"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ui="using:CommunityToolkit.WinUI"
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     mc:Ignorable="d">
 
@@ -22,7 +21,7 @@
             <Button Click="BackButton_Click" IsEnabled="False" x:Name="BackButton">
                 <StackPanel Orientation="Horizontal">
                     <SymbolIcon Symbol="Back"/>
-                    <TextBlock Text="Back" Margin="5,0,0,0"/>
+                    <TextBlock x:Uid="WebViewBackButton" Margin="5,0,0,0"/>
                 </StackPanel>
             </Button>
 
@@ -30,7 +29,7 @@
             <Button Click="ForwardButton_Click" IsEnabled="False" x:Name="ForwardButton">
                 <StackPanel Orientation="Horizontal">
                     <SymbolIcon Symbol="Forward"/>
-                    <TextBlock Text="Forward" Margin="5,0,0,0"/>
+                    <TextBlock x:Uid="WebViewForwardButton" Margin="5,0,0,0"/>
                 </StackPanel>
             </Button>
 
@@ -38,7 +37,7 @@
             <Button Click="ReloadButton_Click">
                 <StackPanel Orientation="Horizontal">
                     <SymbolIcon Symbol="Refresh"/>
-                    <TextBlock Text="Reload" Margin="5,0,0,0"/>
+                    <TextBlock x:Uid="WebViewReloadButton" Margin="5,0,0,0"/>
                 </StackPanel>
             </Button>
 
@@ -47,7 +46,7 @@
                 <StackPanel Orientation="Horizontal">
                     <!-- Using FontIcon to show a "Home" symbol from Segoe MDL2 Assets -->
                     <FontIcon Glyph="" FontFamily="Segoe MDL2 Assets"/>
-                    <TextBlock Text="Home" Margin="5,0,0,0"/>
+                    <TextBlock x:Uid="WebViewHomeButton" Margin="5,0,0,0"/>
                 </StackPanel>
             </Button>
         </controls:WrapPanel>

--- a/AppControl Manager/Pages/Settings.xaml
+++ b/AppControl Manager/Pages/Settings.xaml
@@ -22,16 +22,14 @@
             <controls:WrapPanel Grid.Row="0" VerticalSpacing="4" HorizontalSpacing="4" Orientation="Horizontal" Margin="6,0,6,10">
 
                 <TextBlock TextWrapping="WrapWholeWords" Style="{StaticResource BodyTextBlockStyle}">
-
-<Span>
-    Customize your app settings here. Your preferences will be
-        <Run Foreground="{ThemeResource SystemAccentColor}">saved</Run>
-    so they're ready for you every time you start the AppControl Manager.
-</Span>
+                    <Span>
+                        Customize your app settings here. Your preferences will be
+                            <Run Foreground="{ThemeResource SystemAccentColor}">saved</Run>
+                        so they're ready for you every time you start the AppControl Manager.
+                    </Span>
                 </TextBlock>
 
             </controls:WrapPanel>
-
 
             <StackPanel HorizontalAlignment="Stretch"
                         Spacing="{StaticResource SettingsCardSpacing}" Grid.Row="1">
@@ -39,12 +37,13 @@
                     <win:EntranceThemeTransition FromVerticalOffset="50" />
                     <win:RepositionThemeTransition IsStaggeringEnabled="False" />
                 </win:StackPanel.ChildrenTransitions>
-                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}"
-                           Text="User Configurations" />
-                <controls:SettingsExpander Description="The following are the contents of the User Configurations JSON file"
-                                           Header="User Configs" x:Name="MainUserConfigurationsSettingsExpander"
+
+                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" x:Uid="UserConfigurations" />
+
+                <controls:SettingsExpander x:Uid="UserConfigsSettingsExpander"
+                                           x:Name="MainUserConfigurationsSettingsExpander"
                                            HeaderIcon="{ui:FontIcon Glyph=&#xE71D;}">
-                    <Button Content="Get Configuration"  Click="GetConfigurationButton_Click"
+                    <Button Content="Get Configuration" Click="GetConfigurationButton_Click"
                             Style="{StaticResource AccentButtonStyle}" />
                     <controls:SettingsExpander.Items>
                         <controls:SettingsCard ContentAlignment="Left">
@@ -53,27 +52,27 @@
                                 <controls:WrapPanel Orientation="Horizontal" Margin="0,0,0,10">
                                     <TextBox Header="Signed Policy Path:" x:Name="SignedPolicyPathTextBox" MinWidth="300" Margin="0,0,10,0" VerticalAlignment="Center"/>
                                     <CommandBar Background="Transparent" IsOpen="False" DefaultLabelPosition="Right" VerticalAlignment="Center" Margin="0,25,0,0">
-                                        <AppBarButton Icon="Save" Label="Save" Click="EditButton_Click" Tag="SignedPolicyPath"/>
-                                        <AppBarButton Icon="Clear" Label="Clear" Click="ClearButton_Click" Tag="SignedPolicyPath"/>
-                                        <AppBarButton Icon="Folder" Label="Browse" Click="BrowseButton_Click" Tag="SignedPolicyPath"/>
+                                        <AppBarButton Icon="Save" x:Uid="SaveAppBarButton" Click="EditButton_Click" Tag="SignedPolicyPath"/>
+                                        <AppBarButton Icon="Clear" x:Uid="ClearAppBarButton" Click="ClearButton_Click" Tag="SignedPolicyPath"/>
+                                        <AppBarButton Icon="Folder" x:Uid="BrowseAppBarButton" Click="BrowseButton_Click" Tag="SignedPolicyPath"/>
                                     </CommandBar>
                                 </controls:WrapPanel>
                                 <!-- Unsigned Policy Path -->
                                 <controls:WrapPanel Orientation="Horizontal" Margin="0,0,0,10">
                                     <TextBox Header="Unsigned Policy Path:" x:Name="UnsignedPolicyPathTextBox" MinWidth="300" Margin="0,0,10,0" VerticalAlignment="Center"/>
                                     <CommandBar Background="Transparent" IsOpen="False" DefaultLabelPosition="Right" VerticalAlignment="Center" Margin="0,25,0,0">
-                                        <AppBarButton Icon="Save" Label="Save" Click="EditButton_Click" Tag="UnsignedPolicyPath"/>
-                                        <AppBarButton Icon="Clear" Label="Clear" Click="ClearButton_Click" Tag="UnsignedPolicyPath"/>
-                                        <AppBarButton Icon="Folder" Label="Browse" Click="BrowseButton_Click" Tag="UnsignedPolicyPath"/>
+                                        <AppBarButton Icon="Save" x:Uid="SaveAppBarButton" Click="EditButton_Click" Tag="UnsignedPolicyPath"/>
+                                        <AppBarButton Icon="Clear" x:Uid="ClearAppBarButton" Click="ClearButton_Click" Tag="UnsignedPolicyPath"/>
+                                        <AppBarButton Icon="Folder" x:Uid="BrowseAppBarButton" Click="BrowseButton_Click" Tag="UnsignedPolicyPath"/>
                                     </CommandBar>
                                 </controls:WrapPanel>
                                 <!-- Sign Tool Custom Path -->
                                 <controls:WrapPanel Orientation="Horizontal" Margin="0,0,0,10">
                                     <TextBox Header="Sign Tool Custom Path:" x:Name="SignToolCustomPathTextBox" MinWidth="300" Margin="0,0,10,0" VerticalAlignment="Center"/>
                                     <CommandBar Background="Transparent" IsOpen="False" DefaultLabelPosition="Right" VerticalAlignment="Center" Margin="0,25,0,0">
-                                        <AppBarButton Icon="Save" Label="Save" Click="EditButton_Click" Tag="SignToolCustomPath"/>
-                                        <AppBarButton Icon="Clear" Label="Clear" Click="ClearButton_Click" Tag="SignToolCustomPath"/>
-                                        <AppBarButton Icon="Folder" Label="Browse" Click="BrowseButton_Click" Tag="SignToolCustomPath"/>
+                                        <AppBarButton Icon="Save" x:Uid="SaveAppBarButton" Click="EditButton_Click" Tag="SignToolCustomPath"/>
+                                        <AppBarButton Icon="Clear" x:Uid="ClearAppBarButton" Click="ClearButton_Click" Tag="SignToolCustomPath"/>
+                                        <AppBarButton Icon="Folder" x:Uid="BrowseAppBarButton" Click="BrowseButton_Click" Tag="SignToolCustomPath"/>
                                     </CommandBar>
                                 </controls:WrapPanel>
                                 <!-- Certificate Common Name -->
@@ -88,18 +87,18 @@
                                         MinWidth="300" Margin="0,0,10,0" VerticalAlignment="Center"/>
 
                                     <CommandBar Background="Transparent" IsOpen="False" DefaultLabelPosition="Right" VerticalAlignment="Center" Margin="0,25,0,0">
-                                        <AppBarButton Icon="Save" Label="Save" Click="EditButton_Click" Tag="CertificateCommonName"/>
-                                        <AppBarButton Icon="Clear" Label="Clear" Click="ClearButton_Click" Tag="CertificateCommonName"/>
-                                        <AppBarButton Icon="Refresh" Label="Refresh" Click="CertificateCommonNameSuggestionsRefresh_Click" Tag="CertificateCommonName" ToolTipService.ToolTip="Fetches the latest certificate common names from the User's personal certificate store"/>
+                                        <AppBarButton Icon="Save" x:Uid="SaveAppBarButton" Click="EditButton_Click" Tag="CertificateCommonName"/>
+                                        <AppBarButton Icon="Clear" x:Uid="ClearAppBarButton" Click="ClearButton_Click" Tag="CertificateCommonName"/>
+                                        <AppBarButton Icon="Refresh" x:Uid="RefreshAppBarButton" Click="CertificateCommonNameSuggestionsRefresh_Click" Tag="CertificateCommonName"/>
                                     </CommandBar>
                                 </controls:WrapPanel>
                                 <!-- Certificate Path -->
                                 <controls:WrapPanel Orientation="Horizontal" Margin="0,0,0,10">
                                     <TextBox Header="Certificate Path:" x:Name="CertificatePathTextBox" MinWidth="300" Margin="0,0,10,0" VerticalAlignment="Center"/>
                                     <CommandBar Background="Transparent" IsOpen="False" DefaultLabelPosition="Right" VerticalAlignment="Center" Margin="0,25,0,0">
-                                        <AppBarButton Icon="Save" Label="Save" Click="EditButton_Click" Tag="CertificatePath"/>
-                                        <AppBarButton Icon="Clear" Label="Clear" Click="ClearButton_Click" Tag="CertificatePath"/>
-                                        <AppBarButton Icon="Folder" Label="Browse" Click="BrowseButton_Click" Tag="CertificatePath"/>
+                                        <AppBarButton Icon="Save" x:Uid="SaveAppBarButton" Click="EditButton_Click" Tag="CertificatePath"/>
+                                        <AppBarButton Icon="Clear" x:Uid="ClearAppBarButton" Click="ClearButton_Click" Tag="CertificatePath"/>
+                                        <AppBarButton Icon="Folder" x:Uid="BrowseAppBarButton" Click="BrowseButton_Click" Tag="CertificatePath"/>
                                     </CommandBar>
                                 </controls:WrapPanel>
                             </StackPanel>
@@ -107,8 +106,8 @@
                     </controls:SettingsExpander.Items>
                 </controls:SettingsExpander>
 
-                <!--  'Appearance' section  -->
-                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="Appearance" />
+                <!-- Appearance section -->
+                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" x:Uid="Appearance" />
                 <controls:SettingsExpander IsExpanded="True" Header="Make AppControl Manager Look the Way You Want" HeaderIcon="{ui:FontIcon Glyph=&#xE790;}">
 
                     <controls:SettingsExpander.ItemsHeader>
@@ -130,12 +129,12 @@
 
                     <controls:SettingsExpander.Items>
 
-                        <controls:SettingsCard Description="Mostly suitable when using MicaAlt as the background." Header="Darker Background" HeaderIcon="{ui:FontIcon Glyph=&#xF0E8;}">
-                            <ToggleSwitch x:Name="NavigationViewBackgroundToggle" ToolTipService.ToolTip="It will remove the extra light shadow from the background, giving an overal darker look to the AppControl Manager's appearance."/>
+                        <controls:SettingsCard x:Uid="DarkerBackGroundSettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xF0E8;}">
+                            <ToggleSwitch x:Name="NavigationViewBackgroundToggle"/>
                         </controls:SettingsCard>
 
-                        <controls:SettingsCard Description="Customize the App Background Style" Header="Background Style" HeaderIcon="{ui:FontIcon Glyph=&#xEF1F;}">
-                            <ComboBox x:Name="BackgroundComboBox" ToolTipService.ToolTip="This is the backdrop of the AppControl Manager. The changes you notice will be visible in the background.">
+                        <controls:SettingsCard x:Uid="BackgroundStyleSettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xEF1F;}">
+                            <ComboBox x:Name="BackgroundComboBox">
                                 <ComboBoxItem>MicaAlt</ComboBoxItem>
                                 <ComboBoxItem>Mica</ComboBoxItem>
                                 <ComboBoxItem>Acrylic</ComboBoxItem>
@@ -143,24 +142,24 @@
 
                         </controls:SettingsCard>
 
-                        <controls:SettingsCard Description="Customize the Theme" Header="Theme" HeaderIcon="{ui:FontIcon Glyph=&#xE706;}">
-                            <ComboBox x:Name="ThemeComboBox" ToolTipService.ToolTip="Select a theme for the AppControl Manager">
+                        <controls:SettingsCard x:Uid="AppThemeSettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xE706;}">
+                            <ComboBox x:Name="ThemeComboBox">
                                 <ComboBoxItem>Use System Setting</ComboBoxItem>
                                 <ComboBoxItem>Dark</ComboBoxItem>
                                 <ComboBoxItem>Light</ComboBoxItem>
                             </ComboBox>
                         </controls:SettingsCard>
 
-                        <controls:SettingsCard Description="Choose a style for the main navigation icons" Header="Icons Style" HeaderIcon="{ui:FontIcon Glyph=&#xE8D3;}">
-                            <ComboBox x:Name="IconsStyleComboBox" ToolTipService.ToolTip="Pick a style for the main navigation's icons.">
+                        <controls:SettingsCard x:Uid="MainNavigationIconsSettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xE8D3;}">
+                            <ComboBox x:Name="IconsStyleComboBox">
                                 <ComboBoxItem>Animated</ComboBoxItem>
                                 <ComboBoxItem>Windows Accent</ComboBoxItem>
                                 <ComboBoxItem>Monochromatic</ComboBoxItem>
                             </ComboBox>
                         </controls:SettingsCard>
 
-                        <controls:SettingsCard Description="Customize the Navigation Menu location" Header="Navigation Menu" HeaderIcon="{ui:FontIcon Glyph=&#xE90C;}">
-                            <ComboBox SelectedIndex="0" x:Name="NavigationMenuLocation" ToolTipService.ToolTip="Select a location for the navigation menu">
+                        <controls:SettingsCard x:Uid="MainNavigationLocationSettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xE90C;}">
+                            <ComboBox SelectedIndex="0" x:Name="NavigationMenuLocation">
                                 <ComboBoxItem>Left</ComboBoxItem>
                                 <ComboBoxItem>Top</ComboBoxItem>
                             </ComboBox>
@@ -170,16 +169,15 @@
 
                 </controls:SettingsExpander>
 
-                <!--  'Sound' section  -->
-                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}"
-           Text="Sound" />
-                <controls:SettingsCard Description="Hear audio feedback when using different elements of the AppControl Manager" Header="Sound" HeaderIcon="{ui:FontIcon Glyph=&#xEC4F;}">
+                <!-- Sound section -->
+                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" x:Uid="Sound" />
+                <controls:SettingsCard x:Uid="AppSoundSettingSettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xEC4F;}">
                     <ToggleSwitch x:Name="SoundToggleSwitch" />
                 </controls:SettingsCard>
 
-                <!--  'About' section  -->
+                <!-- About section -->
                 <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}"
-                           Text="About" />
+                           x:Uid="About" />
                 <controls:SettingsExpander x:Name="CopyRightSettingsExpander"
                                            Header="AppControl Manager"
                                            IsExpanded="True"
@@ -221,7 +219,5 @@
             </StackPanel>
 
         </Grid>
-
     </ScrollViewer>
-
 </Page>

--- a/AppControl Manager/Pages/Simulation.xaml
+++ b/AppControl Manager/Pages/Simulation.xaml
@@ -8,7 +8,6 @@
     xmlns:AppControlManager="using:AppControlManager"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ui="using:CommunityToolkit.WinUI"
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     xmlns:tk7controls="using:CommunityToolkit.WinUI.UI.Controls"
     mc:Ignorable="d">
@@ -61,7 +60,7 @@
 
                                 <Button x:Uid="ClearButton" Click="SelectXmlFileButton_Flyout_Clear_Click" />
 
-                                <TextBlock Text="View the XML file you selected." TextWrapping="WrapWholeWords" />
+                                <TextBlock x:Uid="ViewSelectedXMLFileTextBlock" TextWrapping="WrapWholeWords" />
 
                                 <TextBox x:Name="SelectXmlFileButton_SelectedFilesTextBox"
                                     TextWrapping="Wrap" AcceptsReturn="True" IsSpellCheckEnabled="False"
@@ -75,7 +74,7 @@
                     <Button.Content>
                         <StackPanel Orientation="Horizontal">
                             <FontIcon Glyph="&#xEC50;" />
-                            <TextBlock Text="Select XML File" Margin="5,0,0,0"/>
+                            <TextBlock x:Uid="SelectXMLFileTextBlock" Margin="5,0,0,0"/>
                         </StackPanel>
                     </Button.Content>
                 </Button>
@@ -105,7 +104,7 @@
                     <Button.Content>
                         <StackPanel Orientation="Horizontal">
                             <FontIcon Glyph="&#xEC50;" />
-                            <TextBlock Text="Select Files" Margin="5,0,0,0"/>
+                            <TextBlock x:Uid="SelectFilesTextBlock" Margin="5,0,0,0"/>
                         </StackPanel>
                     </Button.Content>
                 </Button>
@@ -136,7 +135,7 @@
                     <Button.Content>
                         <StackPanel Orientation="Horizontal">
                             <FontIcon Glyph="&#xED25;" />
-                            <TextBlock Text="Select Folders" Margin="5,0,0,0"/>
+                            <TextBlock x:Uid="SelectFoldersTextBlock" Margin="5,0,0,0"/>
                         </StackPanel>
                     </Button.Content>
                 </Button>

--- a/AppControl Manager/Pages/StrictKernelPolicyScanResults.xaml
+++ b/AppControl Manager/Pages/StrictKernelPolicyScanResults.xaml
@@ -7,7 +7,6 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    xmlns:ui="using:CommunityToolkit.WinUI"
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     xmlns:tk7controls="using:CommunityToolkit.WinUI.UI.Controls">
 

--- a/AppControl Manager/Pages/SystemInformation/CodeIntegrityInfo.xaml
+++ b/AppControl Manager/Pages/SystemInformation/CodeIntegrityInfo.xaml
@@ -75,7 +75,5 @@
             </controls:WrapPanel>
 
         </Grid>
-
     </ScrollViewer>
-
 </Page>

--- a/AppControl Manager/Pages/Update.xaml
+++ b/AppControl Manager/Pages/Update.xaml
@@ -99,7 +99,5 @@ Header="Hardened Update Procedure" HeaderIcon="{ui:FontIcon Glyph=&#xF552;}" IsC
             </StackPanel>
 
         </Grid>
-
     </ScrollViewer>
-
 </Page>

--- a/AppControl Manager/Pages/UpdatePageCustomMSIXPath.xaml
+++ b/AppControl Manager/Pages/UpdatePageCustomMSIXPath.xaml
@@ -45,7 +45,5 @@
             </StackPanel>
 
         </Grid>
-
     </ScrollViewer>
-
 </Page>

--- a/AppControl Manager/Pages/ValidatePolicy.xaml
+++ b/AppControl Manager/Pages/ValidatePolicy.xaml
@@ -6,7 +6,6 @@
     xmlns:local="using:AppControlManager.Pages"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ui="using:CommunityToolkit.WinUI"
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     mc:Ignorable="d">
@@ -49,17 +48,16 @@
                     <win:RepositionThemeTransition IsStaggeringEnabled="False" />
                 </win:StackPanel.ChildrenTransitions>
 
-                <controls:SettingsCard Description="Browse for an App Control policy XML file to validate"
-                                       x:Name="BrowseForXMLSettingsCard"
-                    Header="Select Policy" IsClickEnabled="True" Click="BrowseForXMLSettingsCard_Click" IsActionIconVisible="False">
+                <controls:SettingsCard x:Uid="ValidateAppControlPolicySettingsCard"
+                   x:Name="BrowseForXMLSettingsCard"
+                   IsClickEnabled="True" Click="BrowseForXMLSettingsCard_Click" IsActionIconVisible="False">
 
-                    <Button Content="Browse" x:Name="BrowseForXMLButton" Click="BrowseForXMLButton_Click" />
+                    <Button x:Uid="BrowseButton" x:Name="BrowseForXMLButton" Click="BrowseForXMLButton_Click" />
 
                 </controls:SettingsCard>
 
             </StackPanel>
 
         </Grid>
-
     </ScrollViewer>
 </Page>

--- a/AppControl Manager/Pages/ViewFileCertificates.xaml
+++ b/AppControl Manager/Pages/ViewFileCertificates.xaml
@@ -6,7 +6,6 @@
     xmlns:local="using:AppControlManager.Pages"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ui="using:CommunityToolkit.WinUI"
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     xmlns:tk7controls="using:CommunityToolkit.WinUI.UI.Controls"
     xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"

--- a/AppControl Manager/Strings/en-US/Resources.resw
+++ b/AppControl Manager/Strings/en-US/Resources.resw
@@ -508,4 +508,181 @@
   <data name="OpenConfigDirectoryButtonText.Text" xml:space="preserve">
     <value>Open User Config Directory</value>
   </data>
+  <data name="ResetStepsButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Will reset the steps and if the base policy is deployed in Audit mode, will redeploy it in Enforced mode.</value>
+  </data>
+  <data name="ResetStepsButton.Content" xml:space="preserve">
+    <value>Reset Steps</value>
+  </data>
+  <data name="AllowNewAppsStep1Text.Text" xml:space="preserve">
+    <value>Select the required info such as a deployed policy XML file and a name for the Supplemental policy that will be created</value>
+  </data>
+  <data name="AllowNewAppsStep2Text.Text" xml:space="preserve">
+    <value>Now install your new app or run a pre-installed app that was being blocked. You can optionally browse for folders to scan such as the location where the app is installed. Once you&apos;re done, use the button below to go to Step 3.</value>
+  </data>
+  <data name="AllowNewAppsStep3Text.Text" xml:space="preserve">
+    <value>Use the Event logs and local files tab to confirm or select the detected files in order to include them in the final Supplemental policy.</value>
+  </data>
+  <data name="AllowNewAppsCreatePolicyButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Start creating the policy with the logs and files you selected</value>
+  </data>
+  <data name="AllowNewAppsCreatePolicyButton.Content" xml:space="preserve">
+    <value>Create Policy</value>
+  </data>
+  <data name="LogSizeNumberBox.ToolTipService.ToolTip" xml:space="preserve">
+    <value>This is the Maximum Capacity of the Code Integrity Operational Log Size</value>
+  </data>
+  <data name="LogSizeNumberBox.Header" xml:space="preserve">
+    <value>Enter a number for Log Size in MB</value>
+  </data>
+  <data name="BrowseTextBlock.Text" xml:space="preserve">
+    <value>Browse</value>
+  </data>
+  <data name="BrowseForBasePolicyTextBlock.Text" xml:space="preserve">
+    <value>Browse for a Base policy file</value>
+  </data>
+  <data name="BrowseForPolicyTextBlock.Text" xml:space="preserve">
+    <value>Browse for a policy XML file</value>
+  </data>
+  <data name="PickPolicyFileButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Click/Tap to choose a XML policy file from your device</value>
+  </data>
+  <data name="ScanLevelComboBox.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Pick a level based on which the Files/Logs will be scanned</value>
+  </data>
+  <data name="WebViewBackButton.Text" xml:space="preserve">
+    <value>Back</value>
+  </data>
+  <data name="WebViewForwardButton.Text" xml:space="preserve">
+    <value>Forward</value>
+  </data>
+  <data name="WebViewReloadButton.Text" xml:space="preserve">
+    <value>Reload</value>
+  </data>
+  <data name="WebViewHomeButton.Text" xml:space="preserve">
+    <value>Home</value>
+  </data>
+  <data name="UserConfigsSettingsExpander.Description" xml:space="preserve">
+    <value>The following are the contents of the User Configurations JSON file</value>
+  </data>
+  <data name="UserConfigsSettingsExpander.Header" xml:space="preserve">
+    <value>User Configs</value>
+  </data>
+  <data name="SaveAppBarButton.Label" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="SaveAppBarButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="BrowseAppBarButton.Label" xml:space="preserve">
+    <value>Browse</value>
+  </data>
+  <data name="BrowseAppBarButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Browse</value>
+  </data>
+  <data name="ClearAppBarButton.Label" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="ClearAppBarButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="RefreshAppBarButton.Label" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+  <data name="RefreshAppBarButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Fetches the latest certificate common names from the User&apos;s personal certificate store</value>
+  </data>
+  <data name="BackgroundStyleSettingsCard.Description" xml:space="preserve">
+    <value>Customize the App Background Style</value>
+  </data>
+  <data name="BackgroundStyleSettingsCard.Header" xml:space="preserve">
+    <value>Background Style</value>
+  </data>
+  <data name="BackgroundStyleSettingsCard.ToolTipService.ToolTip" xml:space="preserve">
+    <value>This is the backdrop of the AppControl Manager. The changes will be visible in the background.</value>
+  </data>
+  <data name="MainNavigationIconsSettingsCard.Description" xml:space="preserve">
+    <value>Choose a style for the main navigation icons</value>
+  </data>
+  <data name="MainNavigationIconsSettingsCard.Header" xml:space="preserve">
+    <value>Icons Style</value>
+  </data>
+  <data name="MainNavigationIconsSettingsCard.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Pick a style for the main navigation&apos;s icons.</value>
+  </data>
+  <data name="AppThemeSettingsCard.Description" xml:space="preserve">
+    <value>Customize the Theme</value>
+  </data>
+  <data name="AppThemeSettingsCard.Header" xml:space="preserve">
+    <value>Theme</value>
+  </data>
+  <data name="AppThemeSettingsCard.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Select a theme for the AppControl Manager</value>
+  </data>
+  <data name="MainNavigationLocationSettingsCard.Description" xml:space="preserve">
+    <value>Customize the Navigation Menu location</value>
+  </data>
+  <data name="MainNavigationLocationSettingsCard.Header" xml:space="preserve">
+    <value>Navigation Menu</value>
+  </data>
+  <data name="MainNavigationLocationSettingsCard.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Select a location for the navigation menu</value>
+  </data>
+  <data name="AppSoundSettingSettingsCard.Description" xml:space="preserve">
+    <value>Hear audio feedback when using different elements of the AppControl Manager</value>
+  </data>
+  <data name="AppSoundSettingSettingsCard.Header" xml:space="preserve">
+    <value>Sound</value>
+  </data>
+  <data name="AppSoundSettingSettingsCard.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Hear audio feedback when using different elements of the AppControl Manager</value>
+  </data>
+  <data name="DarkerBackGroundSettingsCard.Description" xml:space="preserve">
+    <value>Mostly suitable when using MicaAlt as the background.</value>
+  </data>
+  <data name="DarkerBackGroundSettingsCard.Header" xml:space="preserve">
+    <value>Darker Background</value>
+  </data>
+  <data name="DarkerBackGroundSettingsCard.ToolTipService.ToolTip" xml:space="preserve">
+    <value>It will remove the extra light shadow from the background, giving an overall darker look to the AppControl Manager&apos;s appearance.</value>
+  </data>
+  <data name="UserConfigurations.Text" xml:space="preserve">
+    <value>User Configurations</value>
+  </data>
+  <data name="Appearance.Text" xml:space="preserve">
+    <value>Appearance</value>
+  </data>
+  <data name="Sound.Text" xml:space="preserve">
+    <value>Sound</value>
+  </data>
+  <data name="About.Text" xml:space="preserve">
+    <value>About</value>
+  </data>
+  <data name="ValidateAppControlPolicySettingsCard.Description" xml:space="preserve">
+    <value>Browse for an App Control policy XML file to validate</value>
+  </data>
+  <data name="ValidateAppControlPolicySettingsCard.Header" xml:space="preserve">
+    <value>Select Policy</value>
+  </data>
+  <data name="BrowseButton.Content" xml:space="preserve">
+    <value>Browse</value>
+  </data>
+  <data name="ViewSelectedXMLFileTextBlock.Text" xml:space="preserve">
+    <value>View the XML file(s) you selected.</value>
+  </data>
+  <data name="SelectXMLFileTextBlock.Text" xml:space="preserve">
+    <value>Select XML File</value>
+  </data>
+  <data name="SelectFilesTextBlock.Text" xml:space="preserve">
+    <value>Select Files</value>
+  </data>
+  <data name="SelectFoldersTextBlock.Text" xml:space="preserve">
+    <value>Select Folders</value>
+  </data>
+  <data name="ScanLogsTextBlock.Text" xml:space="preserve">
+    <value>Scan Logs</value>
+  </data>
+  <data name="ScanLogsButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Scan the system or the selected EVTX files for Code Integrity/AppLocker logs</value>
+  </data>
 </root>


### PR DESCRIPTION
Further separation of strings from the XAML, improving the ability of the AppControl Manager to be translated into other languages and reducing the likelihood of having typos in the UI text.

Also cleaned up some extra empty lines and removed unnecessary using declarations from XAML pages.