### PR TITLE
Added new Setting behavior to center list views automatically in AppControl Manager

### DIFF
--- a/AppControl Manager/AppSettings/AppSettingsCls.cs
+++ b/AppControl Manager/AppSettings/AppSettingsCls.cs
@@ -81,6 +81,7 @@ internal static class AppSettingsCls
 		MainWindowHeight,
 		MainWindowIsMaximized,
 		AutomaticAssignmentSidebar,
-		AutoCheckForUpdateAtStartup
+		AutoCheckForUpdateAtStartup,
+		ListViewsVerticalCentering
 	}
 }

--- a/AppControl Manager/Others/ListViewUIHelpers.cs
+++ b/AppControl Manager/Others/ListViewUIHelpers.cs
@@ -1,12 +1,22 @@
-﻿using System.Text;
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
 using AppControlManager.IntelGathering;
+using CommunityToolkit.WinUI;
 using Microsoft.UI.Text;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Media;
 using Windows.Foundation;
+using static AppControlManager.AppSettings.AppSettingsCls;
 
 namespace AppControlManager.Others;
 
+/// <summary>
+/// This class includes methods that are helpers for the custom ListView implementations in this application.
+/// </summary>
 internal static class ListViewUIHelpers
 {
 	// An offscreen TextBlock for measurement
@@ -64,4 +74,212 @@ internal static class ListViewUIHelpers
 			.AppendLine($"Opus Data: {row.Opus}")
 			.ToString();
 	}
