### PR TITLE
Replace Edge whitepaper security link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1045,7 +1045,7 @@ NistP384
 
     - Windows Media Player (legacy): isn't needed anymore, [Windows 11 has a modern media player app](https://blogs.windows.com/windows-insider/2021/11/16/new-media-player-for-windows-11-begins-rolling-out-to-windows-insiders/).
 
-    - [Microsoft Defender Application Guard](https://learn.microsoft.com/en-us/windows/security/application-security/application-isolation/microsoft-defender-application-guard/md-app-guard-overview), it's [deprecated](https://learn.microsoft.com/en-us/windows/whats-new/deprecated-features#deprecated-features). Learn more about [Microsoft Edge Security Features here](https://edgestatic.azureedge.net/shared/cms/pdfs/Microsoft_Edge_Security_Whitepaper_v2.pdf).
+    - [Microsoft Defender Application Guard](https://learn.microsoft.com/en-us/windows/security/application-security/application-isolation/microsoft-defender-application-guard/md-app-guard-overview), it's [deprecated](https://learn.microsoft.com/en-us/windows/whats-new/deprecated-features#deprecated-features). Learn more about [Microsoft Edge Security Features here](https://learn.microsoft.com/en-us/deployedge/ms-edge-security-for-business).
 
 <br>
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

By submitting this PR you agree that you've read and accepted the [Contributing document's terms](https://github.com/HotCakeX/Harden-Windows-Security/blob/main/.github/CONTRIBUTING.md).

* [X] Please verify that your code is up-to-date with the `main` branch.
* [X] Define the current behavior and the new behavior we should expect with the changes in this PR.
* [X] Link any issues that this PR will fix.
* [X] Please Allow edits by maintainers
* [X] If your PR involves C# code, please ensure it complies with the code styles defined in the project files in the repository.
-->
Hello! I noticed that the Edge security whitepaper PDF is no longer available. I found it on LinkedIn, and it basically seems to be a PDF of https://learn.microsoft.com/en-us/deployedge/ms-edge-security-for-business so I replaced the link with a link to that. That is all. 

Thanks for putting in the effort to make this guide!