### PR TITLE
Added new helpful UI elements to the AppControl Manager

### DIFF
--- a/AppControl Manager/App.xaml.cs
+++ b/AppControl Manager/App.xaml.cs
@@ -119,6 +119,7 @@ public partial class App : Application
 			_ = services.AddSingleton<ViewModels.MDEAHPolicyCreationVM>();
 			_ = services.AddSingleton<ViewModels.ViewFileCertificatesVM>();
 			_ = services.AddSingleton<ViewModels.MainWindowVM>();
+			_ = services.AddSingleton<ViewModels.CreatePolicyVM>();
 		})
 		.Build();
 

--- a/AppControl Manager/AppControlManagerAPIDocumentation.xml
+++ b/AppControl Manager/AppControlManagerAPIDocumentation.xml
@@ -2472,6 +2472,7 @@
             And creates a valid Code Integrity XML policy file from it.
             </summary>
             <param name="StagingArea">The directory where the XML file will be saved to.</param>
+            <returns>the path to the Microsoft recommended driver block rules base policy path</returns>
         </member>
         <member name="M:AppControlManager.Main.BasePolicyCreator.BuildAllowMSFT(System.String,System.Boolean,System.Nullable{System.UInt64},System.Boolean,System.Boolean,System.Boolean,System.Boolean,System.Boolean,System.String,System.Boolean)">
             <summary>
@@ -2487,6 +2488,7 @@
             <param name="deployAppControlSupplementalPolicy">Indicates if a supplemental policy should be deployed alongside the main policy.</param>
             <param name="PolicyIDToUse">Allows the use of a specific policy ID if provided, overriding the generated one.</param>
             <param name="DeployMicrosoftRecommendedBlockRules">Specifies whether to deploy recommended block rules if no policy ID is provided.</param>
+            <returns>Returns the path to the created policy</returns>
         </member>
         <member name="M:AppControlManager.Main.BasePolicyCreator.BuildDefaultWindows(System.String,System.Boolean,System.Nullable{System.UInt64},System.Boolean,System.Boolean,System.Boolean,System.Boolean,System.Boolean,System.String,System.Boolean)">
             <summary>
@@ -2503,6 +2505,7 @@
             <param name="deployAppControlSupplementalPolicy">Specifies if a supplemental policy should be deployed alongside the main policy.</param>
             <param name="PolicyIDToUse">Allows the use of a specific policy ID instead of generating a new one.</param>
             <param name="DeployMicrosoftRecommendedBlockRules">Indicates whether to retrieve and deploy Microsoft recommended block rules.</param>
+            <returns>Returns the path to the created Default Windows base policy</returns>
         </member>
         <member name="M:AppControlManager.Main.BasePolicyCreator.GetBlockRules(System.String,System.Boolean)">
             <summary>
@@ -2528,6 +2531,7 @@
             <param name="deployAppControlSupplementalPolicy">Indicates if a supplemental policy should be deployed alongside the main policy.</param>
             <param name="PolicyIDToUse">Allows the use of a specific policy ID if provided, overriding the generated one.</param>
             <param name="DeployMicrosoftRecommendedBlockRules">Specifies whether to retrieve and deploy Microsoft recommended block rules.</param>
+            <returns>Returns the signed and reputable base policy file path</returns>
         </member>
         <member name="M:AppControlManager.Main.BasePolicyCreator.BuildStrictKernelMode(System.String,System.Boolean,System.Boolean,System.Boolean,System.String)">
             <summary>
@@ -2539,6 +2543,7 @@
             <param name="NoFlightRoots">Determines the filename variant used for the policy based on flight root settings.</param>
             <param name="deploy">Indicates whether the policy should be deployed after creation.</param>
             <param name="PolicyIDToUse">Specifies an optional policy ID to associate with the created policy.</param>
+            <returns>the path to the Strict Kernel-mode base policy path</returns>
         </member>
         <member name="M:AppControlManager.Main.BasePolicyCreator.MyRegex">
             <remarks>
@@ -4205,34 +4210,26 @@
             <param name="sender"></param>
             <param name="e"></param>
         </member>
-        <member name="M:AppControlManager.Pages.AllowNewAppsStart.GoToStep2Button_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
+        <member name="M:AppControlManager.Pages.AllowNewAppsStart.GoToStep2Button_Click">
             <summary>
             Step 1 validation
             </summary>
-            <param name="sender"></param>
-            <param name="e"></param>
             <exception cref="T:System.InvalidOperationException"></exception>
         </member>
-        <member name="M:AppControlManager.Pages.AllowNewAppsStart.GoToStep3Button_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
+        <member name="M:AppControlManager.Pages.AllowNewAppsStart.GoToStep3Button_Click">
             <summary>
             Step 2 validation
             </summary>
-            <param name="sender"></param>
-            <param name="e"></param>
         </member>
-        <member name="M:AppControlManager.Pages.AllowNewAppsStart.ResetStepsButton_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
+        <member name="M:AppControlManager.Pages.AllowNewAppsStart.ResetStepsButton_Click">
             <summary>
             Steps Reset
             </summary>
-            <param name="sender"></param>
-            <param name="e"></param>
         </member>
-        <member name="M:AppControlManager.Pages.AllowNewAppsStart.ClearSelectedDirectoriesButton_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
+        <member name="M:AppControlManager.Pages.AllowNewAppsStart.ClearSelectedDirectoriesButton_Click">
             <summary>
             Clears the text box and the list of selected directories when the button is clicked.
             </summary>
-            <param name="sender">Represents the source of the event that triggered the button click.</param>
-            <param name="e">Contains event data related to the button click action.</param>
         </member>
         <member name="M:AppControlManager.Pages.AllowNewAppsStart.ScanLevelComboBox_SelectionChanged(System.Object,Microsoft.UI.Xaml.Controls.SelectionChangedEventArgs)">
             <summary>
@@ -4241,28 +4238,22 @@
             <param name="sender">Represents the source of the event, allowing access to the ComboBox that triggered the selection change.</param>
             <param name="e">Contains event data related to the selection change, providing information about the new selection.</param>
         </member>
-        <member name="M:AppControlManager.Pages.AllowNewAppsStart.BrowseForFoldersButton_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
+        <member name="M:AppControlManager.Pages.AllowNewAppsStart.BrowseForFoldersButton_Click">
             <summary>
             Handles the click event for a button to browse and select multiple folders. Selected folders are added to a
             collection and displayed in the UI.
             </summary>
-            <param name="sender">Represents the source of the click event, typically the button that was clicked.</param>
-            <param name="e">Contains event data related to the click event, providing additional information about the action.</param>
         </member>
-        <member name="M:AppControlManager.Pages.AllowNewAppsStart.BrowseForXMLPolicyButton_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
+        <member name="M:AppControlManager.Pages.AllowNewAppsStart.BrowseForXMLPolicyButton_Click">
             <summary>
             Handles the click event for a button to browse and select an XML policy file.
             </summary>
-            <param name="sender">Represents the source of the click event.</param>
-            <param name="e">Contains event data related to the click event.</param>
             <exception cref="T:System.InvalidOperationException">Thrown when the selected file path is not a valid XML file.</exception>
         </member>
-        <member name="M:AppControlManager.Pages.AllowNewAppsStart.CreatePolicyButton_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
+        <member name="M:AppControlManager.Pages.AllowNewAppsStart.CreatePolicyButton_Click">
             <summary>
             Event handler for the Create Policy button
             </summary>
-            <param name="sender"></param>
-            <param name="e"></param>
         </member>
         <member name="M:AppControlManager.Pages.AllowNewAppsStart.LogSizeNumberBox_ValueChanged(Microsoft.UI.Xaml.Controls.NumberBox,Microsoft.UI.Xaml.Controls.NumberBoxValueChangedEventArgs)">
             <summary>
@@ -4307,6 +4298,16 @@
             </summary>
             <param name="sender">Represents the source of the event, typically the button being held.</param>
             <param name="e">Contains data related to the holding gesture, including its current state.</param>
+        </member>
+        <member name="F:AppControlManager.Pages.AllowNewAppsStart.finalSupplementalPolicyPath">
+            <summary>
+            Path of the Supplemental policy that is created
+            </summary>
+        </member>
+        <member name="M:AppControlManager.Pages.AllowNewAppsStart.OpenInPolicyEditor">
+            <summary>
+            Event handler to open the supplemental policy in the Policy Editor
+            </summary>
         </member>
         <member name="M:AppControlManager.Pages.AllowNewAppsStart.InitializeComponent">
             <summary>
@@ -4733,26 +4734,50 @@
             Initializes the CreatePolicy component and sets various log size inputs to disabled. Maintains navigation state.
             </summary>
         </member>
-        <member name="M:AppControlManager.Pages.CreatePolicy.AllowMicrosoftCreate_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
+        <member name="M:AppControlManager.Pages.CreatePolicy.AllowMicrosoftCreate_Click">
             <summary>
             Event handler for creating/deploying AllowMicrosoft policy
             </summary>
-            <param name="sender"></param>
-            <param name="e"></param>
         </member>
-        <member name="M:AppControlManager.Pages.CreatePolicy.DefaultWindowsCreate_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
+        <member name="M:AppControlManager.Pages.CreatePolicy.AllowMicrosoftLogSizeInputEnabled_Toggled">
+            <summary>
+            Event handler for the ToggleSwitch to enable/disable the log size input
+            </summary>
+        </member>
+        <member name="M:AppControlManager.Pages.CreatePolicy.OpenInPolicyEditor_AllowMicrosoft">
+            <summary>
+            Event handler to open the created Allow Microsoft policy in the Policy Editor
+            </summary>
+        </member>
+        <member name="M:AppControlManager.Pages.CreatePolicy.DefaultWindowsCreate_Click">
             <summary>
             Event handler for creating/deploying DefaultWindows policy
             </summary>
-            <param name="sender"></param>
-            <param name="e"></param>
         </member>
-        <member name="M:AppControlManager.Pages.CreatePolicy.SignedAndReputableCreate_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
+        <member name="M:AppControlManager.Pages.CreatePolicy.DefaultWindowsLogSizeInputEnabled_Toggled">
+            <summary>
+            Event handler for the ToggleSwitch to enable/disable the log size input
+            </summary>
+        </member>
+        <member name="M:AppControlManager.Pages.CreatePolicy.OpenInPolicyEditor_DefaultWindows">
+            <summary>
+            Event handler to open the created Default Windows policy in the Policy Editor
+            </summary>
+        </member>
+        <member name="M:AppControlManager.Pages.CreatePolicy.SignedAndReputableCreate_Click">
             <summary>
             Event handler for creating/deploying SignedAndReputable policy
             </summary>
-            <param name="sender"></param>
-            <param name="e"></param>
+        </member>
+        <member name="M:AppControlManager.Pages.CreatePolicy.SignedAndReputableLogSizeInputEnabled_Toggled">
+            <summary>
+            Event handler for the ToggleSwitch to enable/disable the log size input
+            </summary>
+        </member>
+        <member name="M:AppControlManager.Pages.CreatePolicy.OpenInPolicyEditor_SignedAndReputable">
+            <summary>
+            Event handler to open the created Signed and Reputable policy in the Policy Editor
+            </summary>
         </member>
         <member name="M:AppControlManager.Pages.CreatePolicy.AddDriverBlockRulesInfo">
             <summary>
@@ -4760,33 +4785,35 @@
             </summary>
             <returns></returns>
         </member>
-        <member name="M:AppControlManager.Pages.CreatePolicy.RecommendedDriverBlockRulesCreate_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
+        <member name="M:AppControlManager.Pages.CreatePolicy.RecommendedDriverBlockRulesCreate_Click">
             <summary>
             Event handler for creating/deploying Microsoft recommended driver block rules policy
             </summary>
-            <param name="sender"></param>
-            <param name="e"></param>
         </member>
-        <member name="M:AppControlManager.Pages.CreatePolicy.RecommendedDriverBlockRulesScheduledAutoUpdate_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
+        <member name="M:AppControlManager.Pages.CreatePolicy.RecommendedDriverBlockRulesScheduledAutoUpdate_Click">
             <summary>
             Event handler for Auto Update button
             </summary>
-            <param name="sender"></param>
-            <param name="e"></param>
         </member>
-        <member name="M:AppControlManager.Pages.CreatePolicy.RecommendedUserModeBlockRulesCreate_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
+        <member name="M:AppControlManager.Pages.CreatePolicy.OpenInPolicyEditor_RecommendedDriverBlockRules">
+            <summary>
+            Event handler to open the created Microsoft Recommended driver block rules policy in the Policy Editor
+            </summary>
+        </member>
+        <member name="M:AppControlManager.Pages.CreatePolicy.RecommendedUserModeBlockRulesCreate_Click">
             <summary>
             Event handler for creating/deploying Microsoft recommended user-mode block rules policy
             </summary>
-            <param name="sender"></param>
-            <param name="e"></param>
         </member>
-        <member name="M:AppControlManager.Pages.CreatePolicy.StrictKernelModePolicyCreateButton_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
+        <member name="M:AppControlManager.Pages.CreatePolicy.StrictKernelModePolicyCreateButton_Click">
             <summary>
             Event handler to prepare the system for Strict Kernel-mode policy
             </summary>
-            <param name="sender"></param>
-            <param name="e"></param>
+        </member>
+        <member name="M:AppControlManager.Pages.CreatePolicy.OpenInPolicyEditor_StrictKernelModePolicy">
+            <summary>
+            Event handler to open the created Strict Kernel-mode policy in the Policy Editor
+            </summary>
         </member>
         <member name="M:AppControlManager.Pages.CreatePolicy.InitializeComponent">
             <summary>
@@ -5349,22 +5376,15 @@
             Event handler for the CalendarDatePicker date changed event
             </summary>
         </member>
-        <member name="M:AppControlManager.Pages.EventLogsPolicyCreation.SearchBox_TextChanged(System.Object,Microsoft.UI.Xaml.Controls.TextChangedEventArgs)">
-            <summary>
-            Event handler for the SearchBox text change
-            </summary>
-        </member>
         <member name="M:AppControlManager.Pages.EventLogsPolicyCreation.ApplyFilters">
             <summary>
             Applies the date and search filters to the data grid
             </summary>
         </member>
-        <member name="M:AppControlManager.Pages.EventLogsPolicyCreation.ScanLogs_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
+        <member name="M:AppControlManager.Pages.EventLogsPolicyCreation.ScanLogs_Click">
             <summary>
             Event handler for the ScanLogs click
             </summary>
