### PR TITLE
EAF compatibility and package manifest improvements in AppControl Manager

### DIFF
--- a/AppControl Manager/App.xaml.cs
+++ b/AppControl Manager/App.xaml.cs
@@ -16,7 +16,6 @@
 //
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -48,12 +47,23 @@ public partial class App : Application
 
 
 	/// <summary>
+	/// Package Family Name of the application
+	/// </summary>
+	private static readonly string PFN = Package.Current.Id.FamilyName;
+
+	/// <summary>
+	/// The App User Model ID which is in the format of PackageFamilyName!App
+	/// The "App" is what's defined in the Package.appxmanifest file for ID in Application Id="App"
+	/// </summary>
+	internal static readonly string AUMID = AppInfo.Current.AppUserModelId;
+
+	/// <summary>
 	/// Detects the source of the application.
 	/// GitHub => 0
 	/// Microsoft Store => 1
 	/// Unknown => 2
 	/// </summary>
-	internal static readonly int PackageSource = string.Equals(Package.Current.Id.FamilyName, "AppControlManager_sadt7br7jpt02", StringComparison.OrdinalIgnoreCase) ? 0 : (string.Equals(Package.Current.Id.FamilyName, "VioletHansen.AppControlManager_ea7andspwdn10", StringComparison.OrdinalIgnoreCase) ? 1 : 2);
+	internal static readonly int PackageSource = string.Equals(PFN, "AppControlManager_sadt7br7jpt02", StringComparison.OrdinalIgnoreCase) ? 0 : (string.Equals(PFN, "VioletHansen.AppControlManager_ea7andspwdn10", StringComparison.OrdinalIgnoreCase) ? 1 : 2);
 
 
 	/// <summary>