+
+
+	/*
+
+	Windows Community Toolkit
+
+	Copyright © .NET Foundation and Contributors
+
+	All rights reserved.
+
+	MIT License (MIT)
+
+	Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+	The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+	THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+	*/
+
+	// This is a modification of the methods in Windows Community Toolkit, ListViewExtensions, Smooth Scroll Into View feature that only has the center vertically code plus some additional logic
+	// https://github.com/CommunityToolkit/Windows/pull/648
+
+
+	private static readonly Dictionary<ListView, int> ObjRemovalTracking = [];
+
+	/// <summary>
+	/// Smooth scrolling the list to bring the specified index into view, centering vertically
+	/// </summary>
+	/// <param name="listViewBase">List to scroll</param>
+	/// <param name="index">The index to bring into view. Index can be negative.</param>
+	/// <param name="disableAnimation">Set true to disable animation</param>
+	/// <param name="scrollIfVisible">Set false to disable scrolling when the corresponding item is in view</param>
+	/// <param name="additionalHorizontalOffset">Adds additional horizontal offset</param>
+	/// <param name="additionalVerticalOffset">Adds additional vertical offset</param>
+	/// <returns>Returns <see cref="Task"/> that completes after scrolling</returns>
+	internal static async Task SmoothScrollIntoViewWithIndexCenterVerticallyOnlyAsync(this ListViewBase listViewBase, ListView listView, int index, bool disableAnimation = false, bool scrollIfVisible = true, int additionalHorizontalOffset = 0, int additionalVerticalOffset = 0)
+	{
+
+		// Only perform the scroll if the setting is enabled
+		if (!GetSetting<bool>(SettingKeys.ListViewsVerticalCentering))
+		{
+			return;
+		}
+
+		// Don't center if an item was deleted
+		// Without this step, after row deletion in ListView, the data jumps up/down in a weird way
+		if (!ObjRemovalTracking.TryGetValue(listView, out int value))
+		{
+			ObjRemovalTracking.Add(listView, ((IList)listView.ItemsSource).Count);
+		}
+
+		if (value != ((IList)listView.ItemsSource).Count)
+		{
+			ObjRemovalTracking[listView] = ((IList)listView.ItemsSource).Count;
+
+			return;
+		}
+
+		if (index > (listViewBase.Items.Count - 1))
+		{
+			index = listViewBase.Items.Count - 1;
+		}
+
+		if (index < -listViewBase.Items.Count)
+		{
+			index = -listViewBase.Items.Count;
+		}
+
+		index = (index < 0) ? (index + listViewBase.Items.Count) : index;
+
+		bool isVirtualizing = default;
+		double previousXOffset = default, previousYOffset = default;
+
+		ScrollViewer? scrollViewer = listViewBase.FindDescendant<ScrollViewer>();
+		SelectorItem? selectorItem = listViewBase.ContainerFromIndex(index) as SelectorItem;
+
+		if (scrollViewer is null)
+		{
+			return;
+		}
+
+		// If selectorItem is null then the panel is virtualized.
+		// So in order to get the container of the item we need to scroll to that item first and then use ContainerFromIndex
+		if (selectorItem is null)
+		{
+			isVirtualizing = true;
+
+			previousXOffset = scrollViewer.HorizontalOffset;
+			previousYOffset = scrollViewer.VerticalOffset;
+
+			TaskCompletionSource<object?> tcs = new();
+
+			void ViewChanged(object? _, ScrollViewerViewChangedEventArgs __) => tcs.TrySetResult(result: default);
+
+			try
+			{
+				scrollViewer.ViewChanged += ViewChanged;
+				listViewBase.ScrollIntoView(listViewBase.Items[index], ScrollIntoViewAlignment.Leading);
+				_ = await tcs.Task;
+			}
+			finally
+			{
+				scrollViewer.ViewChanged -= ViewChanged;
+			}
+
+			selectorItem = (SelectorItem)listViewBase.ContainerFromIndex(index);
+		}
+
+		GeneralTransform transform = selectorItem.TransformToVisual((UIElement)scrollViewer.Content);
+		Point position = transform.TransformPoint(new Point(0, 0));
+
+		// Scrolling back to previous position
+		if (isVirtualizing)
+		{
+			await scrollViewer.ChangeViewAsync(previousXOffset, previousYOffset, zoomFactor: null, disableAnimation: true);
+		}
+
+		double listViewBaseWidth = listViewBase.ActualWidth;
+		double selectorItemWidth = selectorItem.ActualWidth;
+		double listViewBaseHeight = listViewBase.ActualHeight;
+		double selectorItemHeight = selectorItem.ActualHeight;
+
+		previousXOffset = scrollViewer.HorizontalOffset;
+		previousYOffset = scrollViewer.VerticalOffset;
+
+		double minXPosition = position.X - listViewBaseWidth + selectorItemWidth;
+		double minYPosition = position.Y - listViewBaseHeight + selectorItemHeight;
+
+		double maxXPosition = position.X;
+		double maxYPosition = position.Y;
+
+		double finalXPosition, finalYPosition;
+
+		// If the Item is in view and scrollIfVisible is false then we don't need to scroll
+		if (!scrollIfVisible && (previousXOffset <= maxXPosition && previousXOffset >= minXPosition) && (previousYOffset <= maxYPosition && previousYOffset >= minYPosition))
+		{
+			finalXPosition = previousXOffset;
+			finalYPosition = previousYOffset;
+		}
+		// Center it vertically
+		else
+		{
+			finalXPosition = previousXOffset + additionalHorizontalOffset;
+			finalYPosition = maxYPosition - ((listViewBaseHeight - selectorItemHeight) / 2.0) + additionalVerticalOffset;
+		}
+
+		await scrollViewer.ChangeViewAsync(finalXPosition, finalYPosition, zoomFactor: null, disableAnimation);
+	}
+
+	/// <summary>
+	/// Changes the view of <see cref="ScrollViewer"/> asynchronous.
+	/// </summary>
+	/// <param name="scrollViewer">The scroll viewer.</param>
+	/// <param name="horizontalOffset">The horizontal offset.</param>
+	/// <param name="verticalOffset">The vertical offset.</param>
+	/// <param name="zoomFactor">The zoom factor.</param>
+	/// <param name="disableAnimation">if set to <c>true</c> disable animation.</param>
+	private static async Task ChangeViewAsync(this ScrollViewer scrollViewer, double? horizontalOffset, double? verticalOffset, float? zoomFactor, bool disableAnimation)
+	{
+		if (horizontalOffset > scrollViewer.ScrollableWidth)
+		{
+			horizontalOffset = scrollViewer.ScrollableWidth;
+		}
+		else if (horizontalOffset < 0)
+		{
+			horizontalOffset = 0;
+		}
+
+		if (verticalOffset > scrollViewer.ScrollableHeight)
+		{
+			verticalOffset = scrollViewer.ScrollableHeight;
+		}
+		else if (verticalOffset < 0)
+		{
+			verticalOffset = 0;
+		}
+
+		// MUST check this and return immediately, otherwise this async task will never complete because ViewChanged event won't get triggered
+		if (horizontalOffset == scrollViewer.HorizontalOffset && verticalOffset == scrollViewer.VerticalOffset)
+		{
+			return;
+		}
+
+		TaskCompletionSource<object?> tcs = new();
+
+		void ViewChanged(object? _, ScrollViewerViewChangedEventArgs e)
+		{
+			if (e.IsIntermediate)
+			{
+				return;
+			}
+
+			_ = tcs.TrySetResult(result: default);
+		}
+
+		try
+		{
+			scrollViewer.ViewChanged += ViewChanged;
+			_ = scrollViewer.ChangeView(horizontalOffset, verticalOffset, zoomFactor, disableAnimation);
+			_ = await tcs.Task;
+		}
+		finally
+		{
+			scrollViewer.ViewChanged -= ViewChanged;
+		}
+	}
+
 }