-            <param name="sender"></param>
-            <param name="e"></param>
         </member>
         <member name="M:AppControlManager.Pages.EventLogsPolicyCreation.SelectCodeIntegrityEVTXFiles_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
             <summary>
@@ -5373,33 +5393,30 @@
             <param name="sender"></param>
             <param name="e"></param>
         </member>
-        <member name="M:AppControlManager.Pages.EventLogsPolicyCreation.SelectAppLockerEVTXFiles_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
+        <member name="M:AppControlManager.Pages.EventLogsPolicyCreation.SelectAppLockerEVTXFiles_Click">
             <summary>
             Event handler for the select AppLocker EVTX file path button
             </summary>
-            <param name="sender"></param>
-            <param name="e"></param>
         </member>
-        <member name="M:AppControlManager.Pages.EventLogsPolicyCreation.ClearDataButton_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
+        <member name="M:AppControlManager.Pages.EventLogsPolicyCreation.SelectedAppLockerEVTXFilesFlyout_Clear_Click">
+            <summary>
+            Clears the selected AppLocker EVTX file paths
+            </summary>
+        </member>
+        <member name="M:AppControlManager.Pages.EventLogsPolicyCreation.ClearDataButton_Click">
             <summary>
             Event handler for the Clear Data button
             </summary>
-            <param name="sender"></param>
-            <param name="e"></param>
         </member>
-        <member name="M:AppControlManager.Pages.EventLogsPolicyCreation.SelectAll_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
+        <member name="M:AppControlManager.Pages.EventLogsPolicyCreation.SelectAll_Click">
             <summary>
             Selects all of the displayed rows on the ListView
             </summary>
-            <param name="sender"></param>
-            <param name="e"></param>
         </member>
-        <member name="M:AppControlManager.Pages.EventLogsPolicyCreation.DeSelectAll_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
+        <member name="M:AppControlManager.Pages.EventLogsPolicyCreation.DeSelectAll_Click">
             <summary>
             De-selects all of the displayed rows on the ListView
             </summary>
-            <param name="sender"></param>
-            <param name="e"></param>
         </member>
         <member name="M:AppControlManager.Pages.EventLogsPolicyCreation.ListViewFlyoutMenuDelete_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
             <summary>
@@ -5413,34 +5430,26 @@
             Updates the total logs count displayed on the UI
             </summary>
         </member>
-        <member name="M:AppControlManager.Pages.EventLogsPolicyCreation.AddToPolicyButton_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
+        <member name="M:AppControlManager.Pages.EventLogsPolicyCreation.AddToPolicyButton_Click">
             <summary>
             The button that browses for XML file the logs will be added to
             </summary>
-            <param name="sender"></param>
-            <param name="e"></param>
         </member>
-        <member name="M:AppControlManager.Pages.EventLogsPolicyCreation.BasePolicyFileButton_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
+        <member name="M:AppControlManager.Pages.EventLogsPolicyCreation.BasePolicyFileButton_Click">
             <summary>
             The button to browse for the XML file the supplemental policy that will be created will belong to
             </summary>
-            <param name="sender"></param>
-            <param name="e"></param>
         </member>
-        <member name="M:AppControlManager.Pages.EventLogsPolicyCreation.BaseGUIDSubmitButton_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
+        <member name="M:AppControlManager.Pages.EventLogsPolicyCreation.BaseGUIDSubmitButton_Click">
             <summary>
             The button to submit a base policy GUID that will be used to set the base policy ID in the Supplemental policy file that will be created.
             </summary>
-            <param name="sender"></param>
-            <param name="e"></param>
             <exception cref="T:System.ArgumentException"></exception>
         </member>
-        <member name="M:AppControlManager.Pages.EventLogsPolicyCreation.CreatePolicyButton_Click(Microsoft.UI.Xaml.Controls.SplitButton,Microsoft.UI.Xaml.Controls.SplitButtonClickEventArgs)">
+        <member name="M:AppControlManager.Pages.EventLogsPolicyCreation.CreatePolicyButton_Click">
             <summary>
             When the main button responsible for creating policy is pressed
             </summary>
-            <param name="sender"></param>
-            <param name="args"></param>
         </member>
         <member name="M:AppControlManager.Pages.EventLogsPolicyCreation.ScanLevelComboBox_SelectionChanged(System.Object,Microsoft.UI.Xaml.Controls.SelectionChangedEventArgs)">
             <summary>
@@ -5463,6 +5472,16 @@
             </summary>
             <param name="sender"></param>
             <param name="args"></param>
+        </member>
+        <member name="F:AppControlManager.Pages.EventLogsPolicyCreation.finalSupplementalPolicyPath">
+            <summary>
+            Path of the Supplemental policy that is created or the policy that user selected to add the logs to.
+            </summary>
+        </member>
+        <member name="M:AppControlManager.Pages.EventLogsPolicyCreation.OpenInPolicyEditor">
+            <summary>
+            Event handler to open the supplemental policy in the Policy Editor
+            </summary>
         </member>
         <member name="M:AppControlManager.Pages.EventLogsPolicyCreation.InitializeComponent">
             <summary>
@@ -5778,40 +5797,30 @@
             <param name="e"></param>
             <exception cref="T:System.InvalidOperationException"></exception>
         </member>
-        <member name="M:AppControlManager.Pages.MDEAHPolicyCreation.MSGraphCancelSignInButton_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
+        <member name="M:AppControlManager.Pages.MDEAHPolicyCreation.MSGraphCancelSignInButton_Click">
             <summary>
             Event handler for the Cancel Sign In button
             </summary>
-            <param name="sender"></param>
-            <param name="e"></param>
         </member>
-        <member name="M:AppControlManager.Pages.MDEAHPolicyCreation.MSGraphSignInButton_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
+        <member name="M:AppControlManager.Pages.MDEAHPolicyCreation.MSGraphSignInButton_Click">
             <summary>
             Event handler for the SignIn button for Microsoft Graph
             </summary>
-            <param name="sender"></param>
-            <param name="e"></param>
         </member>
-        <member name="M:AppControlManager.Pages.MDEAHPolicyCreation.MSGraphSignOutButton_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
+        <member name="M:AppControlManager.Pages.MDEAHPolicyCreation.MSGraphSignOutButton_Click">
             <summary>
             Event handler for signing out of Microsoft Graph
             </summary>
-            <param name="sender"></param>
-            <param name="e"></param>
         </member>
-        <member name="M:AppControlManager.Pages.MDEAHPolicyCreation.RetrieveTheLogsButton_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
+        <member name="M:AppControlManager.Pages.MDEAHPolicyCreation.RetrieveTheLogsButton_Click">
             <summary>
             Event handler for the button that retrieves the logs
             </summary>
-            <param name="sender"></param>
-            <param name="e"></param>
         </member>
-        <member name="M:AppControlManager.Pages.MDEAHPolicyCreation.SegmentedControl_SelectionChanged(System.Object,Microsoft.UI.Xaml.Controls.SelectionChangedEventArgs)">
+        <member name="M:AppControlManager.Pages.MDEAHPolicyCreation.SegmentedControl_SelectionChanged">
             <summary>
             Event handler for for the segmented button's selection change
             </summary>
-            <param name="sender"></param>
-            <param name="e"></param>
         </member>
         <member name="M:AppControlManager.Pages.MDEAHPolicyCreation.CopyButton_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
             <summary>
@@ -5826,6 +5835,16 @@
             </summary>
             <param name="sender"></param>
             <param name="args"></param>
+        </member>
+        <member name="F:AppControlManager.Pages.MDEAHPolicyCreation.finalSupplementalPolicyPath">
+            <summary>
+            Path of the Supplemental policy that is created or the policy that user selected to add the logs to.
+            </summary>
+        </member>
+        <member name="M:AppControlManager.Pages.MDEAHPolicyCreation.OpenInPolicyEditor">
+            <summary>
+            Event handler to open the supplemental policy in the Policy Editor
+            </summary>
         </member>
         <member name="M:AppControlManager.Pages.MDEAHPolicyCreation.InitializeComponent">
             <summary>
@@ -8109,6 +8128,18 @@
             <param name="propertyName"></param>
             <returns></returns>
         </member>
+        <member name="M:AppControlManager.ViewModels.CreatePolicyVM.SetProperty``1(``0,``0,System.Action{``0},System.String)">
+            <summary>
+            Sets the property and raises the PropertyChanged event if the value has changed.
+            This also prevents infinite loops where a property raises OnPropertyChanged which could trigger an update in the UI, and the UI might call set again, leading to an infinite loop.
+            </summary>
+            <typeparam name="T"></typeparam>
+            <param name="currentValue"></param>
+            <param name="newValue"></param>
+            <param name="setter"></param>
+            <param name="propertyName"></param>
+            <returns></returns>
+        </member>
         <member name="M:AppControlManager.ViewModels.CreateSupplementalPolicyVM.CalculateColumnWidths">
             <summary>
             Calculates the maximum required width for each column (including header text)
@@ -8568,6 +8599,12 @@
             <summary>
             Event handler to open the Policy HVCI Option/Level ComboBox's dropdown menu when its parent settings card is clicked on
             </summary>
+        </member>
+        <member name="M:AppControlManager.ViewModels.PolicyEditorVM.OpenInPolicyEditor(System.String)">
+            <summary>
+            Used by various methods internally to open a created/modified policy in the Policy Editor
+            </summary>
+            <param name="policyFile">the path to the policy file to open in the Policy Editor</param>
         </member>
         <member name="M:AppControlManager.ViewModels.PolicyEditorVM.SetProperty``1(``0,``0,System.Action{``0},System.String)">
             <summary>

--- a/AppControl Manager/Main/BasePolicyCreator.cs
+++ b/AppControl Manager/Main/BasePolicyCreator.cs
@@ -350,7 +350,8 @@ internal static partial class BasePolicyCreator
 	/// And creates a valid Code Integrity XML policy file from it.
 	/// </summary>
 	/// <param name="StagingArea">The directory where the XML file will be saved to.</param>
-	internal static void GetDriversBlockRules(string StagingArea)
+	/// <returns>the path to the Microsoft recommended driver block rules base policy path</returns>
+	internal static string GetDriversBlockRules(string StagingArea)
 	{
 		string name = "Microsoft Recommended Driver Block Rules";
 
@@ -399,6 +400,8 @@ internal static partial class BasePolicyCreator
 		File.Copy(xmlPath, savePathLocation, true);
 
 		Logger.Write($"The policy file was created and saved to {savePathLocation}");
+
+		return savePathLocation;
 	}
 
 
@@ -415,7 +418,8 @@ internal static partial class BasePolicyCreator
 	/// <param name="deployAppControlSupplementalPolicy">Indicates if a supplemental policy should be deployed alongside the main policy.</param>
 	/// <param name="PolicyIDToUse">Allows the use of a specific policy ID if provided, overriding the generated one.</param>
 	/// <param name="DeployMicrosoftRecommendedBlockRules">Specifies whether to deploy recommended block rules if no policy ID is provided.</param>
-	internal static void BuildAllowMSFT(string StagingArea, bool IsAudit, ulong? LogSize, bool deploy, bool RequireEVSigners, bool EnableScriptEnforcement, bool TestMode, bool deployAppControlSupplementalPolicy, string? PolicyIDToUse, bool DeployMicrosoftRecommendedBlockRules)
+	/// <returns>Returns the path to the created policy</returns>
+	internal static string BuildAllowMSFT(string StagingArea, bool IsAudit, ulong? LogSize, bool deploy, bool RequireEVSigners, bool EnableScriptEnforcement, bool TestMode, bool deployAppControlSupplementalPolicy, string? PolicyIDToUse, bool DeployMicrosoftRecommendedBlockRules)
 	{
 
 		string policyName;
@@ -485,6 +489,8 @@ internal static partial class BasePolicyCreator
 
 		// Assign the created policy path to the Sidebar if condition is met
 		ViewModel.AssignToSidebar(finalPolicyPath);
+
+		return finalPolicyPath;
 	}
 
 
@@ -502,7 +508,8 @@ internal static partial class BasePolicyCreator
 	/// <param name="deployAppControlSupplementalPolicy">Specifies if a supplemental policy should be deployed alongside the main policy.</param>
 	/// <param name="PolicyIDToUse">Allows the use of a specific policy ID instead of generating a new one.</param>
 	/// <param name="DeployMicrosoftRecommendedBlockRules">Indicates whether to retrieve and deploy Microsoft recommended block rules.</param>
-	internal static void BuildDefaultWindows(string StagingArea, bool IsAudit, ulong? LogSize, bool deploy, bool RequireEVSigners, bool EnableScriptEnforcement, bool TestMode, bool deployAppControlSupplementalPolicy, string? PolicyIDToUse, bool DeployMicrosoftRecommendedBlockRules)
+	/// <returns>Returns the path to the created Default Windows base policy</returns>
+	internal static string BuildDefaultWindows(string StagingArea, bool IsAudit, ulong? LogSize, bool deploy, bool RequireEVSigners, bool EnableScriptEnforcement, bool TestMode, bool deployAppControlSupplementalPolicy, string? PolicyIDToUse, bool DeployMicrosoftRecommendedBlockRules)
 	{
 
 		string policyName;
@@ -573,6 +580,8 @@ internal static partial class BasePolicyCreator
 
 		// Assign the created policy path to the Sidebar if condition is met
 		ViewModel.AssignToSidebar(finalPolicyPath);
+
+		return finalPolicyPath;
 	}
 
 
@@ -687,7 +696,8 @@ internal static partial class BasePolicyCreator
 	/// <param name="deployAppControlSupplementalPolicy">Indicates if a supplemental policy should be deployed alongside the main policy.</param>
 	/// <param name="PolicyIDToUse">Allows the use of a specific policy ID if provided, overriding the generated one.</param>
 	/// <param name="DeployMicrosoftRecommendedBlockRules">Specifies whether to retrieve and deploy Microsoft recommended block rules.</param>
-	internal static void BuildSignedAndReputable(string StagingArea, bool IsAudit, ulong? LogSize, bool deploy, bool RequireEVSigners, bool EnableScriptEnforcement, bool TestMode, bool deployAppControlSupplementalPolicy, string? PolicyIDToUse, bool DeployMicrosoftRecommendedBlockRules)
+	/// <returns>Returns the signed and reputable base policy file path</returns>
+	internal static string BuildSignedAndReputable(string StagingArea, bool IsAudit, ulong? LogSize, bool deploy, bool RequireEVSigners, bool EnableScriptEnforcement, bool TestMode, bool deployAppControlSupplementalPolicy, string? PolicyIDToUse, bool DeployMicrosoftRecommendedBlockRules)
 	{
 
 		string policyName;
@@ -762,6 +772,8 @@ internal static partial class BasePolicyCreator
 
 		// Assign the created policy path to the Sidebar if condition is met
 		ViewModel.AssignToSidebar(finalPolicyPath);
+
+		return finalPolicyPath;
 	}
 
 
