### PR TITLE
improving the reliability of installed apps list fetching in the AppControl Manager

### DIFF
--- a/AppControl Manager/Pages/AllowNewApps/AllowNewAppsStart.xaml.cs
+++ b/AppControl Manager/Pages/AllowNewApps/AllowNewAppsStart.xaml.cs
@@ -798,10 +798,7 @@ public sealed partial class AllowNewAppsStart : Page, Sidebar.IAnimatedIconsMana
 		// Get the selected item from the ComboBox
 		string selectedText = (string)comboBox.SelectedItem;
 
-		if (!Enum.TryParse(selectedText, out scanLevel))
-		{
-			throw new InvalidOperationException($"{selectedText} is not a valid Scan Level");
-		}
+		scanLevel = Enum.Parse<ScanLevels>(selectedText);
 	}
 
 

--- a/AppControl Manager/Pages/CreateDenyPolicy.xaml.cs
+++ b/AppControl Manager/Pages/CreateDenyPolicy.xaml.cs
@@ -558,12 +558,22 @@ public sealed partial class CreateDenyPolicy : Page
 			// Loop over each package
 			foreach (Package item in allApps)
 			{
+				// Get the logo string (or an empty string if null)
+				string logoStr = item.Logo?.ToString() ?? string.Empty;
+
+				// Validate that the logo string is a valid absolute URI
+				if (!Uri.TryCreate(logoStr, UriKind.Absolute, out _))
+				{
+					// If invalid, assign a fallback logo
+					logoStr = "ms-appx:///Assets/StoreLogo.backup.png";
+				}
+
 				// Create a new instance of the class that displays each app in the ListView
 				apps.Add(new PackagedAppView(
 					displayName: item.DisplayName,
 					version: $"Version: {item.Id.Version.Major}.{item.Id.Version.Minor}.{item.Id.Version.Build}.{item.Id.Version.Revision}",
 					packageFamilyName: $"PFN: {item.Id.FamilyName}",
-					logo: item.Logo.ToString(),
+					logo: logoStr,
 					packageFamilyNameActual: item.Id.FamilyName
 					));
 			}

--- a/AppControl Manager/Pages/CreateSupplementalPolicy.xaml.cs
+++ b/AppControl Manager/Pages/CreateSupplementalPolicy.xaml.cs
@@ -1840,12 +1840,22 @@ public sealed partial class CreateSupplementalPolicy : Page, Sidebar.IAnimatedIc
 			// Loop over each package
 			foreach (Package item in allApps)
 			{
+				// Get the logo string (or an empty string if null)
+				string logoStr = item.Logo?.ToString() ?? string.Empty;
+
+				// Validate that the logo string is a valid absolute URI
+				if (!Uri.TryCreate(logoStr, UriKind.Absolute, out _))
+				{
+					// If invalid, assign a fallback logo
+					logoStr = "ms-appx:///Assets/StoreLogo.backup.png";
+				}
+
 				// Create a new instance of the class that displays each app in the ListView
 				apps.Add(new PackagedAppView(
 					displayName: item.DisplayName,
 					version: $"Version: {item.Id.Version.Major}.{item.Id.Version.Minor}.{item.Id.Version.Build}.{item.Id.Version.Revision}",
 					packageFamilyName: $"PFN: {item.Id.FamilyName}",
-					logo: item.Logo.ToString(),
+					logo: logoStr,
 					packageFamilyNameActual: item.Id.FamilyName
 					));
 			}


### PR DESCRIPTION
improving the reliability of installed apps list fetching. Fixing this issue: https://github.com/HotCakeX/Harden-Windows-Security/issues/611

The URIs/logos of app have a reliable fallback value now so no error is thrown if they are invalid.

Also improved a small portion of the code to simplify an enum.