--- a/AppControl Manager/Pages/AllowNewApps/AllowNewAppsEventLogsDataGrid.xaml
+++ b/AppControl Manager/Pages/AllowNewApps/AllowNewAppsEventLogsDataGrid.xaml
@@ -112,6 +112,7 @@
             ScrollViewer.HorizontalScrollBarVisibility="Visible"
             ShowsScrollingPlaceholders="True"
             ScrollViewer.VerticalScrollBarVisibility="Visible"
+            SelectionChanged="FileIdentitiesListView_SelectionChanged"
             ContainerContentChanging="ListView_ContainerContentChanging">
 
             <ListView.Header>

--- a/AppControl Manager/Pages/AllowNewApps/AllowNewAppsEventLogsDataGrid.xaml.cs
+++ b/AppControl Manager/Pages/AllowNewApps/AllowNewAppsEventLogsDataGrid.xaml.cs
@@ -731,6 +731,10 @@ public sealed partial class AllowNewAppsEventLogsDataGrid : Page, INotifyPropert
 			// If the item is not already selected, clear previous selections and select this one.
 			if (!item.IsSelected)
 			{
+
+				// Set the counter so that the SelectionChanged event handler will ignore the next 2 events.
+				_skipSelectionChangedCount = 2;
+
 				//clear for exclusive selection
 				FileIdentitiesListView.SelectedItems.Clear();
 				item.IsSelected = true;
@@ -751,4 +755,20 @@ public sealed partial class AllowNewAppsEventLogsDataGrid : Page, INotifyPropert
 		ListViewFlyoutMenuCopy_Click(sender, new RoutedEventArgs());
 		args.Handled = true;
 	}
+
+	// A counter to prevent SelectionChanged event from firing twice when right-clicking on an unselected row
+	private int _skipSelectionChangedCount;
+
+	private async void FileIdentitiesListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
+	{
+		// Check if we need to skip this event.
+		if (_skipSelectionChangedCount > 0)
+		{
+			_skipSelectionChangedCount--;
+			return;
+		}
+
+		await ListViewUIHelpers.SmoothScrollIntoViewWithIndexCenterVerticallyOnlyAsync(listViewBase: (ListView)sender, listView: (ListView)sender, index: ((ListView)sender).SelectedIndex, disableAnimation: false, scrollIfVisible: true, additionalHorizontalOffset: 0, additionalVerticalOffset: 0);
+	}
+
 }

--- a/AppControl Manager/Pages/AllowNewApps/AllowNewAppsLocalFilesDataGrid.xaml
+++ b/AppControl Manager/Pages/AllowNewApps/AllowNewAppsLocalFilesDataGrid.xaml
@@ -110,6 +110,7 @@
          ScrollViewer.HorizontalScrollBarVisibility="Visible"
          ShowsScrollingPlaceholders="True"
          ScrollViewer.VerticalScrollBarVisibility="Visible"
+         SelectionChanged="FileIdentitiesListView_SelectionChanged"
          ContainerContentChanging="ListView_ContainerContentChanging">
 
             <ListView.Header>

--- a/AppControl Manager/Pages/AllowNewApps/AllowNewAppsLocalFilesDataGrid.xaml.cs
+++ b/AppControl Manager/Pages/AllowNewApps/AllowNewAppsLocalFilesDataGrid.xaml.cs
@@ -673,6 +673,9 @@ public sealed partial class AllowNewAppsLocalFilesDataGrid : Page, INotifyProper
 			// If the item is not already selected, clear previous selections and select this one.
 			if (!item.IsSelected)
 			{
+				// Set the counter so that the SelectionChanged event handler will ignore the next 2 events.
+				_skipSelectionChangedCount = 2;
+
 				//clear for exclusive selection
 				FileIdentitiesListView.SelectedItems.Clear();
 				item.IsSelected = true;
@@ -692,5 +695,20 @@ public sealed partial class AllowNewAppsLocalFilesDataGrid : Page, INotifyProper
 	{
 		ListViewFlyoutMenuCopy_Click(sender, new RoutedEventArgs());
 		args.Handled = true;
+	}
+
+	// A counter to prevent SelectionChanged event from firing twice when right-clicking on an unselected row
+	private int _skipSelectionChangedCount;
+
+	private async void FileIdentitiesListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
+	{
+		// Check if we need to skip this event.
+		if (_skipSelectionChangedCount > 0)
+		{
+			_skipSelectionChangedCount--;
+			return;
+		}
+
+		await ListViewUIHelpers.SmoothScrollIntoViewWithIndexCenterVerticallyOnlyAsync(listViewBase: (ListView)sender, listView: (ListView)sender, index: ((ListView)sender).SelectedIndex, disableAnimation: false, scrollIfVisible: true, additionalHorizontalOffset: 0, additionalVerticalOffset: 0);
 	}
 }