@@ -775,7 +787,8 @@ internal static partial class BasePolicyCreator
 	/// <param name="NoFlightRoots">Determines the filename variant used for the policy based on flight root settings.</param>
 	/// <param name="deploy">Indicates whether the policy should be deployed after creation.</param>
 	/// <param name="PolicyIDToUse">Specifies an optional policy ID to associate with the created policy.</param>
-	internal static void BuildStrictKernelMode(string StagingArea, bool IsAudit, bool NoFlightRoots, bool deploy, string? PolicyIDToUse = null)
+	/// <returns>the path to the Strict Kernel-mode base policy path</returns>
+	internal static string BuildStrictKernelMode(string StagingArea, bool IsAudit, bool NoFlightRoots, bool deploy, string? PolicyIDToUse = null)
 	{
 
 		string fileName = NoFlightRoots ? "StrictKernelMode_NoFlightRoots" : "StrictKernelMode";
@@ -827,6 +840,8 @@ internal static partial class BasePolicyCreator
 			// Deploy the CiP file
 			CiToolHelper.UpdatePolicy(cipPath);
 		}
+
+		return finalPolicyPath;
 	}
 
 

--- a/AppControl Manager/Pages/AllowNewApps/AllowNewAppsStart.xaml
+++ b/AppControl Manager/Pages/AllowNewApps/AllowNewAppsStart.xaml
@@ -36,7 +36,7 @@
                 <HyperlinkButton Margin="0,-8,0,8" x:Uid="GuideButtonAtTop" NavigateUri="https://github.com/HotCakeX/Harden-Windows-Security/wiki/Allow-New-Apps" />
 
                 <StackPanel Orientation="Horizontal" Spacing="15" Margin="0,-6,0,10">
-                    <Button x:Name="ResetStepsButton" Click="ResetStepsButton_Click" Style="{StaticResource AccentButtonStyle}" x:Uid="ResetStepsButton" />
+                    <Button x:Name="ResetStepsButton" Click="{x:Bind ResetStepsButton_Click}" Style="{StaticResource AccentButtonStyle}" x:Uid="ResetStepsButton" />
                     <ProgressRing IsActive="False" x:Name="ResetProgressRing"/>
                 </StackPanel>
 
@@ -64,7 +64,7 @@
                     <controls:WrapPanel Grid.Row="1" Orientation="Horizontal" VerticalSpacing="15" HorizontalSpacing="15">
 
                         <TextBox x:Name="SupplementalPolicyNameTextBox" Header="Supplemental Policy Name" PlaceholderText="Enter a name for the Supplemental Policy" />
-                        <Button x:Name="BrowseForXMLPolicyButton" Click="BrowseForXMLPolicyButton_Click" Margin="0,27,0,0"
+                        <Button x:Name="BrowseForXMLPolicyButton" Click="{x:Bind BrowseForXMLPolicyButton_Click}" Margin="0,27,0,0"
                                RightTapped="BrowseForXMLPolicyButton_RightTapped" Holding="BrowseForXMLPolicyButton_Holding" ToolTipService.ToolTip="Click/Tap to choose a Base policy XML file from your device.">
 
                             <Button.Flyout>
@@ -107,7 +107,7 @@
                             SmallChange="1"
                             LargeChange="10" Minimum="2" Maximum="1000000" ValueChanged="LogSizeNumberBox_ValueChanged" />
 
-                        <Button x:Name="GoToStep2Button" Click="GoToStep2Button_Click" Margin="0,27,0,0" Content="Go to step 2" ToolTipService.ToolTip="Start deploying the selected policy in Audit mode and go to step 2" Style="{StaticResource AccentButtonStyle}"/>
+                        <Button x:Name="GoToStep2Button" Click="{x:Bind GoToStep2Button_Click}" Margin="0,27,0,0" Content="Go to step 2" ToolTipService.ToolTip="Start deploying the selected policy in Audit mode and go to step 2" Style="{StaticResource AccentButtonStyle}"/>
 
                     </controls:WrapPanel>
 
@@ -138,14 +138,14 @@
                     <controls:WrapPanel Grid.Row="1" Orientation="Horizontal" VerticalSpacing="8" HorizontalSpacing="8">
 
                         <Button x:Name="BrowseForFoldersButton" RightTapped="BrowseForFoldersButton_RightTapped"
-                               Holding="BrowseForFoldersButton_Holding" Click="BrowseForFoldersButton_Click" Content="Browse for folders" ToolTipService.ToolTip="Browse for folders of your new or existing apps that are installed and are getting blocked">
+                               Holding="BrowseForFoldersButton_Holding" Click="{x:Bind BrowseForFoldersButton_Click}" Content="Browse for folders" ToolTipService.ToolTip="Browse for folders of your new or existing apps that are installed and are getting blocked">
 
                             <Button.Flyout>
                                 <Flyout x:Name="BrowseForFoldersButton_FlyOut">
 
                                     <controls:WrapPanel Orientation="Vertical" HorizontalSpacing="15" VerticalSpacing="15">
 
-                                        <Button x:Uid="ClearButton" Click="ClearSelectedDirectoriesButton_Click" />
+                                        <Button x:Uid="ClearButton" Click="{x:Bind ClearSelectedDirectoriesButton_Click}" />
 
                                         <TextBlock x:Uid="ViewSelectedFoldersTextBlock" TextWrapping="WrapWholeWords" Width="400" />
 
@@ -160,7 +160,7 @@
 
                         </Button>
 
-                        <Button x:Name="GoToStep3Button" Click="GoToStep3Button_Click" Content="Go to step 3" ToolTipService.ToolTip="Start scanning the event logs and the selected directories (if any) and go to step 3" Style="{StaticResource AccentButtonStyle}"/>
+                        <Button x:Name="GoToStep3Button" Click="{x:Bind GoToStep3Button_Click}" Content="Go to step 3" ToolTipService.ToolTip="Start scanning the event logs and the selected directories (if any) and go to step 3" Style="{StaticResource AccentButtonStyle}"/>
 
                     </controls:WrapPanel>
 
@@ -198,9 +198,13 @@
                             <x:String>Hash</x:String>
                         </ComboBox>
 
-                        <Button x:Name="CreatePolicyButton" Click="CreatePolicyButton_Click" x:Uid="AllowNewAppsCreatePolicyButton" Style="{StaticResource AccentButtonStyle}"/>
+                        <Button x:Name="CreatePolicyButton" Click="{x:Bind CreatePolicyButton_Click}" x:Uid="AllowNewAppsCreatePolicyButton" Style="{StaticResource AccentButtonStyle}"/>
                     </controls:WrapPanel>
-                    <InfoBar x:Name="Step3InfoBar" Severity="Informational" IsOpen="False" IsClosable='False' Margin="0,20,0,0" Grid.Row="2"/>
+                    <InfoBar x:Name="Step3InfoBar" Severity="Informational" IsOpen="False" IsClosable='False' Margin="0,20,0,0" Grid.Row="2">
+                        <InfoBar.ActionButton>
+                            <Button x:Uid="OpenInPolicyEditorButton" Visibility="{x:Bind ViewModel.OpenInPolicyEditorInfoBarActionButtonVisibility, Mode=OneWay}" Click="{x:Bind OpenInPolicyEditor}" />
+                        </InfoBar.ActionButton>
+                    </InfoBar>
                 </Grid>
             </Border>
 

--- a/AppControl Manager/Pages/CreatePolicy.xaml
+++ b/AppControl Manager/Pages/CreatePolicy.xaml
@@ -55,13 +55,16 @@
                              IsOpen="False"
                              IsClosable="False"
                              Severity="Informational">
+                            <InfoBar.ActionButton>
+                                <Button x:Uid="OpenInPolicyEditorButton" Visibility="{x:Bind ViewModel.AllowMicrosoftInfoBarActionButtonVisibility, Mode=OneWay}" Click="{x:Bind OpenInPolicyEditor_AllowMicrosoft}" />
+                            </InfoBar.ActionButton>
                         </InfoBar>
                     </controls:SettingsExpander.ItemsHeader>
 
                     <controls:WrapPanel Orientation="Horizontal" HorizontalSpacing="6" VerticalSpacing="10">
 
                         <Button x:Name="AllowMicrosoftCreate" Content="Create" ToolTipService.ToolTip="Create the Allow Microsoft base policy"
-                            Style="{StaticResource AccentButtonStyle}" Margin="0,0,15,0" Click="AllowMicrosoftCreate_Click" />
+                            Style="{StaticResource AccentButtonStyle}" Margin="0,0,15,0" Click="{x:Bind AllowMicrosoftCreate_Click}" />
 
                         <ToggleButton x:Name="AllowMicrosoftCreateAndDeploy" x:Uid="DeployAfterCreationButton" Margin="0,0,15,0" />
 
@@ -85,7 +88,7 @@
                                     IsEnabled="False"
                                     LargeChange="10" Minimum="2" Maximum="1000000" Margin="0,0,30,0" />
 
-                                <ToggleSwitch x:Name="AllowMicrosoftLogSizeInputEnabled" IsEnabled="False" Toggled="AllowMicrosoftLogSizeInputEnabled_Toggled" />
+                                <ToggleSwitch x:Name="AllowMicrosoftLogSizeInputEnabled" IsEnabled="False" Toggled="{x:Bind AllowMicrosoftLogSizeInputEnabled_Toggled}" />
 
                             </controls:WrapPanel>
 
@@ -125,13 +128,16 @@
                              IsOpen="False"
                              IsClosable="False"
                              Severity="Informational">
+                            <InfoBar.ActionButton>
+                                <Button x:Uid="OpenInPolicyEditorButton" Visibility="{x:Bind ViewModel.DefaultWindowsInfoBarActionButtonVisibility, Mode=OneWay}" Click="{x:Bind OpenInPolicyEditor_DefaultWindows}" />
+                            </InfoBar.ActionButton>
                         </InfoBar>
                     </controls:SettingsExpander.ItemsHeader>
 
                     <controls:WrapPanel Orientation="Horizontal" HorizontalSpacing="6" VerticalSpacing="10">
 
                         <Button x:Name="DefaultWindowsCreate" Content="Create" ToolTipService.ToolTip="Create the Default Windows base policy"
-                                Style="{StaticResource AccentButtonStyle}" Margin="0,0,15,0" Click="DefaultWindowsCreate_Click" />
+                                Style="{StaticResource AccentButtonStyle}" Margin="0,0,15,0" Click="{x:Bind DefaultWindowsCreate_Click}" />
 
                         <ToggleButton x:Name="DefaultWindowsCreateAndDeploy" x:Uid="DeployAfterCreationButton" Margin="0,0,15,0" />
 
@@ -155,7 +161,7 @@
                                     SmallChange="1"
                                     LargeChange="10" Minimum="2" Maximum="1000000" Margin="0,0,30,0" />
 
-                                <ToggleSwitch x:Name="DefaultWindowsLogSizeInputEnabled" IsEnabled="False" Toggled="DefaultWindowsLogSizeInputEnabled_Toggled" />
+                                <ToggleSwitch x:Name="DefaultWindowsLogSizeInputEnabled" IsEnabled="False" Toggled="{x:Bind DefaultWindowsLogSizeInputEnabled_Toggled}" />
 
                             </controls:WrapPanel>
 
@@ -195,13 +201,16 @@
                              IsOpen="False"
                              IsClosable="False"
                              Severity="Informational">
+                            <InfoBar.ActionButton>
+                                <Button x:Uid="OpenInPolicyEditorButton" Visibility="{x:Bind ViewModel.SignedAndReputableInfoBarActionButtonVisibility, Mode=OneWay}" Click="{x:Bind OpenInPolicyEditor_SignedAndReputable}" />
+                            </InfoBar.ActionButton>
                         </InfoBar>
                     </controls:SettingsExpander.ItemsHeader>
 
                     <controls:WrapPanel Orientation="Horizontal" HorizontalSpacing="6" VerticalSpacing="10">
 
                         <Button x:Name="SignedAndReputableCreate" Content="Create" ToolTipService.ToolTip="Create the Signed and Reputable base policy"
-                                Style="{StaticResource AccentButtonStyle}" Margin="0,0,15,0" Click="SignedAndReputableCreate_Click" />
+                                Style="{StaticResource AccentButtonStyle}" Margin="0,0,15,0" Click="{x:Bind SignedAndReputableCreate_Click}" />
 
                         <ToggleButton x:Name="SignedAndReputableCreateAndDeploy" x:Uid="DeployAfterCreationButton" Margin="0,0,15,0" />
 
@@ -225,7 +234,7 @@
                                     SmallChange="1"
                                     LargeChange="10" Minimum="2" Maximum="1000000" Margin="0,0,30,0" />
 
-                                <ToggleSwitch x:Name="SignedAndReputableLogSizeInputEnabled" IsEnabled="False" Toggled="SignedAndReputableLogSizeInputEnabled_Toggled" />
+                                <ToggleSwitch x:Name="SignedAndReputableLogSizeInputEnabled" IsEnabled="False" Toggled="{x:Bind SignedAndReputableLogSizeInputEnabled_Toggled}" />
 
                             </controls:WrapPanel>
 
@@ -265,18 +274,21 @@
                             IsOpen="False"
                             IsClosable="False"
                             Severity="Informational">
+                            <InfoBar.ActionButton>
+                                <Button x:Uid="OpenInPolicyEditorButton" Visibility="{x:Bind ViewModel.MSFTRecommendedDriverBlockRulesInfoBarActionButtonVisibility, Mode=OneWay}" Click="{x:Bind OpenInPolicyEditor_RecommendedDriverBlockRules}" />
+                            </InfoBar.ActionButton>
                         </InfoBar>
                     </controls:SettingsExpander.ItemsHeader>
 
                     <controls:WrapPanel Orientation="Horizontal" HorizontalSpacing="6" VerticalSpacing="10">
 
                         <Button x:Name="RecommendedDriverBlockRulesCreate" Content="Create" ToolTipService.ToolTip="Create the Microsoft Recommended Drivers Block List policy"
