### PR TITLE
Fixed an issue when more than 1 cert with the same CN exists and the app would show error

### DIFF
--- a/AppControl Manager/IntelGathering/CertCNFetcher.cs
+++ b/AppControl Manager/IntelGathering/CertCNFetcher.cs
@@ -52,7 +52,9 @@ internal static class CertCNFetcher
 					// Add the CN to the output set and warn if there is already CN with the same name in the HashSet
 					if (!output.Add(cn))
 					{
-						throw new InvalidOperationException($"There are more than 1 certificates with the common name '{cn}' in the Personal certificate store of the Current User. Delete one of them if you want to use it.");
+						Logger.Write($"There are more than 1 certificates with the common name '{cn}' in the Personal certificate store of the Current User. Only certificates without duplicate common names can be used at the moment.");
+
+						_ = output.Remove(cn);
 					}
 				}
 			}


### PR DESCRIPTION
Related issue: https://github.com/HotCakeX/Harden-Windows-Security/issues/693