--- a/AppControl Manager/Pages/CreateDenyPolicyFilesAndFoldersScanResults.xaml
+++ b/AppControl Manager/Pages/CreateDenyPolicyFilesAndFoldersScanResults.xaml
@@ -121,6 +121,7 @@
             ScrollViewer.HorizontalScrollBarVisibility="Visible"
             ShowsScrollingPlaceholders="True"
             ScrollViewer.VerticalScrollBarVisibility="Visible"
+            SelectionChanged="FileIdentitiesListView_SelectionChanged"
             ContainerContentChanging="ListView_ContainerContentChanging">
 
             <ListView.Header>

--- a/AppControl Manager/Pages/CreateDenyPolicyFilesAndFoldersScanResults.xaml.cs
+++ b/AppControl Manager/Pages/CreateDenyPolicyFilesAndFoldersScanResults.xaml.cs
@@ -624,6 +624,9 @@ public sealed partial class CreateDenyPolicyFilesAndFoldersScanResults : Page, I
 			// If the item is not already selected, clear previous selections and select this one.
 			if (!item.IsSelected)
 			{
+				// Set the counter so that the SelectionChanged event handler will ignore the next 2 events.
+				_skipSelectionChangedCount = 2;
+
 				//clear for exclusive selection
 				FileIdentitiesListView.SelectedItems.Clear();
 				item.IsSelected = true;
@@ -642,5 +645,20 @@ public sealed partial class CreateDenyPolicyFilesAndFoldersScanResults : Page, I
 	{
 		ListViewFlyoutMenuCopy_Click(sender, new RoutedEventArgs());
 		args.Handled = true;
+	}
+
+	// A counter to prevent SelectionChanged event from firing twice when right-clicking on an unselected row
+	private int _skipSelectionChangedCount;
+
+	private async void FileIdentitiesListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
+	{
+		// Check if we need to skip this event.
+		if (_skipSelectionChangedCount > 0)
+		{
+			_skipSelectionChangedCount--;
+			return;
+		}
+
+		await ListViewUIHelpers.SmoothScrollIntoViewWithIndexCenterVerticallyOnlyAsync(listViewBase: (ListView)sender, listView: (ListView)sender, index: ((ListView)sender).SelectedIndex, disableAnimation: false, scrollIfVisible: true, additionalHorizontalOffset: 0, additionalVerticalOffset: 0);
 	}
 }

--- a/AppControl Manager/Pages/CreateSupplementalPolicyFilesAndFoldersScanResults.xaml
+++ b/AppControl Manager/Pages/CreateSupplementalPolicyFilesAndFoldersScanResults.xaml
@@ -122,6 +122,7 @@
            ScrollViewer.HorizontalScrollBarVisibility="Visible"
            ShowsScrollingPlaceholders="True"
            ScrollViewer.VerticalScrollBarVisibility="Visible"
+           SelectionChanged="FileIdentitiesListView_SelectionChanged"
            ContainerContentChanging="ListView_ContainerContentChanging">
 
             <ListView.Header>