-                            Style="{StaticResource AccentButtonStyle}" Margin="0,0,15,0" Click="RecommendedDriverBlockRulesCreate_Click" />
+                            Style="{StaticResource AccentButtonStyle}" Margin="0,0,15,0" Click="{x:Bind RecommendedDriverBlockRulesCreate_Click}" />
 
                         <ToggleButton x:Name="RecommendedDriverBlockRulesCreateAndDeploy" x:Uid="DeployAfterCreationButton" Margin="0,0,15,0" />
 
                         <Button x:Name="RecommendedDriverBlockRulesScheduledAutoUpdate" Content="Auto Update" ToolTipService.ToolTip="Configures the Microsoft Recommended Drivers Block List to be automatically updated using a scheduled task"
-                            Style="{StaticResource AccentButtonStyle}" Click="RecommendedDriverBlockRulesScheduledAutoUpdate_Click" Margin="0,0,15,0" />
+                            Style="{StaticResource AccentButtonStyle}" Click="{x:Bind RecommendedDriverBlockRulesScheduledAutoUpdate_Click}" Margin="0,0,15,0" />
 
                     </controls:WrapPanel>
 
@@ -299,7 +311,7 @@
                     <controls:WrapPanel Orientation="Horizontal" HorizontalSpacing="6" VerticalSpacing="10">
 
                         <Button x:Name="RecommendedUserModeBlockRulesCreate" Content="Create" ToolTipService.ToolTip="Create the Microsoft recommended user-mode block rules policy"
-                              Style="{StaticResource AccentButtonStyle}" Margin="0,0,15,0" Click="RecommendedUserModeBlockRulesCreate_Click" />
+                              Style="{StaticResource AccentButtonStyle}" Margin="0,0,15,0" Click="{x:Bind RecommendedUserModeBlockRulesCreate_Click}" />
 
                         <ToggleButton x:Name="RecommendedUserModeBlockRulesCreateAndDeploy" x:Uid="DeployAfterCreationButton" Margin="0,0,15,0" />
 
@@ -322,12 +334,15 @@
                         IsOpen="False"
                         IsClosable="False"
                         Severity="Informational">
+                            <InfoBar.ActionButton>
+                                <Button x:Uid="OpenInPolicyEditorButton" Visibility="{x:Bind ViewModel.StrictKernelModeInfoBarActionButtonVisibility, Mode=OneWay}" Click="{x:Bind OpenInPolicyEditor_StrictKernelModePolicy}" />
+                            </InfoBar.ActionButton>
                         </InfoBar>
                     </controls:SettingsExpander.ItemsHeader>
 
                     <controls:WrapPanel Orientation="Horizontal" HorizontalSpacing="6" VerticalSpacing="10">
 
-                        <Button x:Name="StrictKernelModePolicyCreateButton" Content="Create" Click="StrictKernelModePolicyCreateButton_Click"
+                        <Button x:Name="StrictKernelModePolicyCreateButton" Content="Create" Click="{x:Bind StrictKernelModePolicyCreateButton_Click}"
                              Style="{StaticResource AccentButtonStyle}" Margin="0,0,15,0" ToolTipService.ToolTip="Create the Strict Kernel-mode base policy"  />
 
                         <ToggleButton x:Name="StrictKernelModePolicyToggleButtonForDeploy" x:Uid="DeployAfterCreationButton" Margin="0,0,15,0" />
@@ -337,14 +352,14 @@
                     <controls:SettingsExpander.Items>
 
                         <controls:SettingsCard Description="Indicates that the created/deployed policy will have (Enabled:Audit Mode) policy rule option and will generate audit logs instead of blocking files."
-                                Header="Audit" IsClickEnabled="True" IsActionIconVisible="False" Click="StrictKernelModePolicyAuditSettingsCard_Click">
+                                Header="Audit" IsClickEnabled="True" IsActionIconVisible="False" Click="{x:Bind StrictKernelModePolicyAuditSettingsCard_Click}">
                             <ToggleSwitch x:Name="StrictKernelModePolicyAudit" />
 
                         </controls:SettingsCard>
 
                         <controls:SettingsCard x:Name="StrictKernelModePolicyUseNoFlightRootsToggleSwitchSettingsCard" Description="Do not allow flight root certificates"
                              Header="No flight root certificates"
-                             IsClickEnabled="True" IsActionIconVisible="False" Click="StrictKernelModePolicyUseNoFlightRootsToggleSwitchSettingsCard_Click">
+                             IsClickEnabled="True" IsActionIconVisible="False" Click="{x:Bind StrictKernelModePolicyUseNoFlightRootsToggleSwitchSettingsCard_Click}">
 
                             <ToggleSwitch x:Name="StrictKernelModePolicyUseNoFlightRootsToggleSwitch" />
 

--- a/AppControl Manager/Pages/EventLogsPolicyCreation.xaml
+++ b/AppControl Manager/Pages/EventLogsPolicyCreation.xaml
@@ -27,6 +27,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
@@ -52,7 +53,7 @@
 
                 <controls:WrapPanel Orientation="Vertical" HorizontalSpacing="15" VerticalSpacing="15">
 
-                    <Button x:Uid="ClearButton" Click="SelectedAppLockerEVTXFilesFlyout_Clear_Click" />
+                    <Button x:Uid="ClearButton" Click="{x:Bind SelectedAppLockerEVTXFilesFlyout_Clear_Click}" />
 
                     <TextBlock Text="View the AppLocker EVTX files you selected." TextWrapping="WrapWholeWords" />
 
@@ -85,7 +86,13 @@
 
         </controls:WrapPanel>
 
-        <Border Grid.Row="1" Margin="0,10,0,10"
+        <InfoBar x:Name="MainInfoBar" Grid.Row="1" Visibility="Collapsed">
+            <InfoBar.ActionButton>
+                <Button x:Uid="OpenInPolicyEditorButton" Visibility="{x:Bind ViewModel.OpenInPolicyEditorInfoBarActionButtonVisibility, Mode=OneWay}" Click="{x:Bind OpenInPolicyEditor}" />
+            </InfoBar.ActionButton>
+        </InfoBar>
+
+        <Border Grid.Row="2" Margin="0,10,0,10"
             Style="{StaticResource GridCardStyle}" Padding="8">
 
             <controls:WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalSpacing="10" VerticalSpacing="10">
@@ -93,7 +100,7 @@
                 <ProgressRing x:Name="ScanLogsProgressRing" Visibility="Collapsed" IsActive="False" />
 
                 <!-- Scan button -->
-                <Button x:Name="ScanLogs" x:Uid="ScanLogsButton" Style="{StaticResource AccentButtonStyle}" Click="ScanLogs_Click" >
+                <Button x:Name="ScanLogs" x:Uid="ScanLogsButton" Style="{StaticResource AccentButtonStyle}" Click="{x:Bind ScanLogs_Click}" >
                     <Button.Content>
                         <StackPanel Orientation="Horizontal">
                             <FontIcon Glyph="&#xEE6F;" />
@@ -102,7 +109,7 @@
                     </Button.Content>
                 </Button>
 
-                <SplitButton x:Name="CreatePolicyButton" ToolTipService.ToolTip="Create the supplemental policy" Click="CreatePolicyButton_Click">
+                <SplitButton x:Name="CreatePolicyButton" ToolTipService.ToolTip="Create the supplemental policy" Click="{x:Bind CreatePolicyButton_Click}">
 
                     <SplitButton.Content>
                         <StackPanel Orientation="Horizontal">
@@ -152,7 +159,7 @@
                                                 <Span>Browse for a XML policy file to add <Bold>the logs</Bold> to </Span>
                                             </TextBlock>
 
-                                            <Button Margin="5" x:Name="AddToPolicyButton" Content="Browse" ToolTipService.ToolTip="Select a XML file to add the scanned logs to" Style="{StaticResource AccentButtonStyle}" Click="AddToPolicyButton_Click" />
+                                            <Button Margin="5" x:Name="AddToPolicyButton" Content="Browse" ToolTipService.ToolTip="Select a XML file to add the scanned logs to" Style="{StaticResource AccentButtonStyle}" Click="{x:Bind AddToPolicyButton_Click}" />
 
                                         </StackPanel>
                                     </controls:Case>
@@ -168,7 +175,7 @@
                                                     policy XML file that this <Underline>Supplemental</Underline> policy will belong to </Span>
                                             </TextBlock>
 
-                                            <Button Margin="5" x:Name="BasePolicyFileButton" Content="Browse" ToolTipService.ToolTip="Select a base policy that this supplemental policy will belong to." Style="{StaticResource AccentButtonStyle}" Click="BasePolicyFileButton_Click" />
+                                            <Button Margin="5" x:Name="BasePolicyFileButton" Content="Browse" ToolTipService.ToolTip="Select a base policy that this supplemental policy will belong to." Style="{StaticResource AccentButtonStyle}" Click="{x:Bind BasePolicyFileButton_Click}" />
                                         </StackPanel>
                                     </controls:Case>
 
@@ -179,7 +186,7 @@
 
                                             <TextBox x:Name="BaseGUIDTextBox" PlaceholderText="Enter a Base policy GUID" Width="300" Margin="10" VerticalAlignment="Center" VerticalContentAlignment="Center" ToolTipService.ToolTip="Enter the Base GUID" />
 
-                                            <Button Margin="5" x:Name="BaseGUIDSubmitButton" Content="Submit" ToolTipService.ToolTip="Submit the GUID" Style="{StaticResource AccentButtonStyle}" Click="BaseGUIDSubmitButton_Click" />
+                                            <Button Margin="5" x:Name="BaseGUIDSubmitButton" Content="Submit" ToolTipService.ToolTip="Submit the GUID" Style="{StaticResource AccentButtonStyle}" Click="{x:Bind BaseGUIDSubmitButton_Click}" />
                                         </StackPanel>
                                     </controls:Case>
                                 </controls:SwitchPresenter>
@@ -200,7 +207,7 @@
                                 </MenuFlyoutItem.Icon>
                             </MenuFlyoutItem>
 
-                            <MenuFlyoutItem x:Name="BrowseForAppLockerEVTXFilesButton" RightTapped="BrowseForAppLockerEVTXFilesButton_RightTapped" Holding="BrowseForAppLockerEVTXFilesButton_Holding" Text="Select AppLocker EVTX Files" Click="SelectAppLockerEVTXFiles_Click" ToolTipService.ToolTip="Browse for AppLocker EVTX logs">
+                            <MenuFlyoutItem x:Name="BrowseForAppLockerEVTXFilesButton" RightTapped="BrowseForAppLockerEVTXFilesButton_RightTapped" Holding="BrowseForAppLockerEVTXFilesButton_Holding" Text="Select AppLocker EVTX Files" Click="{x:Bind SelectAppLockerEVTXFiles_Click}" ToolTipService.ToolTip="Browse for AppLocker EVTX logs">
                                 <MenuFlyoutItem.Icon>
                                     <FontIcon Glyph="&#xEC50;" />
                                 </MenuFlyoutItem.Icon>
@@ -216,19 +223,19 @@
 
                         <MenuFlyout Placement="Bottom">
 
-                            <MenuFlyoutItem x:Uid="SelectAllMenuFlyoutItem" Click="SelectAll_Click">
+                            <MenuFlyoutItem x:Uid="SelectAllMenuFlyoutItem" Click="{x:Bind SelectAll_Click}">
                                 <MenuFlyoutItem.Icon>
                                     <FontIcon Glyph="&#xE762;"/>
                                 </MenuFlyoutItem.Icon>
                             </MenuFlyoutItem>
 
-                            <MenuFlyoutItem x:Uid="DeSelectAllMenuFlyoutItem" Click="DeSelectAll_Click">
+                            <MenuFlyoutItem x:Uid="DeSelectAllMenuFlyoutItem" Click="{x:Bind DeSelectAll_Click}">
                                 <MenuFlyoutItem.Icon>
                                     <FontIcon Glyph="&#xE8E6;"/>
                                 </MenuFlyoutItem.Icon>
                             </MenuFlyoutItem>
 
-                            <MenuFlyoutItem Click="ClearDataButton_Click" x:Uid="ClearDataMenuFlyoutItem">
+                            <MenuFlyoutItem Click="{x:Bind ClearDataButton_Click}" x:Uid="ClearDataMenuFlyoutItem">
                                 <MenuFlyoutItem.Icon>
                                     <SymbolIcon Symbol="Delete" />
                                 </MenuFlyoutItem.Icon>
@@ -254,7 +261,7 @@
                  VerticalAlignment="Center"
                  VerticalContentAlignment="Center"/>
 
-                <TextBox x:Name="SearchBox" Width="300" x:Uid="SearchBoxTextBox" TextChanged="SearchBox_TextChanged" VerticalAlignment="Center" VerticalContentAlignment="Center" />
+                <TextBox x:Name="SearchBox" Width="300" x:Uid="SearchBoxTextBox" TextChanged="{x:Bind ApplyFilters}" VerticalAlignment="Center" VerticalContentAlignment="Center" />
 
                 <Button Content="Policy Name">
                     <Button.Flyout>
@@ -280,6 +287,8 @@
                     <x:String>Publisher</x:String>
                     <x:String>Hash</x:String>
                 </ComboBox>
+
+                <ToggleButton x:Name="OnlyIncludeSelectedItemsToggleButton" x:Uid="OnlyIncludeSelectedItemsToggleButton" />
 
                 <Button>
                     <Button.Content>
@@ -326,7 +335,7 @@
         </Border>
 
         <ListView x:Name="FileIdentitiesListView"
-            Grid.Row="2"
+            Grid.Row="3"
             SelectionMode="Extended"
             ItemsSource="{x:Bind ViewModel.FileIdentities, Mode=OneWay}"
             ScrollViewer.HorizontalScrollMode="Enabled"

--- a/AppControl Manager/Pages/MDEAHPolicyCreation.xaml
+++ b/AppControl Manager/Pages/MDEAHPolicyCreation.xaml
@@ -42,7 +42,11 @@
 
         </controls:WrapPanel>
 
-        <InfoBar x:Name="MainInfoBar" Grid.Row="1" Visibility="Collapsed" />
+        <InfoBar x:Name="MainInfoBar" Grid.Row="1" Visibility="Collapsed">
+            <InfoBar.ActionButton>
+                <Button x:Uid="OpenInPolicyEditorButton" Visibility="{x:Bind ViewModel.OpenInPolicyEditorInfoBarActionButtonVisibility, Mode=OneWay}" Click="{x:Bind OpenInPolicyEditor}" />
+            </InfoBar.ActionButton>
+        </InfoBar>
 
         <controls:WrapPanel Grid.Row="2" Orientation="Horizontal" VerticalAlignment="Center" HorizontalSpacing="10" VerticalSpacing="10">
 