@@ -129,10 +139,11 @@ public partial class App : Application
 	/// </summary>
 	internal App()
 	{
+
 		// If the current session is not elevated and user configured the app to ask for elevation on startup
 		if (!IsElevated && Settings.PromptForElevationOnStartup)
 		{
-
+			/*
 			ProcessStartInfo processInfo = new()
 			{
 				FileName = Environment.ProcessPath,
@@ -153,6 +164,19 @@ public partial class App : Application
 				// Do nothing if the user cancels the UAC prompt.
 				Logger.Write("User canceled the UAC prompt.");
 			}
+			catch (System.ComponentModel.Win32Exception ex)
+			{
+				Logger.Write(ErrorWriter.FormatException(ex));
+				Logger.Write($"Win32Exception.NativeErrorCode: {ex.NativeErrorCode}");
+			}
+			catch (Exception ex)
+			{
+				Logger.Write(ErrorWriter.FormatException(ex));
+			}
+			finally
+			{
+				processStartResult?.Dispose();
+			}
 
 			// Explicitly exit the current instance only after launching the elevated instance
 			if (processStartResult is not null)
@@ -162,6 +186,15 @@ public partial class App : Application
 				// Exit the process
 				Environment.Exit(0);
 			}
+
+			*/
+
+			if (ReLaunch.Action())
+			{
+				// Exit the process
+				Environment.Exit(0);
+			}
+
 		}
 
 		this.InitializeComponent();

--- a/AppControl Manager/AppControl Manager.csproj
+++ b/AppControl Manager/AppControl Manager.csproj
@@ -87,7 +87,7 @@
     <PublishAot>True</PublishAot>
     <OptimizationPreference>Speed</OptimizationPreference>
     <ErrorReport>send</ErrorReport>
-    <FileVersion>1.9.9.0</FileVersion>
+    <FileVersion>2.0.0.0</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/AppControl Manager/AppControlManagerAPIDocumentation.xml
+++ b/AppControl Manager/AppControlManagerAPIDocumentation.xml
@@ -1187,6 +1187,17 @@
             Provides application-specific behavior to supplement the default Application class.
             </summary>
         </member>
+        <member name="F:AppControlManager.App.PFN">
+            <summary>
+            Package Family Name of the application
+            </summary>
+        </member>
+        <member name="F:AppControlManager.App.AUMID">
+            <summary>
+            The App User Model ID which is in the format of PackageFamilyName!App
+            The "App" is what's defined in the Package.appxmanifest file for ID in Application Id="App"
+            </summary>
+        </member>
         <member name="F:AppControlManager.App.PackageSource">
             <summary>
             Detects the source of the application.
@@ -3651,6 +3662,28 @@
             <param name="authenticodeSHA256"></param>
             <param name="authenticodeSHA1"></param>
             <param name="siSigningScenario"></param>
+        </member>
+        <member name="F:AppControlManager.Others.ReLaunch.CLSCTX_LOCAL_SERVER">
+            <summary>
+            CLSCTX_LOCAL_SERVER (0x4) is used for out-of-process COM objects.
+            </summary>
+        </member>
+        <member name="F:AppControlManager.Others.ReLaunch.clsidApplicationActivationManager">
+            <summary>
+            The CLSID of the Application Activation Manager.
+            </summary>
+        </member>
+        <member name="F:AppControlManager.Others.ReLaunch.arguments">
+            <summary>
+            The command-line arguments to pass to the application.
+            </summary>
+        </member>
+        <member name="M:AppControlManager.Others.ReLaunch.Action">
+            <summary>
+            Relaunches the application with Administrator privileges
+            </summary>
+            <returns></returns>
+            <exception cref="T:System.InvalidOperationException"></exception>
         </member>
         <member name="M:AppControlManager.Others.CiPolicyHandler.RemoveSupplementalSigners(System.String)">
             <summary>
@@ -9305,6 +9338,15 @@
         <member name="M:Windows.Win32.UI_Shell_IFileOpenDialog_Extensions.SetClientGuid(Windows.Win32.UI.Shell.IFileOpenDialog.Interface,System.Guid@)">
             <inheritdoc cref="M:Windows.Win32.UI.Shell.IFileOpenDialog.Interface.SetClientGuid(System.Guid*)"/>
         </member>
+        <member name="M:Windows.Win32.UI_Shell_IApplicationActivationManager_Extensions.ActivateApplication(Windows.Win32.UI.Shell.IApplicationActivationManager.Interface,System.String,System.String,Windows.Win32.UI.Shell.ACTIVATEOPTIONS,System.UInt32@)">
+            <inheritdoc cref="M:Windows.Win32.UI.Shell.IApplicationActivationManager.Interface.ActivateApplication(Windows.Win32.Foundation.PCWSTR,Windows.Win32.Foundation.PCWSTR,Windows.Win32.UI.Shell.ACTIVATEOPTIONS,System.UInt32*)"/>
+        </member>
+        <member name="M:Windows.Win32.UI_Shell_IApplicationActivationManager_Extensions.ActivateForFile(Windows.Win32.UI.Shell.IApplicationActivationManager.Interface,System.String,Windows.Win32.UI.Shell.IShellItemArray*,System.String,System.UInt32@)">
+            <inheritdoc cref="M:Windows.Win32.UI.Shell.IApplicationActivationManager.Interface.ActivateForFile(Windows.Win32.Foundation.PCWSTR,Windows.Win32.UI.Shell.IShellItemArray*,Windows.Win32.Foundation.PCWSTR,System.UInt32*)"/>
+        </member>
+        <member name="M:Windows.Win32.UI_Shell_IApplicationActivationManager_Extensions.ActivateForProtocol(Windows.Win32.UI.Shell.IApplicationActivationManager.Interface,System.String,Windows.Win32.UI.Shell.IShellItemArray*,System.UInt32@)">
+            <inheritdoc cref="M:Windows.Win32.UI.Shell.IApplicationActivationManager.Interface.ActivateForProtocol(Windows.Win32.Foundation.PCWSTR,Windows.Win32.UI.Shell.IShellItemArray*,System.UInt32*)"/>
+        </member>
         <member name="T:Windows.Win32.Foundation.HRESULT">
             <remarks>
             <para>The **HRESULT** data type is the same as the [SCODE](scode.md) data type. An **HRESULT** value consists of the following fields: - A 1-bit code indicating severity, where zero represents success and 1 represents failure. - A 4-bit reserved value. - An 11-bit code indicating responsibility for the error or warning, also known as a facility code. - A 16-bit code describing the error or warning. Most MAPI interface methods and functions return **HRESULT** values to provide detailed cause formation. **HRESULT** values are also used widely in OLE interface methods. OLE provides several macros for converting between **HRESULT** values and **SCODE** values, another common data type for error handling. > [!NOTE] > In 64-bit MAPI, **HRESULT** is still a 32-bit value. For information about the OLE use of **HRESULT** values, see the  *OLE Programmer's Reference*. For more information about the use of these values in MAPI, see [Error Handling](error-handling-in-mapi.md) and any of the following interface methods: [IABLogon::GetLastError](iablogon-getlasterror.md) [IMAPISupport::GetLastError](imapisupport-getlasterror.md) [IMAPIControl::GetLastError](imapicontrol-getlasterror.md) [IMAPITable::GetLastError](imapitable-getlasterror.md) [IMAPIProp::GetLastError](imapiprop-getlasterror.md) [IMAPIViewAdviseSink::OnPrint](imapiviewadvisesink-onprint.md)</para>
@@ -11417,6 +11459,44 @@
         <member name="F:Windows.Win32.UI.Shell.IFileOpenDialog.IID_Guid">
             <summary>The IID guid for this interface.</summary>
             <value>{d57c7288-d4ad-4768-be02-9d969532d960}</value>
+        </member>
+        <member name="M:Windows.Win32.UI.Shell.IApplicationActivationManager.QueryInterface(System.Guid@,System.Void*@)">
+            <inheritdoc cref="M:Windows.Win32.UI.Shell.IApplicationActivationManager.QueryInterface(System.Guid*,System.Void**)"/>
+        </member>
+        <member name="M:Windows.Win32.UI.Shell.IApplicationActivationManager.ActivateApplication(System.String,System.String,Windows.Win32.UI.Shell.ACTIVATEOPTIONS,System.UInt32@)">
+            <inheritdoc cref="M:Windows.Win32.UI.Shell.IApplicationActivationManager.ActivateApplication(Windows.Win32.Foundation.PCWSTR,Windows.Win32.Foundation.PCWSTR,Windows.Win32.UI.Shell.ACTIVATEOPTIONS,System.UInt32*)"/>
+        </member>
+        <member name="M:Windows.Win32.UI.Shell.IApplicationActivationManager.ActivateApplication(Windows.Win32.Foundation.PCWSTR,Windows.Win32.Foundation.PCWSTR,Windows.Win32.UI.Shell.ACTIVATEOPTIONS,System.UInt32*)">
+            <summary>Activates the specified Windows Store app for the generic launch contract (Windows.Launch) in the current session.</summary>
+            <param name="appUserModelId">The application user model ID of the Windows Store app.</param>
+            <param name="arguments">A pointer to an optional, app-specific, argument string.</param>
+            <param name="options">One or more of the following flags used to support design mode, debugging, and testing scenarios.</param>
+            <param name="processId">A pointer to a value that, when this method returns successfully, receives the process ID of the app instance that fulfills this contract.</param>
+            <returns>If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.</returns>
+            <remarks>
+            <para><see href="https://learn.microsoft.com/windows/win32/api/shobjidl_core/nf-shobjidl_core-iapplicationactivationmanager-activateapplication">Learn more about this API from docs.microsoft.com</see>.</para>
+            </remarks>
+        </member>
+        <member name="M:Windows.Win32.UI.Shell.IApplicationActivationManager.ActivateForFile(System.String,Windows.Win32.UI.Shell.IShellItemArray*,System.String,System.UInt32@)">
+            <inheritdoc cref="M:Windows.Win32.UI.Shell.IApplicationActivationManager.ActivateForFile(Windows.Win32.Foundation.PCWSTR,Windows.Win32.UI.Shell.IShellItemArray*,Windows.Win32.Foundation.PCWSTR,System.UInt32*)"/>
+        </member>
+        <!-- Badly formed XML comment ignored for member "M:Windows.Win32.UI.Shell.IApplicationActivationManager.ActivateForFile(Windows.Win32.Foundation.PCWSTR,Windows.Win32.UI.Shell.IShellItemArray*,Windows.Win32.Foundation.PCWSTR,System.UInt32*)" -->
+        <member name="M:Windows.Win32.UI.Shell.IApplicationActivationManager.ActivateForProtocol(System.String,Windows.Win32.UI.Shell.IShellItemArray*,System.UInt32@)">
+            <inheritdoc cref="M:Windows.Win32.UI.Shell.IApplicationActivationManager.ActivateForProtocol(Windows.Win32.Foundation.PCWSTR,Windows.Win32.UI.Shell.IShellItemArray*,System.UInt32*)"/>
+        </member>
+        <member name="M:Windows.Win32.UI.Shell.IApplicationActivationManager.ActivateForProtocol(Windows.Win32.Foundation.PCWSTR,Windows.Win32.UI.Shell.IShellItemArray*,System.UInt32*)">
+            <summary>Activates the specified Windows Store app for the protocol contract (Windows.Protocol).</summary>
+            <param name="appUserModelId">The application user model ID of the Windows Store app.</param>
+            <param name="itemArray">A pointer to an array of a single Shell item. The first item in the array is converted into a Uri object that is passed to the app through <a href="https://docs.microsoft.com/uwp/api/windows.applicationmodel.activation.protocolactivatedeventargs">ProtocolActivatedEventArgs</a>. Any items in the array except for the first element are ignored.</param>
+            <param name="processId">A pointer to a value that, when this method returns successfully, receives the process ID of the app instance that fulfills this contract.</param>
+            <returns>If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.</returns>
+            <remarks>
+            <para><see href="https://learn.microsoft.com/windows/win32/api/shobjidl_core/nf-shobjidl_core-iapplicationactivationmanager-activateforprotocol">Learn more about this API from docs.microsoft.com</see>.</para>
+            </remarks>
+        </member>
+        <member name="F:Windows.Win32.UI.Shell.IApplicationActivationManager.IID_Guid">
+            <summary>The IID guid for this interface.</summary>
+            <value>{2e941141-7f97-4756-ba1d-9decde894a3d}</value>
         </member>
         <member name="T:Windows.Win32.UI.Shell.PropertiesSystem.GETPROPERTYSTOREFLAGS">
             <summary>Indicates flags that modify the property store object retrieved by methods that create a property store, such as IShellItem2::GetPropertyStore or IPropertyStoreFactory::GetPropertyStore.</summary>

--- a/AppControl Manager/MainWindow.xaml.cs
+++ b/AppControl Manager/MainWindow.xaml.cs
@@ -18,7 +18,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using AnimatedVisuals;
@@ -555,21 +554,29 @@ internal sealed partial class MainWindow : Window
 	/// <param name="args"></param>
 	private void MainWindow_Closed(object sender, WindowEventArgs args)
 	{
-		// Get the current size of the window
-		SizeInt32 size = m_AppWindow.Size;
+		try
+		{
+			// Get the current size of the window
+			SizeInt32 size = m_AppWindow.Size;
 
-		// Save to window width and height to the app settings
-		App.Settings.MainWindowWidth = size.Width;
-		App.Settings.MainWindowHeight = size.Height;
+			// Save to window width and height to the app settings
+			App.Settings.MainWindowWidth = size.Width;
+			App.Settings.MainWindowHeight = size.Height;
 
-		Win32InteropInternal.WINDOWPLACEMENT windowPlacement = new();
+			Win32InteropInternal.WINDOWPLACEMENT windowPlacement = new();
 
-		// Check if the window is maximized
-		_ = Win32InteropInternal.GetWindowPlacement(GlobalVars.hWnd, ref windowPlacement);
+			// Check if the window is maximized
+			_ = Win32InteropInternal.GetWindowPlacement(GlobalVars.hWnd, ref windowPlacement);
 
-		// Save the maximized status of the window before closing to the app settings
-		App.Settings.MainWindowIsMaximized = windowPlacement.showCmd is Win32InteropInternal.ShowWindowCommands.SW_SHOWMAXIMIZED;
+			// Save the maximized status of the window before closing to the app settings
+			App.Settings.MainWindowIsMaximized = windowPlacement.showCmd is Win32InteropInternal.ShowWindowCommands.SW_SHOWMAXIMIZED;
+		}
+		catch (Exception ex)
+		{
+			Logger.Write($"There was a program saving the window size when closing the app: {ex.Message}");
+		}
 	}
+
 
 
 	/// <summary>
@@ -845,7 +852,7 @@ internal sealed partial class MainWindow : Window
 		if (args.Reason == AutoSuggestionBoxTextChangeReason.UserInput)
 		{
 			// Get the text user entered in the search box
-			string query = sender.Text.ToLowerInvariant().Trim();
+			string query = sender.Text.Trim();
 
 			// Filter menu items based on the search query
 			List<string> suggestions = new(NavigationPageToItemContentMap.Keys.Where(name => name.Contains(query, StringComparison.OrdinalIgnoreCase)));
@@ -994,6 +1001,7 @@ internal sealed partial class MainWindow : Window
 						App.Settings.PromptForElevationOnStartup = true;
 					}
 
+					/*
 					ProcessStartInfo processInfo = new()
 					{
 						FileName = Environment.ProcessPath,
@@ -1017,6 +1025,15 @@ internal sealed partial class MainWindow : Window
 
 					// Explicitly exit the current instance only after launching the elevated instance
 					if (processStartResult is not null)
+					{
+						Application.Current.Exit();
+					}
+
+					return;
+
+					*/
+
+					if (ReLaunch.Action())
 					{
 						Application.Current.Exit();
 					}

--- a/AppControl Manager/NativeMethods.txt
+++ b/AppControl Manager/NativeMethods.txt
@@ -2,3 +2,4 @@ CoCreateInstance
 SHCreateItemFromParsingName
 IFileOpenDialog
 FileOpenDialog
+IApplicationActivationManager

--- a/AppControl Manager/Others/ReLaunch.cs
+++ b/AppControl Manager/Others/ReLaunch.cs
@@ -1,0 +1,106 @@
+// MIT License
+//
+// Copyright (c) 2023-Present - Violet Hansen - (aka HotCakeX on GitHub) - Email Address: spynetgirl@outlook.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// See here for more information: https://github.com/HotCakeX/Harden-Windows-Security/blob/main/LICENSE
+//
+
+using System;
+
+namespace AppControlManager.Others;
+
+internal static unsafe class ReLaunch
+{
+
+	// Won't work if Explorer.exe is not available like early in boot process
+
+	/*
+		AO_NONE (0x00000000)
+		AO_DESIGNMODE (0x00000001)
+		AO_NOERRORUI (0x00000002)
+		AO_NOSPLASHSCREEN (0x00000004)
+		AO_PRELAUNCH (0x02000000)		
+		
+		AO_BACKGROUNDTASK (0x00010000)
+		AO_REMEDIATION (0x00080000)
+		AO_TERMINATEBEFOREACTIVATE (0x00200000)
+		AO_NOFOREGROUND (0x01000000)
+		AO_NOMINSPLASHSCREENTIMER (0x04000000)
+		AO_EXTENDEDTIMEOUT (0x08000000)
+		AO_COMPONENT (0x10000000)
+		AO_ELEVATE (0x20000000)
+		AO_HOSTEDVIEW (0x40000000)	 
+	 */
+
+
+	/// <summary>
+	/// CLSCTX_LOCAL_SERVER (0x4) is used for out-of-process COM objects.
+	/// </summary>
+	private const uint CLSCTX_LOCAL_SERVER = 0x4;
+
+	/// <summary>
+	/// The CLSID of the Application Activation Manager.
+	/// </summary>
+	private static readonly Guid clsidApplicationActivationManager = new("45BA127D-10A8-46EA-8AB7-56EA9078943C");
+
+	/// <summary>
+	/// The command-line arguments to pass to the application.
+	/// </summary>
+	private static readonly string arguments = string.Empty;
+
+	/// <summary>
+	/// Relaunches the application with Administrator privileges
+	/// </summary>
+	/// <returns></returns>
+	/// <exception cref="InvalidOperationException"></exception>
+	internal static bool Action()
+	{
+		// Create an instance of the Application Activation Manager.
+		int hr = Windows.Win32.PInvoke.CoCreateInstance(
+			clsidApplicationActivationManager,
+			pUnkOuter: null,
+			(Windows.Win32.System.Com.CLSCTX)CLSCTX_LOCAL_SERVER,
+			out Windows.Win32.UI.Shell.IApplicationActivationManager* activationManager);
+
+		if (hr < 0)
+		{
+			throw new InvalidOperationException($"CoCreateInstance failed with HRESULT: 0x{(uint)hr:X}");
+		}
+
+		try
+		{
+			activationManager->ActivateApplication(App.AUMID, arguments, (Windows.Win32.UI.Shell.ACTIVATEOPTIONS)0x20000000, out uint processId);
+		}
+		catch (Exception ex) when (ex.HResult == -2147023673)
+		{
+			Logger.Write("Elevation request cancelled by the user.");
+
+			return false;
+		}
+		catch (Exception ex)
+		{
+			Logger.Write(ErrorWriter.FormatException(ex));
+
+			throw new InvalidOperationException($"ActivationManager failed with HRESULT: 0x{(uint)hr:X}");
+		}
+		finally
+		{
+			if (activationManager is not null)
+			{
+				_ = ((Windows.Win32.System.Com.IUnknown*)activationManager)->Release();
+			}
+		}
+
+		return true;
+	}
+}

--- a/AppControl Manager/Package.appxmanifest
+++ b/AppControl Manager/Package.appxmanifest
@@ -4,14 +4,22 @@
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   xmlns:uap18="http://schemas.microsoft.com/appx/manifest/uap/windows10/18"
-  IgnorableNamespaces="uap rescap uap18">
+  xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
+  xmlns:desktop4="http://schemas.microsoft.com/appx/manifest/desktop/windows10/4"
+  xmlns:desktop5="http://schemas.microsoft.com/appx/manifest/desktop/windows10/5"
+  xmlns:desktop10="http://schemas.microsoft.com/appx/manifest/desktop/windows10/10"
+  xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
+  xmlns:uap16="http://schemas.microsoft.com/appx/manifest/uap/windows10/16"
+  xmlns:uap17="http://schemas.microsoft.com/appx/manifest/uap/windows10/17"
+  IgnorableNamespaces="uap rescap uap18 uap17 uap16 uap10 desktop desktop4 desktop5 desktop10">
 
   <Identity
     Name="AppControlManager"
     Publisher="CN=SelfSignedCertForAppControlManager"
-    Version="1.9.9.0" />
+    Version="2.0.0.0" />
 
   <mp:PhoneIdentity PhoneProductId="199a23ec-7cb6-4ab5-ab50-8baca348bc79" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 
@@ -19,11 +27,17 @@
     <DisplayName>AppControl Manager</DisplayName>
     <PublisherDisplayName>SelfSignedCertForAppControlManager</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
+
+    <uap10:PackageIntegrity>
+      <uap10:Content Enforcement="on" />
+    </uap10:PackageIntegrity>
+
+    <uap17:UpdateWhileInUse>defer</uap17:UpdateWhileInUse>
   </Properties>
 
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.22621.0" MaxVersionTested="10.0.26100.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.22621.0" MaxVersionTested="10.0.26100.0" />
   </Dependencies>
 
   <Resources>
@@ -44,6 +58,13 @@
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
         <uap:LockScreen BadgeLogo="Assets\BadgeLogo.png" Notification="badge"/>
       </uap:VisualElements>
+      <Extensions>
+        <uap3:Extension Category="windows.appExecutionAlias" Executable="AppControlManager.exe" EntryPoint="Windows.FullTrustApplication">
+          <uap3:AppExecutionAlias>
+            <desktop:ExecutionAlias Alias="AppControl.exe" />
+          </uap3:AppExecutionAlias>
+        </uap3:Extension>
+      </Extensions>
     </Application>
   </Applications>
 

--- a/AppControl Manager/app.manifest
+++ b/AppControl Manager/app.manifest
@@ -2,7 +2,7 @@
 <!-- INFO: https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests -->
 <!-- INFO (for legacy UWP but its info can be used for better understanding): https://learn.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/root-elements -->
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.9.9.0" name="AppControlManager"/>
+  <assemblyIdentity version="2.0.0.0" name="AppControlManager"/>
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>


### PR DESCRIPTION
# What's New

* Improved compatibility with EAF (Export Address Filtering) process mitigation. - Thanks @secmmo4 and @dcasota for reporting and assisting in fixing it.
* Added an app alias called `AppControl.exe` so you can use it to launch the AppControl Manager from PowerShell, command prompt and so on.
* Updates from Microsoft Store will no longer close the app while in use, instead will wait until you close the app to complete the update.
* Bumped app version to `2.0.0.0`