--- a/AppControl Manager/Pages/CreateSupplementalPolicyFilesAndFoldersScanResults.xaml.cs
+++ b/AppControl Manager/Pages/CreateSupplementalPolicyFilesAndFoldersScanResults.xaml.cs
@@ -618,9 +618,12 @@ public sealed partial class CreateSupplementalPolicyFilesAndFoldersScanResults :
 	{
 		if (sender is ListViewItem item)
 		{
-			// If the item is not already selected, clear previous selections and select this one.
+			// If the item is not already selected
 			if (!item.IsSelected)
 			{
+				// Set the counter so that the SelectionChanged event handler will ignore the next 2 events.
+				_skipSelectionChangedCount = 2;
+
 				//clear for exclusive selection
 				FileIdentitiesListView.SelectedItems.Clear();
 				item.IsSelected = true;
@@ -640,5 +643,20 @@ public sealed partial class CreateSupplementalPolicyFilesAndFoldersScanResults :
 	{
 		ListViewFlyoutMenuCopy_Click(sender, new RoutedEventArgs());
 		args.Handled = true;
+	}
+
+	// A counter to prevent SelectionChanged event from firing twice when right-clicking on an unselected row
+	private int _skipSelectionChangedCount;
+
+	private async void FileIdentitiesListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
+	{
+		// Check if we need to skip this event.
+		if (_skipSelectionChangedCount > 0)
+		{
+			_skipSelectionChangedCount--;
+			return;
+		}
+
+		await ListViewUIHelpers.SmoothScrollIntoViewWithIndexCenterVerticallyOnlyAsync(listViewBase: (ListView)sender, listView: (ListView)sender, index: ((ListView)sender).SelectedIndex, disableAnimation: false, scrollIfVisible: true, additionalHorizontalOffset: 0, additionalVerticalOffset: 0);
 	}
 }

--- a/AppControl Manager/Pages/EventLogsPolicyCreation.xaml
+++ b/AppControl Manager/Pages/EventLogsPolicyCreation.xaml
@@ -333,6 +333,7 @@
             ScrollViewer.HorizontalScrollBarVisibility="Visible"
             ShowsScrollingPlaceholders="True"
             ScrollViewer.VerticalScrollBarVisibility="Visible"
+            SelectionChanged="FileIdentitiesListView_SelectionChanged"                  
             ContainerContentChanging="ListView_ContainerContentChanging">
 
             <ListView.Header>

--- a/AppControl Manager/Pages/EventLogsPolicyCreation.xaml.cs
+++ b/AppControl Manager/Pages/EventLogsPolicyCreation.xaml.cs
@@ -1222,6 +1222,9 @@ public sealed partial class EventLogsPolicyCreation : Page, INotifyPropertyChang
 			// If the item is not already selected, clear previous selections and select this one.
 			if (!item.IsSelected)
 			{
+				// Set the counter so that the SelectionChanged event handler will ignore the next 2 events.
+				_skipSelectionChangedCount = 2;
+
 				//clear for exclusive selection
 				FileIdentitiesListView.SelectedItems.Clear();
 				item.IsSelected = true;
@@ -1243,4 +1246,18 @@ public sealed partial class EventLogsPolicyCreation : Page, INotifyPropertyChang
 		args.Handled = true;
 	}
 
+	// A counter to prevent SelectionChanged event from firing twice when right-clicking on an unselected row
+	private int _skipSelectionChangedCount;
+
+	private async void FileIdentitiesListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
+	{
+		// Check if we need to skip this event.
+		if (_skipSelectionChangedCount > 0)
+		{
+			_skipSelectionChangedCount--;
+			return;
+		}
+
+		await ListViewUIHelpers.SmoothScrollIntoViewWithIndexCenterVerticallyOnlyAsync(listViewBase: (ListView)sender, listView: (ListView)sender, index: ((ListView)sender).SelectedIndex, disableAnimation: false, scrollIfVisible: true, additionalHorizontalOffset: 0, additionalVerticalOffset: 0);
+	}
 }

--- a/AppControl Manager/Pages/MDEAHPolicyCreation.xaml
+++ b/AppControl Manager/Pages/MDEAHPolicyCreation.xaml
@@ -408,6 +408,7 @@
              ScrollViewer.HorizontalScrollMode="Enabled"
              ScrollViewer.IsHorizontalRailEnabled="True"
              ScrollViewer.HorizontalScrollBarVisibility="Visible"
+             SelectionChanged="FileIdentitiesListView_SelectionChanged"
              ShowsScrollingPlaceholders="True"
              ScrollViewer.VerticalScrollBarVisibility="Visible"
              ContainerContentChanging="ListView_ContainerContentChanging">

--- a/AppControl Manager/Pages/MDEAHPolicyCreation.xaml.cs
+++ b/AppControl Manager/Pages/MDEAHPolicyCreation.xaml.cs
@@ -1468,6 +1468,9 @@ DeviceEvents
 			// If the item is not already selected, clear previous selections and select this one.
 			if (!item.IsSelected)
 			{
+				// Set the counter so that the SelectionChanged event handler will ignore the next 2 events.
+				_skipSelectionChangedCount = 2;
+
 				//clear for exclusive selection
 				FileIdentitiesListView.SelectedItems.Clear();
 				item.IsSelected = true;
@@ -1487,6 +1490,21 @@ DeviceEvents
 	{
 		ListViewFlyoutMenuCopy_Click(sender, new RoutedEventArgs());
 		args.Handled = true;
+	}
+
+	// A counter to prevent SelectionChanged event from firing twice when right-clicking on an unselected row
+	private int _skipSelectionChangedCount;
+
+	private async void FileIdentitiesListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
+	{
+		// Check if we need to skip this event.
+		if (_skipSelectionChangedCount > 0)
+		{
+			_skipSelectionChangedCount--;
+			return;
+		}
+
+		await ListViewUIHelpers.SmoothScrollIntoViewWithIndexCenterVerticallyOnlyAsync(listViewBase: (ListView)sender, listView: (ListView)sender, index: ((ListView)sender).SelectedIndex, disableAnimation: false, scrollIfVisible: true, additionalHorizontalOffset: 0, additionalVerticalOffset: 0);
 	}
 }
 

--- a/AppControl Manager/Pages/Settings.xaml
+++ b/AppControl Manager/Pages/Settings.xaml
@@ -152,6 +152,16 @@
 
                 </controls:SettingsExpander>
 
+                <!-- Behavior section -->
+                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" x:Uid="Behavior" />
+                <controls:SettingsExpander IsExpanded="True" x:Uid="BehaviorSettingSettingsExpander" HeaderIcon="{ui:FontIcon Glyph=&#xE9E9;}">
+                    <controls:SettingsExpander.Items>
+                        <controls:SettingsCard x:Uid="ListViewsCenterVerticallyUponSelectionSettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xE8E3;}" IsClickEnabled="True" IsActionIconVisible="False" Click="ListViewsCenterVerticallyUponSelectionSettingsCard_Click">
+                            <ToggleSwitch x:Name="ListViewsCenterVerticallyUponSelectionToggleSwitch" />
+                        </controls:SettingsCard>
+                    </controls:SettingsExpander.Items>
+                </controls:SettingsExpander>
+
                 <!-- Sound section -->
                 <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" x:Uid="Sound" />
                 <controls:SettingsCard x:Uid="AppSoundSettingSettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xEC4F;}" IsClickEnabled="True" IsActionIconVisible="False" Click="SoundToggleSwitchSettingsCard_Click">

--- a/AppControl Manager/Pages/Settings.xaml.cs
+++ b/AppControl Manager/Pages/Settings.xaml.cs
@@ -39,6 +39,8 @@ public sealed partial class Settings : Page
 
 		SoundToggleSwitch.IsOn = GetSetting<bool>(SettingKeys.SoundSetting);
 
+		ListViewsCenterVerticallyUponSelectionToggleSwitch.IsOn = GetSetting<bool>(SettingKeys.ListViewsVerticalCentering);
+
 		BackgroundComboBox.SelectedIndex = (GetSetting<string>(SettingKeys.BackDropBackground)) switch
 		{
 			"MicaAlt" => 0,
@@ -78,6 +80,7 @@ public sealed partial class Settings : Page
 		NavigationMenuLocation.SelectionChanged += NavigationViewLocationComboBox_SelectionChanged;
 		SoundToggleSwitch.Toggled += SoundToggleSwitch_Toggled;
 		IconsStyleComboBox.SelectionChanged += IconsStyleComboBox_SelectionChanged;
+		ListViewsCenterVerticallyUponSelectionToggleSwitch.Toggled += ListViewsCenterVerticallyUponSelectionToggleSwitch_Toggled;
 	}
 
 
@@ -198,7 +201,7 @@ public sealed partial class Settings : Page
 		// Raise the event to notify the app of the sound setting change
 		SoundManager.OnSoundSettingChanged(isSoundOn);
 
-		// Save the sound setting to the local app settings
+		// Save the setting to the local app settings
 		SaveSetting(SettingKeys.SoundSetting, isSoundOn);
 	}
 