@@ -124,11 +128,11 @@
 
             <controls:WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalSpacing="10" VerticalSpacing="10">
 
-                <Button Content="Sign In" x:Name="MSGraphSignInButton" Click="MSGraphSignInButton_Click" ToolTipService.ToolTip="Sign into your tenant"/>
+                <Button Content="Sign In" x:Name="MSGraphSignInButton" Click="{x:Bind MSGraphSignInButton_Click}" ToolTipService.ToolTip="Sign into your tenant"/>
 
-                <Button Content="Sign Out" IsEnabled="False" x:Name="MSGraphSignOutButton" Click="MSGraphSignOutButton_Click" ToolTipService.ToolTip="Sign out of your tenant and discard any saved authentication tokens"/>
+                <Button Content="Sign Out" IsEnabled="False" x:Name="MSGraphSignOutButton" Click="{x:Bind MSGraphSignOutButton_Click}" ToolTipService.ToolTip="Sign out of your tenant and discard any saved authentication tokens"/>
 
-                <Button Content="Cancel Sign In" x:Name="MSGraphCancelSignInButton" IsEnabled="False" Click="MSGraphCancelSignInButton_Click" ToolTipService.ToolTip="Cancel the sign in process"/>
+                <Button Content="Cancel Sign In" x:Name="MSGraphCancelSignInButton" IsEnabled="False" Click="{x:Bind MSGraphCancelSignInButton_Click}" ToolTipService.ToolTip="Cancel the sign in process"/>
 
                 <Button Content="Device Name" x:Name="MSGraphDeviceNameButton" ToolTipService.ToolTip="Enter a device name to filter the incoming logs">
                     <Button.Flyout>
@@ -148,7 +152,7 @@
                 </Button>
 
 
-                <Button Content="Retrieve The Logs" x:Name="RetrieveTheLogsButton" IsEnabled="False" Click="RetrieveTheLogsButton_Click" ToolTipService.ToolTip="Retrieve the logs by submitting an Advanced Hunting query to MDE"/>
+                <Button Content="Retrieve The Logs" x:Name="RetrieveTheLogsButton" IsEnabled="False" Click="{x:Bind RetrieveTheLogsButton_Click}" ToolTipService.ToolTip="Retrieve the logs by submitting an Advanced Hunting query to MDE"/>
 
                 <Button Content="Query Examples" ToolTipService.ToolTip="You can copy the following queries and use them in the MDE Advanced Hunting portal to generate standard logs that are compatible with the AppControl Manager, or you can use the built-in functionality of the application to automatically retrieve the logs and process them">
                     <Button.Flyout>
@@ -242,7 +246,7 @@
                                 Spacing="8">
                                 <controls:Segmented x:Name="segmentedControl"
                                     HorizontalAlignment="Stretch"
-                                    SelectedIndex="1" SelectionChanged="SegmentedControl_SelectionChanged">
+                                    SelectedIndex="1" SelectionChanged="{x:Bind SegmentedControl_SelectionChanged}">
                                     <controls:SegmentedItem Content="Add To Policy"
                                             Tag="AddToPolicy" Width="160" Icon="{ui:FontIcon Glyph=&#xEB49;}" />
                                     <controls:SegmentedItem Content="Base Policy File"
@@ -396,6 +400,8 @@
                     <x:String>Publisher</x:String>
                     <x:String>Hash</x:String>
                 </ComboBox>
+
+                <ToggleButton x:Name="OnlyIncludeSelectedItemsToggleButton" x:Uid="OnlyIncludeSelectedItemsToggleButton" />
 
             </controls:WrapPanel>
 

--- a/AppControl Manager/Pages/PolicyEditor.xaml
+++ b/AppControl Manager/Pages/PolicyEditor.xaml
@@ -44,6 +44,8 @@
 
             <controls:WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalSpacing="10" VerticalSpacing="10">
 
+                <ProgressRing IsIndeterminate="True" Visibility="{x:Bind ViewModel.ProgressBarVisibility, Mode=OneWay}" />
+
                 <Button x:Name="BrowseForPolicyButton" IsEnabled="{x:Bind ViewModel.UIElementsEnabledState, Mode=OneWay}" Click="{x:Bind ViewModel.BrowseForPolicyButton_Click}"
                     VerticalAlignment="Center" HorizontalAlignment="Center" RightTapped="{x:Bind BrowseForPolicyButton_RightTappedOrHolding}" Holding="{x:Bind BrowseForPolicyButton_RightTappedOrHolding}"
                         ToolTipService.ToolTip="Browse for an App Control XML policy file">

--- a/AppControl Manager/Pages/Settings.xaml.cs
+++ b/AppControl Manager/Pages/Settings.xaml.cs
@@ -139,6 +139,8 @@ internal sealed partial class Settings : Page
 
 		// Raise the global OnNavigationViewLocationChanged event
 		NavigationViewLocationManager.OnNavigationViewLocationChanged(selectedLocation);
+
+		App.Settings.NavViewPaneDisplayMode = selectedLocation;
 	}
 
 	/// <summary>

--- a/AppControl Manager/Strings/en-US/Resources.resw
+++ b/AppControl Manager/Strings/en-US/Resources.resw
@@ -122,11 +122,18 @@
   <data name="CreateDenyPolicyNavItem.ToolTipService.ToolTip" xml:space="preserve">
     <value>Create Deny App Control Policies</value>
   </data>
+  <data name="CreateDenyPolicyNavItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Create Deny App Control Policies</value>
+  </data>
   <data name="CreatePolicyNavItem.Content" xml:space="preserve">
     <value>Create Policy</value>
     <comment>Main Navigation</comment>
   </data>
   <data name="CreatePolicyNavItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Create AppControl Policies with different characteristics</value>
+    <comment>Main Navigation</comment>
+  </data>
+  <data name="CreatePolicyNavItem.AutomationProperties.HelpText" xml:space="preserve">
     <value>Create AppControl Policies with different characteristics</value>
     <comment>Main Navigation</comment>
   </data>
@@ -136,10 +143,16 @@
   <data name="CreateSupplementalPolicyNavItem.ToolTipService.ToolTip" xml:space="preserve">
     <value>Create Supplemental AppControl Policies</value>
   </data>
+  <data name="CreateSupplementalPolicyNavItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Create Supplemental AppControl Policies</value>
+  </data>
   <data name="BuildNewCertificateNavItem.Content" xml:space="preserve">
     <value>Build New Certificate</value>
   </data>
   <data name="BuildNewCertificateNavItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Generate Certificates that are suitable for signing App Control Policies</value>
+  </data>
+  <data name="BuildNewCertificateNavItem.AutomationProperties.HelpText" xml:space="preserve">
     <value>Generate Certificates that are suitable for signing App Control Policies</value>
   </data>
   <data name="ViewFileCertificatesNavItem.Content" xml:space="preserve">
@@ -148,10 +161,16 @@
   <data name="ViewFileCertificatesNavItem.ToolTipService.ToolTip" xml:space="preserve">
     <value>View advanced and highly detailed information about all certificates of signed files</value>
   </data>
+  <data name="ViewFileCertificatesNavItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>View advanced and highly detailed information about all certificates of signed files</value>
+  </data>
   <data name="CreatePolicyFromEventLogsNavItem.Content" xml:space="preserve">
     <value>Create policy from Event Logs</value>
   </data>
   <data name="CreatePolicyFromEventLogsNavItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Create App Control policy either from the local event logs or EVTX files</value>
+  </data>
+  <data name="CreatePolicyFromEventLogsNavItem.AutomationProperties.HelpText" xml:space="preserve">
     <value>Create App Control policy either from the local event logs or EVTX files</value>
   </data>
   <data name="CreatePolicyFromMDEAHNavItem.Content" xml:space="preserve">
@@ -160,10 +179,16 @@
   <data name="CreatePolicyFromMDEAHNavItem.ToolTipService.ToolTip" xml:space="preserve">
     <value>Create App Control policy from Microsoft Defender for Endpoint (MDE) Advanced Hunting Logs</value>
   </data>
+  <data name="CreatePolicyFromMDEAHNavItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Create App Control policy from Microsoft Defender for Endpoint (MDE) Advanced Hunting Logs</value>
+  </data>
   <data name="SimulationNavItem.Content" xml:space="preserve">
     <value>Simulation</value>
   </data>
   <data name="SimulationNavItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Simulate deployment of App Control policies</value>
+  </data>
+  <data name="SimulationNavItem.AutomationProperties.HelpText" xml:space="preserve">
     <value>Simulate deployment of App Control policies</value>
   </data>
   <data name="AllowNewAppsNavItem.Content" xml:space="preserve">
@@ -172,10 +197,16 @@
   <data name="AllowNewAppsNavItem.ToolTipService.ToolTip" xml:space="preserve">
     <value>Allow new apps or programs that are being blocked from installation or are already installed but are being blocked from running.</value>
   </data>
+  <data name="AllowNewAppsNavItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Allow new apps or programs that are being blocked from installation or are already installed but are being blocked from running.</value>
+  </data>
   <data name="SystemInformationNavItem.Content" xml:space="preserve">
     <value>System Information</value>
   </data>
   <data name="SystemInformationNavItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>View information about the system</value>
+  </data>
+  <data name="SystemInformationNavItem.AutomationProperties.HelpText" xml:space="preserve">
     <value>View information about the system</value>
   </data>
   <data name="GetCodeIntegrityHashesNavItem.Content" xml:space="preserve">
@@ -184,10 +215,16 @@
   <data name="GetCodeIntegrityHashesNavItem.ToolTipService.ToolTip" xml:space="preserve">
     <value>Get Code Integrity Hashes of files</value>
   </data>
+  <data name="GetCodeIntegrityHashesNavItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Get Code Integrity Hashes of files</value>
+  </data>
   <data name="GetSecurePolicySettingsNavItem.Content" xml:space="preserve">
     <value>Get Secure Policy Settings</value>
   </data>
   <data name="GetSecurePolicySettingsNavItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Get the secure policy settings among the deployed policies</value>
+  </data>
+  <data name="GetSecurePolicySettingsNavItem.AutomationProperties.HelpText" xml:space="preserve">
     <value>Get the secure policy settings among the deployed policies</value>
   </data>
   <data name="ConfigurePolicyRuleOptionsNavItem.Content" xml:space="preserve">
@@ -196,10 +233,16 @@
   <data name="ConfigurePolicyRuleOptionsNavItem.ToolTipService.ToolTip" xml:space="preserve">
     <value>Configure Policy Rule Options</value>
   </data>
+  <data name="ConfigurePolicyRuleOptionsNavItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Configure Policy Rule Options</value>
+  </data>
   <data name="MergePoliciesNavItem.Content" xml:space="preserve">
     <value>Merge App Control Policies</value>
   </data>
   <data name="MergePoliciesNavItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Merge 2 App Control policies together or deduplicate a single policy</value>
+  </data>
+  <data name="MergePoliciesNavItem.AutomationProperties.HelpText" xml:space="preserve">
     <value>Merge 2 App Control policies together or deduplicate a single policy</value>
   </data>
   <data name="DeploymentNavItem.Content" xml:space="preserve">
@@ -208,10 +251,16 @@
   <data name="DeploymentNavItem.ToolTipService.ToolTip" xml:space="preserve">
     <value>Deploy signed or unsigned AppControl policies on the system</value>
   </data>
+  <data name="DeploymentNavItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Deploy signed or unsigned AppControl policies on the system</value>
+  </data>
   <data name="ValidatePoliciesNavItem.Content" xml:space="preserve">
     <value>Validate Policies</value>
   </data>
   <data name="ValidatePoliciesNavItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Validate App Control Policies</value>
+  </data>
+  <data name="ValidatePoliciesNavItem.AutomationProperties.HelpText" xml:space="preserve">
     <value>Validate App Control Policies</value>
   </data>
   <data name="GitHubDocsNavItem.Content" xml:space="preserve">
@@ -220,10 +269,16 @@
   <data name="GitHubDocsNavItem.ToolTipService.ToolTip" xml:space="preserve">
     <value>Get online documentation from GitHub about how to use the application</value>
   </data>
+  <data name="GitHubDocsNavItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Get online documentation from GitHub about how to use the application</value>
+  </data>
   <data name="MSFTDocsNavItem.Content" xml:space="preserve">
     <value>Microsoft Documentation</value>
   </data>
   <data name="MSFTDocsNavItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Get online documentation from Microsoft about App Control for Business policies</value>
+  </data>
+  <data name="MSFTDocsNavItem.AutomationProperties.HelpText" xml:space="preserve">
     <value>Get online documentation from Microsoft about App Control for Business policies</value>
   </data>
   <data name="LogsNavItem.Content" xml:space="preserve">
@@ -233,6 +288,9 @@
     <value>Settings</value>
   </data>
   <data name="LogsNavItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>View the application logs in real time</value>
+  </data>
+  <data name="LogsNavItem.AutomationProperties.HelpText" xml:space="preserve">
     <value>View the application logs in real time</value>
   </data>
   <data name="ScanResults" xml:space="preserve">
@@ -250,10 +308,16 @@
   <data name="GuideButtonAtTop.ToolTipService.ToolTip" xml:space="preserve">
     <value>Click/Tap to visit the full Guide for this page on GitHub</value>
   </data>
+  <data name="GuideButtonAtTop.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Click/Tap to visit the full Guide for this page on GitHub</value>
+  </data>
   <data name="DeployAfterCreationButton.Content" xml:space="preserve">
     <value>Deploy after Creation</value>
   </data>
   <data name="DeployAfterCreationButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Toggling this button means the policy will be deployed on the system after it&apos;s been created</value>
+  </data>
+  <data name="DeployAfterCreationButton.AutomationProperties.HelpText" xml:space="preserve">
     <value>Toggling this button means the policy will be deployed on the system after it&apos;s been created</value>
   </data>
   <data name="CreateSupplementalPolicyButton.Content" xml:space="preserve">
@@ -262,10 +326,16 @@
   <data name="CreateSupplementalPolicyButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>Create the Supplemental policy based on the configurations you selected</value>
   </data>
+  <data name="CreateSupplementalPolicyButton.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Create the Supplemental policy based on the configurations you selected</value>
+  </data>
   <data name="CreateDenyPolicyButton.Content" xml:space="preserve">
     <value>Create Deny Policy</value>
   </data>
   <data name="CreateDenyPolicyButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Create the Deny policy based on the configurations you selected</value>
+  </data>
+  <data name="CreateDenyPolicyButton.AutomationProperties.HelpText" xml:space="preserve">
     <value>Create the Deny policy based on the configurations you selected</value>
   </data>
   <data name="CreateDenyPolicyFilesAndFoldersSettingsExpander.Description" xml:space="preserve">
@@ -277,6 +347,9 @@
   <data name="CreateDenyPolicyFilesAndFoldersSettingsExpander.ToolTipService.ToolTip" xml:space="preserve">
     <value>Create Deny policy by scanning files and folders</value>
   </data>
+  <data name="CreateDenyPolicyFilesAndFoldersSettingsExpander.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Create Deny policy by scanning files and folders</value>
+  </data>
   <data name="CreateDenyPolicyPFNSettingsExpander.Description" xml:space="preserve">
     <value>Create a Deny policy based on an app&apos;s Package Family Name (PFN)</value>
   </data>
@@ -284,6 +357,9 @@
     <value>Package Family Name</value>
   </data>
   <data name="CreateDenyPolicyPFNSettingsExpander.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Create a Deny policy based on an app&apos;s Package Family Name (PFN)</value>
+  </data>
+  <data name="CreateDenyPolicyPFNSettingsExpander.AutomationProperties.HelpText" xml:space="preserve">
     <value>Create a Deny policy based on an app&apos;s Package Family Name (PFN)</value>
   </data>
   <data name="AuditRuleOptionSettingsCard.Description" xml:space="preserve">
@@ -295,6 +371,9 @@
   <data name="AuditRuleOptionSettingsCard.ToolTipService.ToolTip" xml:space="preserve">
     <value>Indicates that the created/deployed policy will have (Enabled:Audit Mode) policy rule option and will generate audit logs instead of blocking files.</value>
   </data>
+  <data name="AuditRuleOptionSettingsCard.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Indicates that the created/deployed policy will have (Enabled:Audit Mode) policy rule option and will generate audit logs instead of blocking files.</value>
+  </data>
   <data name="RequireEVSignersRuleOption.Description" xml:space="preserve">
     <value>Indicates that the created/deployed policy will have (Require EV Signers) policy rule option which will only allow kernel-mode drivers signed with an EV certificate to run.</value>
   </data>
@@ -302,6 +381,9 @@
     <value>Require EVSigners</value>
   </data>
   <data name="RequireEVSignersRuleOption.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Indicates that the created/deployed policy will have (Require EV Signers) policy rule option which will only allow kernel-mode drivers signed with an EV certificate to run.</value>
+  </data>
+  <data name="RequireEVSignersRuleOption.AutomationProperties.HelpText" xml:space="preserve">
     <value>Indicates that the created/deployed policy will have (Require EV Signers) policy rule option which will only allow kernel-mode drivers signed with an EV certificate to run.</value>
   </data>
   <data name="EnableScriptEnforcementRuleOption.Description" xml:space="preserve">
@@ -313,6 +395,9 @@
   <data name="EnableScriptEnforcementRuleOption.ToolTipService.ToolTip" xml:space="preserve">
     <value>Enables script enforcement for the policy which will severely limit the attack surface of PowerShell by requiring only scripts/modules signed and allowed in the Code Integrity policy to run.</value>
   </data>
+  <data name="EnableScriptEnforcementRuleOption.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Enables script enforcement for the policy which will severely limit the attack surface of PowerShell by requiring only scripts/modules signed and allowed in the Code Integrity policy to run.</value>
+  </data>
   <data name="TestModeRuleOption.Description" xml:space="preserve">
     <value>Indicates that the created/deployed policy will have (Enabled:Boot Audit on Failure) and (Enabled:Advanced Boot Options Menu) policy rule options. Useful for testing the policy and having recovery options available when something goes wrong. Not recommended to be used in the final production-ready policy due to security reasons.</value>
   </data>
@@ -322,10 +407,16 @@
   <data name="TestModeRuleOption.ToolTipService.ToolTip" xml:space="preserve">
     <value>Indicates that the created/deployed policy will have (Enabled:Boot Audit on Failure) and (Enabled:Advanced Boot Options Menu) policy rule options. Useful for testing the policy and having recovery options available when something goes wrong. Not recommended to be used in the final production-ready policy due to security reasons.</value>
   </data>
+  <data name="TestModeRuleOption.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Indicates that the created/deployed policy will have (Enabled:Boot Audit on Failure) and (Enabled:Advanced Boot Options Menu) policy rule options. Useful for testing the policy and having recovery options available when something goes wrong. Not recommended to be used in the final production-ready policy due to security reasons.</value>
+  </data>
   <data name="FileBrowseButton.Content" xml:space="preserve">
     <value>Browse</value>
   </data>
   <data name="FileBrowseButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Opens the File picker dialog allowing you select file(s)</value>
+  </data>
+  <data name="FileBrowseButton.AutomationProperties.HelpText" xml:space="preserve">
     <value>Opens the File picker dialog allowing you select file(s)</value>
   </data>
   <data name="FolderBrowseButton.Content" xml:space="preserve">
@@ -334,16 +425,25 @@
   <data name="FolderBrowseButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>Opens the Folder picker dialog allowing you select folder(s)</value>
   </data>
+  <data name="FolderBrowseButton.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Opens the Folder picker dialog allowing you select folder(s)</value>
+  </data>
   <data name="SupplementalPolicyNameTextBox.PlaceholderText" xml:space="preserve">
     <value>Supplemental Policy Name</value>
   </data>
   <data name="SupplementalPolicyNameTextBox.ToolTipService.ToolTip" xml:space="preserve">
     <value>Enter a name for the Supplemental policy that will be created.</value>
   </data>
+  <data name="SupplementalPolicyNameTextBox.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Enter a name for the Supplemental policy that will be created.</value>
+  </data>
   <data name="SupplementalPolicyNameSettingsCard.Description" xml:space="preserve">
     <value>The name of the Supplemental policy that is going to be created.</value>
   </data>
   <data name="SupplementalPolicyNameSettingsCard.ToolTipService.ToolTip" xml:space="preserve">
+    <value>The name of the Supplemental policy that is going to be created.</value>
+  </data>
+  <data name="SupplementalPolicyNameSettingsCard.AutomationProperties.HelpText" xml:space="preserve">
     <value>The name of the Supplemental policy that is going to be created.</value>
   </data>
   <data name="SupplementalPolicyNameSettingsCard.Header" xml:space="preserve">
@@ -358,13 +458,22 @@
   <data name="SupplementalFilesAndFoldersSettingsCard.ToolTipService.ToolTip" xml:space="preserve">
     <value>Create Supplemental policy by scanning files and folders</value>
   </data>
+  <data name="SupplementalFilesAndFoldersSettingsCard.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Create Supplemental policy by scanning files and folders</value>
+  </data>
   <data name="ClearButton.Content" xml:space="preserve">
     <value>Clear</value>
   </data>
   <data name="ClearButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>Clear</value>
   </data>
+  <data name="ClearButton.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Clear</value>
+  </data>
   <data name="ReviewEventLogsNavItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Review the Event Logs that were collected during the Audit mode phase</value>
+  </data>
+  <data name="ReviewEventLogsNavItem.AutomationProperties.HelpText" xml:space="preserve">
     <value>Review the Event Logs that were collected during the Audit mode phase</value>
   </data>
   <data name="ReviewEventLogsNavItem.Content" xml:space="preserve">
@@ -376,10 +485,16 @@
   <data name="ReviewLocalFilesNavItem.ToolTipService.ToolTip" xml:space="preserve">
     <value>Review the Local Files. These are the files that were found in the directories you browsed for.</value>
   </data>
+  <data name="ReviewLocalFilesNavItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Review the Local Files. These are the files that were found in the directories you browsed for.</value>
+  </data>
   <data name="AllowNewAppsInternalMainNavItem.Content" xml:space="preserve">
     <value>Start allowing apps or files</value>
   </data>
   <data name="AllowNewAppsInternalMainNavItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Start allowing apps or files by either running them or browsing for their directories during the Audit mode phase.</value>
+  </data>
+  <data name="AllowNewAppsInternalMainNavItem.AutomationProperties.HelpText" xml:space="preserve">
     <value>Start allowing apps or files by either running them or browsing for their directories during the Audit mode phase.</value>
   </data>
   <data name="ExtraActionsDropDownButton.Content" xml:space="preserve">
@@ -388,10 +503,16 @@
   <data name="ExtraActionsDropDownButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>Offers multiple different actions to take on the displayed data</value>
   </data>
+  <data name="ExtraActionsDropDownButton.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Offers multiple different actions to take on the displayed data</value>
+  </data>
   <data name="ClearDataMenuFlyoutItem.Text" xml:space="preserve">
     <value>Clear Data</value>
   </data>
   <data name="ClearDataMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Clear all of the displayed data</value>
+  </data>
+  <data name="ClearDataMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
     <value>Clear all of the displayed data</value>
   </data>
   <data name="DeployAfterCreationMenuFlyoutItem.Text" xml:space="preserve">
@@ -400,10 +521,16 @@
   <data name="DeployAfterCreationMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
     <value>Toggling this button means the policy will be deployed on the system after it&apos;s been created</value>
   </data>
+  <data name="DeployAfterCreationMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Toggling this button means the policy will be deployed on the system after it&apos;s been created</value>
+  </data>
   <data name="SearchBoxTextBox.PlaceholderText" xml:space="preserve">
     <value>Search the data...</value>
   </data>
   <data name="SearchBoxTextBox.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Search among the displayed data</value>
+  </data>
+  <data name="SearchBoxTextBox.AutomationProperties.HelpText" xml:space="preserve">
     <value>Search among the displayed data</value>
   </data>
   <data name="DeSelectAllMenuFlyoutItem.Text" xml:space="preserve">
@@ -412,10 +539,16 @@
   <data name="DeSelectAllMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
     <value>De-select any selected data</value>
   </data>
+  <data name="DeSelectAllMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>De-select any selected data</value>
+  </data>
   <data name="SelectAllMenuFlyoutItem.Text" xml:space="preserve">
     <value>Select All</value>
   </data>
   <data name="SelectAllMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Select all of the displayed data</value>
+  </data>
+  <data name="SelectAllMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
     <value>Select all of the displayed data</value>
   </data>
   <data name="SelectAllButton.Content" xml:space="preserve">
@@ -424,10 +557,16 @@
   <data name="SelectAllButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>Select all</value>
   </data>
+  <data name="SelectAllButton.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Select all</value>
+  </data>
   <data name="RefreshButton.Content" xml:space="preserve">
     <value>Refresh</value>
   </data>
   <data name="RefreshButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+  <data name="RefreshButton.AutomationProperties.HelpText" xml:space="preserve">
     <value>Refresh</value>
   </data>
   <data name="RemoveSelectionsButton.Content" xml:space="preserve">
@@ -436,10 +575,16 @@
   <data name="RemoveSelectionsButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>Remove Selections</value>
   </data>
+  <data name="RemoveSelectionsButton.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Remove Selections</value>
+  </data>
   <data name="SelectedAppsTextBlock.Text" xml:space="preserve">
     <value>Selected Apps: 0</value>
   </data>
   <data name="SelectedAppsTextBlock.ToolTipService.ToolTip" xml:space="preserve">
+    <value>The total number of the selected Apps</value>
+  </data>
+  <data name="SelectedAppsTextBlock.AutomationProperties.HelpText" xml:space="preserve">
     <value>The total number of the selected Apps</value>
   </data>
   <data name="BrowseForFoldersDenyPolicySettingsCard.Description" xml:space="preserve">
@@ -451,6 +596,9 @@
   <data name="BrowseForFoldersDenyPolicySettingsCard.ToolTipService.ToolTip" xml:space="preserve">
     <value>Browse for Folder paths to scan and include in the Deny policy. The folders will be scanned recursively.</value>
   </data>
+  <data name="BrowseForFoldersDenyPolicySettingsCard.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Browse for Folder paths to scan and include in the Deny policy. The folders will be scanned recursively.</value>
+  </data>
   <data name="BrowseForFilesDenyPolicySettingsCard.Description" xml:space="preserve">
     <value>Browse for file paths to scan and include in the Deny policy.</value>
   </data>
@@ -460,6 +608,9 @@
   <data name="BrowseForFilesDenyPolicySettingsCard.ToolTipService.ToolTip" xml:space="preserve">
     <value>Browse for file paths to scan and include in the Deny policy.</value>
   </data>
+  <data name="BrowseForFilesDenyPolicySettingsCard.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Browse for file paths to scan and include in the Deny policy.</value>
+  </data>
   <data name="DenyPolicyNameSettingsCard.Description" xml:space="preserve">
     <value>The name of the Deny policy that is going to be created.</value>
   </data>
@@ -467,6 +618,9 @@
     <value>Policy Name</value>
   </data>
   <data name="DenyPolicyNameSettingsCard.ToolTipService.ToolTip" xml:space="preserve">
+    <value>The name of the Deny policy that is going to be created.</value>
+  </data>
+  <data name="DenyPolicyNameSettingsCard.AutomationProperties.HelpText" xml:space="preserve">
     <value>The name of the Deny policy that is going to be created.</value>
   </data>
   <data name="ViewSelectedBasePolicyTextBlock.Text" xml:space="preserve">
@@ -484,10 +638,16 @@
   <data name="TotalLogsTextBlock.ToolTipService.ToolTip" xml:space="preserve">
     <value>The total number of the logs</value>
   </data>
+  <data name="TotalLogsTextBlock.AutomationProperties.HelpText" xml:space="preserve">
+    <value>The total number of the logs</value>
+  </data>
   <data name="RefreshLogFilesButton.Content" xml:space="preserve">
     <value>Refresh The Logs</value>
   </data>
   <data name="RefreshLogFilesButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Retrieve the latest logs for the current session by reading them from the log file in the user configurations directory</value>
+  </data>
+  <data name="RefreshLogFilesButton.AutomationProperties.HelpText" xml:space="preserve">
     <value>Retrieve the latest logs for the current session by reading them from the log file in the user configurations directory</value>
   </data>
   <data name="MainSearchAutoSuggestBox.PlaceholderText" xml:space="preserve">
@@ -496,7 +656,13 @@
   <data name="MainSearchAutoSuggestBox.ToolTipService.ToolTip" xml:space="preserve">
     <value>Enter menu item names to find them quickly</value>
   </data>
+  <data name="MainSearchAutoSuggestBox.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Enter menu item names to find them quickly</value>
+  </data>
   <data name="UpdateNavItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Check for updates</value>