@@ -405,4 +408,24 @@ public sealed partial class Settings : Page
 		NavigationViewBackgroundToggle.IsOn = !NavigationViewBackgroundToggle.IsOn;
 		NavigationViewBackground_Toggled(NavigationViewBackgroundToggle, new RoutedEventArgs());
 	}
+
+
+	private void ListViewsCenterVerticallyUponSelectionSettingsCard_Click(object sender, RoutedEventArgs e)
+	{
+		ListViewsCenterVerticallyUponSelectionToggleSwitch.IsOn = !ListViewsCenterVerticallyUponSelectionToggleSwitch.IsOn;
+	}
+
+
+	private void ListViewsCenterVerticallyUponSelectionToggleSwitch_Toggled(object sender, RoutedEventArgs e)
+	{
+		// Get the ToggleSwitch that triggered the event
+		ToggleSwitch toggleSwitch = (ToggleSwitch)sender;
+
+		// Get the state of the toggle switch (on or off)
+		bool IsOn = toggleSwitch.IsOn;
+
+		// Save the setting to the local app settings
+		SaveSetting(SettingKeys.ListViewsVerticalCentering, IsOn);
+	}
+
 }

--- a/AppControl Manager/Pages/Simulation.xaml
+++ b/AppControl Manager/Pages/Simulation.xaml
@@ -270,6 +270,7 @@
                 ScrollViewer.HorizontalScrollBarVisibility="Visible"
                 ShowsScrollingPlaceholders="True"
                 ScrollViewer.VerticalScrollBarVisibility="Visible"