+  </data>
+  <data name="UpdateNavItem.AutomationProperties.HelpText" xml:space="preserve">
     <value>Check for updates</value>
   </data>
   <data name="UpdateNavItem.Content" xml:space="preserve">
@@ -505,10 +671,16 @@
   <data name="OpenConfigDirectoryButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>Open the directory where user configurations and user generated files are stored</value>
   </data>
+  <data name="OpenConfigDirectoryButton.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Open the directory where user configurations and user generated files are stored</value>
+  </data>
   <data name="OpenConfigDirectoryButtonText.Text" xml:space="preserve">
     <value>Open User Config Directory</value>
   </data>
   <data name="ResetStepsButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Will reset the steps and if the base policy is deployed in Audit mode, will redeploy it in Enforced mode.</value>
+  </data>
+  <data name="ResetStepsButton.AutomationProperties.HelpText" xml:space="preserve">
     <value>Will reset the steps and if the base policy is deployed in Audit mode, will redeploy it in Enforced mode.</value>
   </data>
   <data name="ResetStepsButton.Content" xml:space="preserve">
@@ -526,10 +698,16 @@
   <data name="AllowNewAppsCreatePolicyButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>Start creating the policy with the logs and files you selected</value>
   </data>
+  <data name="AllowNewAppsCreatePolicyButton.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Start creating the policy with the logs and files you selected</value>
+  </data>
   <data name="AllowNewAppsCreatePolicyButton.Content" xml:space="preserve">
     <value>Create Policy</value>
   </data>
   <data name="LogSizeNumberBox.ToolTipService.ToolTip" xml:space="preserve">
+    <value>This is the Maximum Capacity of the Code Integrity Operational Log Size</value>
+  </data>
+  <data name="LogSizeNumberBox.AutomationProperties.HelpText" xml:space="preserve">
     <value>This is the Maximum Capacity of the Code Integrity Operational Log Size</value>
   </data>
   <data name="LogSizeNumberBox.Header" xml:space="preserve">
@@ -547,7 +725,13 @@
   <data name="PickPolicyFileButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>Click/Tap to choose a XML policy file from your device</value>
   </data>
+  <data name="PickPolicyFileButton.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Click/Tap to choose a XML policy file from your device</value>
+  </data>
   <data name="ScanLevelComboBox.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Pick a level based on which the Files/Logs will be scanned</value>
+  </data>
+  <data name="ScanLevelComboBox.AutomationProperties.HelpText" xml:space="preserve">
     <value>Pick a level based on which the Files/Logs will be scanned</value>
   </data>
   <data name="WebViewBackButton.Text" xml:space="preserve">
@@ -574,10 +758,16 @@
   <data name="SaveAppBarButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>Save</value>
   </data>
+  <data name="SaveAppBarButton.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Save</value>
+  </data>
   <data name="BrowseAppBarButton.Label" xml:space="preserve">
     <value>Browse</value>
   </data>
   <data name="BrowseAppBarButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Browse</value>
+  </data>
+  <data name="BrowseAppBarButton.AutomationProperties.HelpText" xml:space="preserve">
     <value>Browse</value>
   </data>
   <data name="ClearAppBarButton.Label" xml:space="preserve">
@@ -586,10 +776,16 @@
   <data name="ClearAppBarButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>Clear</value>
   </data>
+  <data name="ClearAppBarButton.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Clear</value>
+  </data>
   <data name="RefreshAppBarButton.Label" xml:space="preserve">
     <value>Refresh</value>
   </data>
   <data name="RefreshAppBarButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Fetches the latest certificate common names from the User&apos;s personal certificate store</value>
+  </data>
+  <data name="RefreshAppBarButton.AutomationProperties.HelpText" xml:space="preserve">
     <value>Fetches the latest certificate common names from the User&apos;s personal certificate store</value>
   </data>
   <data name="BackgroundStyleSettingsCard.Description" xml:space="preserve">
@@ -601,6 +797,9 @@
   <data name="BackgroundStyleSettingsCard.ToolTipService.ToolTip" xml:space="preserve">
     <value>This is the backdrop of the AppControl Manager. The changes will be visible in the background.</value>
   </data>
+  <data name="BackgroundStyleSettingsCard.AutomationProperties.HelpText" xml:space="preserve">
+    <value>This is the backdrop of the AppControl Manager. The changes will be visible in the background.</value>
+  </data>
   <data name="MainNavigationIconsSettingsCard.Description" xml:space="preserve">
     <value>Choose a style for the main navigation icons</value>
   </data>
@@ -608,6 +807,9 @@
     <value>Icons Style</value>
   </data>
   <data name="MainNavigationIconsSettingsCard.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Pick a style for the main navigation&apos;s icons.</value>
+  </data>
+  <data name="MainNavigationIconsSettingsCard.AutomationProperties.HelpText" xml:space="preserve">
     <value>Pick a style for the main navigation&apos;s icons.</value>
   </data>
   <data name="AppThemeSettingsCard.Description" xml:space="preserve">
@@ -619,6 +821,9 @@
   <data name="AppThemeSettingsCard.ToolTipService.ToolTip" xml:space="preserve">
     <value>Select a theme for the AppControl Manager</value>
   </data>
+  <data name="AppThemeSettingsCard.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Select a theme for the AppControl Manager</value>
+  </data>
   <data name="MainNavigationLocationSettingsCard.Description" xml:space="preserve">
     <value>Customize the Navigation Menu location</value>
   </data>
@@ -626,6 +831,9 @@
     <value>Navigation Menu</value>
   </data>
   <data name="MainNavigationLocationSettingsCard.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Select a location for the navigation menu</value>
+  </data>
+  <data name="MainNavigationLocationSettingsCard.AutomationProperties.HelpText" xml:space="preserve">
     <value>Select a location for the navigation menu</value>
   </data>
   <data name="AppSoundSettingSettingsCard.Description" xml:space="preserve">
@@ -637,6 +845,9 @@
   <data name="AppSoundSettingSettingsCard.ToolTipService.ToolTip" xml:space="preserve">
     <value>Hear audio feedback when using different elements of the AppControl Manager</value>
   </data>
+  <data name="AppSoundSettingSettingsCard.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Hear audio feedback when using different elements of the AppControl Manager</value>
+  </data>
   <data name="DarkerBackGroundSettingsCard.Description" xml:space="preserve">
     <value>Mostly suitable when using MicaAlt as the background.</value>
   </data>
@@ -644,6 +855,9 @@
     <value>Darker Background</value>
   </data>
   <data name="DarkerBackGroundSettingsCard.ToolTipService.ToolTip" xml:space="preserve">
+    <value>It will remove the extra light shadow from the background, giving an overall darker look to the AppControl Manager&apos;s appearance.</value>
+  </data>
+  <data name="DarkerBackGroundSettingsCard.AutomationProperties.HelpText" xml:space="preserve">
     <value>It will remove the extra light shadow from the background, giving an overall darker look to the AppControl Manager&apos;s appearance.</value>
   </data>
   <data name="UserConfigurations.Text" xml:space="preserve">
@@ -683,6 +897,9 @@
     <value>Scan Logs</value>
   </data>
   <data name="ScanLogsButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Scan the system or the selected EVTX files for Code Integrity/AppLocker logs</value>
+  </data>
+  <data name="ScanLogsButton.AutomationProperties.HelpText" xml:space="preserve">
     <value>Scan the system or the selected EVTX files for Code Integrity/AppLocker logs</value>
   </data>
   <data name="RuleOption_EnabledUMCI" xml:space="preserve">
@@ -1372,6 +1589,9 @@ NOTE: This option is always enforced if any App Control UMCI policy enables it. 
   <data name="SupplementalPolicyCustomPatternBasedFileRuleActualPatternSettingsCard.ToolTipService.ToolTip" xml:space="preserve">
     <value>Use this section to enter a custom pattern-based file rule to add to the supplemental policy.</value>
   </data>
+  <data name="SupplementalPolicyCustomPatternBasedFileRuleActualPatternSettingsCard.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Use this section to enter a custom pattern-based file rule to add to the supplemental policy.</value>
+  </data>
   <data name="SupplementalPolicyCustomPatternBasedFileRuleActualPatternSettingsCard.Header" xml:space="preserve">
     <value>Custom Pattern-based File Rule</value>
   </data>
@@ -1379,6 +1599,9 @@ NOTE: This option is always enforced if any App Control UMCI policy enables it. 
     <value>Click/Tap here to see more information about the patterns you can use</value>
   </data>
   <data name="CustomPatternBasedFileRuleInfoSettingsCard.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Click/Tap here to see more information about the patterns you can use</value>
+  </data>
+  <data name="CustomPatternBasedFileRuleInfoSettingsCard.AutomationProperties.HelpText" xml:space="preserve">
     <value>Click/Tap here to see more information about the patterns you can use</value>
   </data>
   <data name="CustomPatternBasedFileRuleInfoSettingsCard.Header" xml:space="preserve">
@@ -1390,10 +1613,16 @@ NOTE: This option is always enforced if any App Control UMCI policy enables it. 
   <data name="SupplementalPolicyCustomPatternBasedCustomPatternTextBox.ToolTipService.ToolTip" xml:space="preserve">
     <value>Enter a custom matching pattern for file rules. All of the file paths that match this pattern will be allowed by the Supplemental policy.</value>
   </data>
+  <data name="SupplementalPolicyCustomPatternBasedCustomPatternTextBox.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Enter a custom matching pattern for file rules. All of the file paths that match this pattern will be allowed by the Supplemental policy.</value>
+  </data>
   <data name="SupplementalPolicyCustomPatternBasedFileRuleSettingsExpander.Description" xml:space="preserve">
     <value>Create a supplemental policy that uses custom pattern-based file rule.</value>
   </data>
   <data name="SupplementalPolicyCustomPatternBasedFileRuleSettingsExpander.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Create a supplemental policy that uses custom pattern-based file rule.</value>
+  </data>
+  <data name="SupplementalPolicyCustomPatternBasedFileRuleSettingsExpander.AutomationProperties.HelpText" xml:space="preserve">
     <value>Create a supplemental policy that uses custom pattern-based file rule.</value>
   </data>
   <data name="SupplementalPolicyCustomPatternBasedFileRuleSettingsExpander.Header" xml:space="preserve">
@@ -1405,6 +1634,9 @@ NOTE: This option is always enforced if any App Control UMCI policy enables it. 
   <data name="DenyPolicyCustomPatternBasedFileRuleActualPatternSettingsCard.ToolTipService.ToolTip" xml:space="preserve">
     <value>Use this section to enter a custom pattern-based file rule to add to the Deny policy.</value>
   </data>
+  <data name="DenyPolicyCustomPatternBasedFileRuleActualPatternSettingsCard.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Use this section to enter a custom pattern-based file rule to add to the Deny policy.</value>
+  </data>
   <data name="DenyPolicyCustomPatternBasedFileRuleActualPatternSettingsCard.Header" xml:space="preserve">
     <value>Custom Pattern-based File Rule</value>
   </data>
@@ -1414,10 +1646,16 @@ NOTE: This option is always enforced if any App Control UMCI policy enables it. 
   <data name="DenyPolicyCustomPatternBasedCustomPatternTextBox.ToolTipService.ToolTip" xml:space="preserve">
     <value>Enter a custom matching pattern for file rules. All of the file paths that match this pattern will be denied by the Deny policy.</value>
   </data>
+  <data name="DenyPolicyCustomPatternBasedCustomPatternTextBox.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Enter a custom matching pattern for file rules. All of the file paths that match this pattern will be denied by the Deny policy.</value>
+  </data>
   <data name="DenyPolicyCustomPatternBasedFileRuleSettingsExpander.Description" xml:space="preserve">
     <value>Create a Deny policy that uses custom pattern-based file rule.</value>
   </data>
   <data name="DenyPolicyCustomPatternBasedFileRuleSettingsExpander.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Create a Deny policy that uses custom pattern-based file rule.</value>
+  </data>
+  <data name="DenyPolicyCustomPatternBasedFileRuleSettingsExpander.AutomationProperties.HelpText" xml:space="preserve">
     <value>Create a Deny policy that uses custom pattern-based file rule.</value>
   </data>
   <data name="DenyPolicyCustomPatternBasedFileRuleSettingsExpander.Header" xml:space="preserve">
@@ -1432,6 +1670,9 @@ NOTE: This option is always enforced if any App Control UMCI policy enables it. 
   <data name="NoMSRecommendedBlockRules.ToolTipService.ToolTip" xml:space="preserve">
     <value>Using this option means the Microsoft Recommended (User-Mode) Block Rules will not be created/deployed along with the base policy. (Not Recommended)</value>
   </data>
+  <data name="NoMSRecommendedBlockRules.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Using this option means the Microsoft Recommended (User-Mode) Block Rules will not be created/deployed along with the base policy. (Not Recommended)</value>
+  </data>
   <data name="BehaviorSettingSettingsExpander.Header" xml:space="preserve">
     <value>Change the behavior of the AppControl Manager and various elements inside of it</value>
   </data>
@@ -1439,6 +1680,9 @@ NOTE: This option is always enforced if any App Control UMCI policy enables it. 
     <value>Behavior</value>
   </data>
   <data name="BehaviorSettingSettingsExpander.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Change the behavior of the AppControl Manager and various elements inside of it</value>
+  </data>
+  <data name="BehaviorSettingSettingsExpander.AutomationProperties.HelpText" xml:space="preserve">
     <value>Change the behavior of the AppControl Manager and various elements inside of it</value>
   </data>
   <data name="ListViewsCenterVerticallyUponSelectionSettingsCard.Description" xml:space="preserve">
@@ -1450,6 +1694,9 @@ NOTE: This option is always enforced if any App Control UMCI policy enables it. 
   <data name="ListViewsCenterVerticallyUponSelectionSettingsCard.ToolTipService.ToolTip" xml:space="preserve">
     <value>Whenever you select an item in a List View, center that item vertically on the screen.</value>
   </data>
+  <data name="ListViewsCenterVerticallyUponSelectionSettingsCard.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Whenever you select an item in a List View, center that item vertically on the screen.</value>
+  </data>
   <data name="CacheSecurityCatalogsScanResultsSettingsCard.Description" xml:space="preserve">
     <value>Cache the results of the security catalogs scan for 5 minutes before scanning them again. This can improve scan performance within the app.</value>
   </data>
@@ -1459,10 +1706,16 @@ NOTE: This option is always enforced if any App Control UMCI policy enables it. 
   <data name="CacheSecurityCatalogsScanResultsSettingsCard.ToolTipService.ToolTip" xml:space="preserve">
     <value>Cache the results of the security catalogs scan for 5 minutes before scanning them again. This can improve scan performance within the app.</value>
   </data>
+  <data name="CacheSecurityCatalogsScanResultsSettingsCard.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Cache the results of the security catalogs scan for 5 minutes before scanning them again. This can improve scan performance within the app.</value>
+  </data>
   <data name="PolicyEditorNavItem.Content" xml:space="preserve">
     <value>Policy Editor</value>
   </data>
   <data name="PolicyEditorNavItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Edit App Control policies, view and remove individual rules and modify other details.</value>
+  </data>
+  <data name="PolicyEditorNavItem.AutomationProperties.HelpText" xml:space="preserve">
     <value>Edit App Control policies, view and remove individual rules and modify other details.</value>
   </data>
   <data name="PromptForElevationSettingsCard.Description" xml:space="preserve">
@@ -1473,5 +1726,26 @@ NOTE: This option is always enforced if any App Control UMCI policy enables it. 
   </data>
   <data name="PromptForElevationSettingsCard.ToolTipService.ToolTip" xml:space="preserve">
     <value>If this is enabled, AppControl Manager will prompt for elevation to run with Administrator privileges on startup.</value>
+  </data>
+  <data name="PromptForElevationSettingsCard.AutomationProperties.HelpText" xml:space="preserve">
+    <value>If this is enabled, AppControl Manager will prompt for elevation to run with Administrator privileges on startup.</value>
+  </data>
+  <data name="OpenInPolicyEditorButton.Content" xml:space="preserve">
+    <value>Open In The Policy Editor</value>
+  </data>
+  <data name="OpenInPolicyEditorButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Open the policy in the Policy Editor where you can see detailed overview of the policy and have the option to customize it further right inside of this app.</value>
+  </data>
+  <data name="OpenInPolicyEditorButton.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Open the policy in the Policy Editor where you can see detailed overview of the policy and have the option to customize it further right inside of this app.</value>
+  </data>
+  <data name="OnlyIncludeSelectedItemsToggleButton.Content" xml:space="preserve">
+    <value>Only Use Selected Items</value>
+  </data>
+  <data name="OnlyIncludeSelectedItemsToggleButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Only include the selected items in the supplemental policy. You can select one or more items in the ListView and if this option is enabled, only those will be included in the supplemental policy. If this is disabled, everything will be included in the supplemental policy. If you use this option and nothing is selected in the ListView, everything will be included in the supplemental policy.</value>
+  </data>
+  <data name="OnlyIncludeSelectedItemsToggleButton.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Only include the selected items in the supplemental policy. You can select one or more items in the ListView and if this option is enabled, only those will be included in the supplemental policy. If this is disabled, everything will be included in the supplemental policy. If you use this option and nothing is selected in the ListView, everything will be included in the supplemental policy.</value>
   </data>
 </root>

--- a/AppControl Manager/ViewModels/AllowNewAppsVM.cs
+++ b/AppControl Manager/ViewModels/AllowNewAppsVM.cs
@@ -64,6 +64,13 @@ internal sealed partial class AllowNewAppsVM : INotifyPropertyChanged
 
 	#region UI-Bound Properties
 
+	private Visibility _OpenInPolicyEditorInfoBarActionButtonVisibility = Visibility.Collapsed;
+	internal Visibility OpenInPolicyEditorInfoBarActionButtonVisibility
+	{
+		get => _OpenInPolicyEditorInfoBarActionButtonVisibility;
+		set => SetProperty(_OpenInPolicyEditorInfoBarActionButtonVisibility, value, newValue => _OpenInPolicyEditorInfoBarActionButtonVisibility = newValue);
+	}
+
 	/// <summary>
 	/// Holds the state of the Event Logs menu item, indicating whether it is enabled or disabled.
 	/// </summary>

--- a/AppControl Manager/ViewModels/CreatePolicyVM.cs
+++ b/AppControl Manager/ViewModels/CreatePolicyVM.cs
@@ -1,0 +1,102 @@
+// MIT License
+//
+// Copyright (c) 2023-Present - Violet Hansen - (aka HotCakeX on GitHub) - Email Address: spynetgirl@outlook.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// See here for more information: https://github.com/HotCakeX/Harden-Windows-Security/blob/main/LICENSE
+//
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Microsoft.UI.Xaml;
+
+namespace AppControlManager.ViewModels;
+
+#pragma warning disable CA1812 // an internal class that is apparently never instantiated
+// It's handled by Dependency Injection so this warning is a false-positive.
+internal sealed partial class CreatePolicyVM : INotifyPropertyChanged
+{
+	public event PropertyChangedEventHandler? PropertyChanged;
+
+	// private readonly DispatcherQueue Dispatch = DispatcherQueue.GetForCurrentThread();
+
+
+	#region UI-Bound Properties
+
+	private Visibility _AllowMicrosoftInfoBarActionButtonVisibility = Visibility.Collapsed;
+	internal Visibility AllowMicrosoftInfoBarActionButtonVisibility
+	{
+		get => _AllowMicrosoftInfoBarActionButtonVisibility;
+		set => SetProperty(_AllowMicrosoftInfoBarActionButtonVisibility, value, newValue => _AllowMicrosoftInfoBarActionButtonVisibility = newValue);
+	}
+
+
+	private Visibility _DefaultWindowsInfoBarActionButtonVisibility = Visibility.Collapsed;
+	internal Visibility DefaultWindowsInfoBarActionButtonVisibility
+	{
+		get => _DefaultWindowsInfoBarActionButtonVisibility;
+		set => SetProperty(_DefaultWindowsInfoBarActionButtonVisibility, value, newValue => _DefaultWindowsInfoBarActionButtonVisibility = newValue);
+	}
+
+	private Visibility _SignedAndReputableInfoBarActionButtonVisibility = Visibility.Collapsed;
+	internal Visibility SignedAndReputableInfoBarActionButtonVisibility
+	{
+		get => _SignedAndReputableInfoBarActionButtonVisibility;
+		set => SetProperty(_SignedAndReputableInfoBarActionButtonVisibility, value, newValue => _SignedAndReputableInfoBarActionButtonVisibility = newValue);
+	}
+
+	private Visibility _MSFTRecommendedDriverBlockRulesInfoBarActionButtonVisibility = Visibility.Collapsed;
+	internal Visibility MSFTRecommendedDriverBlockRulesInfoBarActionButtonVisibility
+	{
+		get => _MSFTRecommendedDriverBlockRulesInfoBarActionButtonVisibility;
+		set => SetProperty(_MSFTRecommendedDriverBlockRulesInfoBarActionButtonVisibility, value, newValue => _MSFTRecommendedDriverBlockRulesInfoBarActionButtonVisibility = newValue);
+	}
+
+	private Visibility _StrictKernelModeInfoBarActionButtonVisibility = Visibility.Collapsed;
+	internal Visibility StrictKernelModeInfoBarActionButtonVisibility
+	{
+		get => _StrictKernelModeInfoBarActionButtonVisibility;
+		set => SetProperty(_StrictKernelModeInfoBarActionButtonVisibility, value, newValue => _StrictKernelModeInfoBarActionButtonVisibility = newValue);
+	}
+
+	#endregion
+
+
+
+
+	/// <summary>
+	/// Sets the property and raises the PropertyChanged event if the value has changed.
+	/// This also prevents infinite loops where a property raises OnPropertyChanged which could trigger an update in the UI, and the UI might call set again, leading to an infinite loop.
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	/// <param name="currentValue"></param>
+	/// <param name="newValue"></param>
+	/// <param name="setter"></param>
+	/// <param name="propertyName"></param>
+	/// <returns></returns>
+	private bool SetProperty<T>(T currentValue, T newValue, Action<T> setter, [CallerMemberName] string? propertyName = null)
+	{
+		if (EqualityComparer<T>.Default.Equals(currentValue, newValue))
+			return false;
+		setter(newValue);
+		OnPropertyChanged(propertyName);
+		return true;
+	}
+
+
+	private void OnPropertyChanged(string? propertyName)
+	{
+		PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+	}
+}

--- a/AppControl Manager/ViewModels/EventLogsPolicyCreationVM.cs
+++ b/AppControl Manager/ViewModels/EventLogsPolicyCreationVM.cs
@@ -47,6 +47,12 @@ internal sealed partial class EventLogsPolicyCreationVM : INotifyPropertyChanged
 
 	#region UI-Bound Properties
 
+	private Visibility _OpenInPolicyEditorInfoBarActionButtonVisibility = Visibility.Collapsed;
+	internal Visibility OpenInPolicyEditorInfoBarActionButtonVisibility
+	{
+		get => _OpenInPolicyEditorInfoBarActionButtonVisibility;
+		set => SetProperty(_OpenInPolicyEditorInfoBarActionButtonVisibility, value, newValue => _OpenInPolicyEditorInfoBarActionButtonVisibility = newValue);
+	}
 
 	#endregion
 

--- a/AppControl Manager/ViewModels/MDEAHPolicyCreationVM.cs
+++ b/AppControl Manager/ViewModels/MDEAHPolicyCreationVM.cs
@@ -47,6 +47,12 @@ internal sealed partial class MDEAHPolicyCreationVM : INotifyPropertyChanged
 
 	#region UI-Bound Properties
 
+	private Visibility _OpenInPolicyEditorInfoBarActionButtonVisibility = Visibility.Collapsed;
+	internal Visibility OpenInPolicyEditorInfoBarActionButtonVisibility
+	{
+		get => _OpenInPolicyEditorInfoBarActionButtonVisibility;
+		set => SetProperty(_OpenInPolicyEditorInfoBarActionButtonVisibility, value, newValue => _OpenInPolicyEditorInfoBarActionButtonVisibility = newValue);
+	}
 
 	#endregion
 

--- a/AppControl Manager/ViewModels/ViewCurrentPoliciesVM.cs
+++ b/AppControl Manager/ViewModels/ViewCurrentPoliciesVM.cs
@@ -453,7 +453,7 @@ internal sealed partial class ViewCurrentPoliciesVM : INotifyPropertyChanged
 				{
 					case 0: // Default Windows
 						{
-							BasePolicyCreator.BuildDefaultWindows(
+							_ = BasePolicyCreator.BuildDefaultWindows(
 							StagingArea: stagingArea,
 							IsAudit: false,
 							LogSize: null,
@@ -470,7 +470,7 @@ internal sealed partial class ViewCurrentPoliciesVM : INotifyPropertyChanged
 						}
 					case 1: // Allow Microsoft
 						{
-							BasePolicyCreator.BuildAllowMSFT(
+							_ = BasePolicyCreator.BuildAllowMSFT(
 							StagingArea: stagingArea,
 							IsAudit: false,
 							LogSize: null,
@@ -487,7 +487,7 @@ internal sealed partial class ViewCurrentPoliciesVM : INotifyPropertyChanged
 						}
 					case 2: // Signed and Reputable
 						{
-							BasePolicyCreator.BuildSignedAndReputable(
+							_ = BasePolicyCreator.BuildSignedAndReputable(
 							StagingArea: stagingArea,
 							IsAudit: false,
 							LogSize: null,
@@ -504,7 +504,7 @@ internal sealed partial class ViewCurrentPoliciesVM : INotifyPropertyChanged
 						}
 					case 3: // Strict Kernel-Mode
 						{
-							BasePolicyCreator.BuildStrictKernelMode(
+							_ = BasePolicyCreator.BuildStrictKernelMode(
 								StagingArea: stagingArea,
 								IsAudit: false,
 								NoFlightRoots: false,
@@ -515,7 +515,7 @@ internal sealed partial class ViewCurrentPoliciesVM : INotifyPropertyChanged
 						}
 					case 4: // Strict Kernel-Mode(No Flight Roots)
 						{
-							BasePolicyCreator.BuildStrictKernelMode(
+							_ = BasePolicyCreator.BuildStrictKernelMode(
 								StagingArea: stagingArea,
 								IsAudit: false,
 								NoFlightRoots: true,


### PR DESCRIPTION
# What's New

* Added a new message bar to the [Create Policy From Event Logs](https://github.com/HotCakeX/Harden-Windows-Security/wiki/Create-Policy-From-Event-Logs) to show real time messages about the currently running processes.

* Added a new button called `Only Use Selected Items` to the [Create Policy From Event Logs](https://github.com/HotCakeX/Harden-Windows-Security/wiki/Create-Policy-From-Event-Logs) and [Create Policy From MDE Advanced Hunting](https://github.com/HotCakeX/Harden-Windows-Security/wiki/Create-Policy-From-MDE-Advanced-Hunting) pages. The following is the description of the button:

  * Only include the selected items in the supplemental policy. You can select one or more items in the ListView and if this option is enabled, only those will be included in the supplemental policy. If this is disabled, everything will be included in the supplemental policy. If you use this option and nothing is selected in the ListView, everything will be included in the supplemental policy.

* Added a Progress Ring to the [Policy Editor](https://github.com/HotCakeX/Harden-Windows-Security/wiki/PolicyEditor) page to show the progress when a policy is being loaded.

* Added additional helpful insights to many UI elements for accessibility purposes so tools such as screen readers will be able to use them to generate proper feedback for people that need them.

* Added more messages to the message bar in the [Create Policy From MDE Advanced Hunting](https://github.com/HotCakeX/Harden-Windows-Security/wiki/Create-Policy-From-MDE-Advanced-Hunting) page. They offer more information about the current operation and its progress.

* Added a button called `Open In The Policy Editor` to the following pages:

  * [Create AppControl Policy](https://github.com/HotCakeX/Harden-Windows-Security/wiki/Create-App-Control-Policy)

  * [Allow New Apps](https://github.com/HotCakeX/Harden-Windows-Security/wiki/Allow-New-Apps)
  
  * [Create Policy From Event Logs](https://github.com/HotCakeX/Harden-Windows-Security/wiki/Create-Policy-From-Event-Logs)
  
  * [Create Policy From MDE Advanced Hunting](https://github.com/HotCakeX/Harden-Windows-Security/wiki/Create-Policy-From-MDE-Advanced-Hunting)


This feature enables users to seamlessly open newly created policies directly in the [Policy Editor](https://github.com/HotCakeX/Harden-Windows-Security/wiki/PolicyEditor), offering a detailed overview of the policy, its associated rules, and the ability to refine and customize it further. By streamlining this workflow, the feature significantly reduces friction and enhances the overall user experience. **The button only appears at the end of the operation on the message bars of each section.**

<br>