+                SelectionChanged="SimOutputListView_SelectionChanged"
                 ContainerContentChanging="ListView_ContainerContentChanging">
 
             <ListView.Header>

--- a/AppControl Manager/Pages/Simulation.xaml.cs
+++ b/AppControl Manager/Pages/Simulation.xaml.cs
@@ -689,6 +689,9 @@ public sealed partial class Simulation : Page, INotifyPropertyChanged
 			// If the item is not already selected, clear previous selections and select this one.
 			if (!item.IsSelected)
 			{
+				// Set the counter so that the SelectionChanged event handler will ignore the next 2 events.
+				_skipSelectionChangedCount = 2;
+
 				//clear for exclusive selection
 				SimOutputListView.SelectedItems.Clear();
 				item.IsSelected = true;
@@ -708,5 +711,20 @@ public sealed partial class Simulation : Page, INotifyPropertyChanged
 	{
 		ListViewFlyoutMenuCopy_Click(sender, new RoutedEventArgs());
 		args.Handled = true;
+	}
+
+	// A counter to prevent SelectionChanged event from firing twice when right-clicking on an unselected row
+	private int _skipSelectionChangedCount;
+
+	private async void SimOutputListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
+	{
+		// Check if we need to skip this event.
+		if (_skipSelectionChangedCount > 0)
+		{
+			_skipSelectionChangedCount--;
+			return;
+		}
+
+		await ListViewUIHelpers.SmoothScrollIntoViewWithIndexCenterVerticallyOnlyAsync(listViewBase: (ListView)sender, listView: (ListView)sender, index: ((ListView)sender).SelectedIndex, disableAnimation: false, scrollIfVisible: true, additionalHorizontalOffset: 0, additionalVerticalOffset: 0);
 	}
 }

--- a/AppControl Manager/Pages/StrictKernelPolicyScanResults.xaml
+++ b/AppControl Manager/Pages/StrictKernelPolicyScanResults.xaml
@@ -121,6 +121,7 @@
             ScrollViewer.HorizontalScrollBarVisibility="Visible"
             ShowsScrollingPlaceholders="True"
             ScrollViewer.VerticalScrollBarVisibility="Visible"
+            SelectionChanged="FileIdentitiesListView_SelectionChanged"
             ContainerContentChanging="ListView_ContainerContentChanging">
 
             <ListView.Header>

--- a/AppControl Manager/Pages/StrictKernelPolicyScanResults.xaml.cs
+++ b/AppControl Manager/Pages/StrictKernelPolicyScanResults.xaml.cs
@@ -643,6 +643,9 @@ public sealed partial class StrictKernelPolicyScanResults : Page, INotifyPropert
 			// If the item is not already selected, clear previous selections and select this one.
 			if (!item.IsSelected)
 			{
+				// Set the counter so that the SelectionChanged event handler will ignore the next 2 events.
+				_skipSelectionChangedCount = 2;
+
 				//clear for exclusive selection
 				FileIdentitiesListView.SelectedItems.Clear();
 				item.IsSelected = true;
@@ -664,4 +667,18 @@ public sealed partial class StrictKernelPolicyScanResults : Page, INotifyPropert
 		args.Handled = true;
 	}
 
+	// A counter to prevent SelectionChanged event from firing twice when right-clicking on an unselected row
+	private int _skipSelectionChangedCount;
+
+	private async void FileIdentitiesListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
+	{
+		// Check if we need to skip this event.
+		if (_skipSelectionChangedCount > 0)
+		{
+			_skipSelectionChangedCount--;
+			return;
+		}
+
+		await ListViewUIHelpers.SmoothScrollIntoViewWithIndexCenterVerticallyOnlyAsync(listViewBase: (ListView)sender, listView: (ListView)sender, index: ((ListView)sender).SelectedIndex, disableAnimation: false, scrollIfVisible: true, additionalHorizontalOffset: 0, additionalVerticalOffset: 0);
+	}
 }

--- a/AppControl Manager/Pages/ViewFileCertificates.xaml
+++ b/AppControl Manager/Pages/ViewFileCertificates.xaml
@@ -102,6 +102,7 @@
           ScrollViewer.HorizontalScrollBarVisibility="Visible"
           ShowsScrollingPlaceholders="True"
           ScrollViewer.VerticalScrollBarVisibility="Visible"
+          SelectionChanged="FileCertificatesListView_SelectionChanged"
           ContainerContentChanging="ListView_ContainerContentChanging">
 
             <ListView.Header>

--- a/AppControl Manager/Pages/ViewFileCertificates.xaml.cs
+++ b/AppControl Manager/Pages/ViewFileCertificates.xaml.cs
@@ -805,6 +805,9 @@ public sealed partial class ViewFileCertificates : Page, INotifyPropertyChanged
 			// If the item is not already selected, clear previous selections and select this one.
 			if (!item.IsSelected)
 			{
+				// Set the counter so that the SelectionChanged event handler will ignore the next 2 events.
+				_skipSelectionChangedCount = 2;
+
 				item.IsSelected = true;
 			}
 		}
@@ -821,5 +824,20 @@ public sealed partial class ViewFileCertificates : Page, INotifyPropertyChanged
 	{
 		ListViewFlyoutMenuCopy_Click(sender, new RoutedEventArgs());
 		args.Handled = true;
+	}
+
+	// A counter to prevent SelectionChanged event from firing twice when right-clicking on an unselected row
+	private int _skipSelectionChangedCount;
+
+	private async void FileCertificatesListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
+	{
+		// Check if we need to skip this event.
+		if (_skipSelectionChangedCount > 0)
+		{
+			_skipSelectionChangedCount--;
+			return;
+		}
+
+		await ListViewUIHelpers.SmoothScrollIntoViewWithIndexCenterVerticallyOnlyAsync(listViewBase: (ListView)sender, listView: (ListView)sender, index: ((ListView)sender).SelectedIndex, disableAnimation: false, scrollIfVisible: true, additionalHorizontalOffset: 0, additionalVerticalOffset: 0);
 	}
 }

--- a/AppControl Manager/Strings/en-US/Resources.resw
+++ b/AppControl Manager/Strings/en-US/Resources.resw
@@ -1432,4 +1432,22 @@ NOTE: This option is always enforced if any App Control UMCI policy enables it. 
   <data name="NoMSRecommendedBlockRules.ToolTipService.ToolTip" xml:space="preserve">
     <value>Using this option means the Microsoft Recommended (User-Mode) Block Rules will not be created/deployed along with the base policy. (Not Recommended)</value>
   </data>
+  <data name="BehaviorSettingSettingsExpander.Header" xml:space="preserve">
+    <value>Change the behavior of the AppControl Manager and various elements inside of it</value>
+  </data>
+  <data name="Behavior.Text" xml:space="preserve">
+    <value>Behavior</value>
+  </data>
+  <data name="BehaviorSettingSettingsExpander.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Change the behavior of the AppControl Manager and various elements inside of it</value>
+  </data>
+  <data name="ListViewsCenterVerticallyUponSelectionSettingsCard.Description" xml:space="preserve">
+    <value>Whenever you select an item in a List View, center that item vertically on the screen.</value>
+  </data>
+  <data name="ListViewsCenterVerticallyUponSelectionSettingsCard.Header" xml:space="preserve">
+    <value>List Views Center Vertically Upon Selection</value>
+  </data>
+  <data name="ListViewsCenterVerticallyUponSelectionSettingsCard.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Whenever you select an item in a List View, center that item vertically on the screen.</value>
+  </data>
 </root>


### PR DESCRIPTION
This is a new option in the app settings that is off by default. It is an accessibility setting and also makes it easier to interact with the List Views across the app. Works with touch, mouse and keyboard.

It is added under a new settings category called "Behavior". More customizations will be added under this category in the future. This option, just like others, is remembered between app sessons so you only need to configure it once.

<img width="1280" alt="image" src="https://github.com/user-attachments/assets/bd0acdcd-39c2-441d-a192-902be1667fa3" />
