### PR TITLE
Improved Intune policy retrieval and page internals

### DIFF
--- a/AppControl Manager/AppControlManagerAPIDocumentation.xml
+++ b/AppControl Manager/AppControlManagerAPIDocumentation.xml
@@ -5300,7 +5300,7 @@
         </member>
         <member name="M:AppControlManager.Pages.AllowNewAppsStart.CreatePolicyButton_Click">
             <summary>
-            Event handler for the Create Policy button
+            Event handler for the Create Policy button - Step 3
             </summary>
         </member>
         <member name="M:AppControlManager.Pages.AllowNewAppsStart.BrowseForXMLPolicyButton_Flyout_Clear_Click(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
@@ -6760,29 +6760,13 @@
         </member>
         <member name="T:AppControlManager.Pages.PolicyEditor">
             <summary>
-            The PolicyEditor class manages the UI for editing policies, including handling item deletions and enhancing ListView
-            interactions.
+            The PolicyEditor class manages the UI for editing policies.
             </summary>
         </member>
         <member name="M:AppControlManager.Pages.PolicyEditor.#ctor">
             <summary>
-            Initializes a new instance of the PolicyEditor class. Sets up the component, enables navigation caching, and
-            assigns the data context.
+            Initializes a new instance of the PolicyEditor class.
             </summary>
-        </member>
-        <member name="M:AppControlManager.Pages.PolicyEditor.FileBasedRulesListView_DeleteItems(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
-            <summary>
-            Event handler for deleting selected items from the FileBasedRulesListView's Items Source
-            </summary>
-            <param name="sender"></param>
-            <param name="e"></param>
-        </member>
-        <member name="M:AppControlManager.Pages.PolicyEditor.SignatureBasedRulesListView_DeleteItems(System.Object,Microsoft.UI.Xaml.RoutedEventArgs)">
-            <summary>
-            Event handler for deleting selected items from the SignatureBasedRulesListView's Items Source
-            </summary>
-            <param name="sender"></param>
-            <param name="e"></param>
         </member>
         <member name="M:AppControlManager.Pages.PolicyEditor.InitializeComponent">
             <summary>
@@ -7167,20 +7151,6 @@
             Helper method to copy a specified property to clipboard without reflection
             </summary>
             <param name="getProperty">Function that retrieves the desired property value as a string</param>
-        </member>
-        <member name="M:AppControlManager.Pages.ViewFileCertificates.FetchForCIP(System.String)">
-            <summary>
-            Get the certificates of the .CIP files
-            </summary>
-            <param name="file"></param>
-            <returns></returns>
-        </member>
-        <member name="M:AppControlManager.Pages.ViewFileCertificates.FetchForCER(System.String)">
-            <summary>
-            Fetch for the .cer files
-            </summary>
-            <param name="file"></param>
-            <returns></returns>
         </member>
         <member name="M:AppControlManager.Pages.ViewFileCertificates.Fetch(System.String)">
             <summary>
@@ -8674,7 +8644,12 @@
         </member>
         <member name="P:AppControlManager.ViewModels.AllowNewAppsVM.DeployPolicy">
             <summary>
-            Toggle button to determine whether the new Supplemental policy should be deployed on the system after creation or not
+            Toggle button to determine whether the new Supplemental policy should be deployed on the system after creation or not.
+            </summary>
+        </member>
+        <member name="P:AppControlManager.ViewModels.AllowNewAppsVM.DeployPolicyState">
+            <summary>
+            The Enabled/Disabled state of the DeployPolicy button.
             </summary>
         </member>
         <member name="M:AppControlManager.ViewModels.AllowNewAppsVM.CalculateColumnWidthEventLogs">
@@ -9280,6 +9255,16 @@
             </summary>
             <param name="policyFile">the path to the policy file to open in the Policy Editor</param>
         </member>
+        <member name="M:AppControlManager.ViewModels.PolicyEditorVM.FileBasedRulesListView_DeleteItems">
+            <summary>
+            Event handler for deleting selected items from the FileBasedRulesListView's Items Source
+            </summary>
+        </member>
+        <member name="M:AppControlManager.ViewModels.PolicyEditorVM.SignatureBasedRulesListView_DeleteItems">
+            <summary>
+            Event handler for deleting selected items from the SignatureBasedRulesListView's Items Source
+            </summary>
+        </member>
         <member name="F:AppControlManager.ViewModels.SettingsVM.VersionTextBlockText">
             <summary>
             Set the version in the settings card to the current app version
@@ -9524,6 +9509,20 @@
             </summary>
             <param name="row">The selected FileCertificateInfoCol row from the ListView.</param>
             <returns>A formatted string of the row's properties with labels.</returns>
+        </member>
+        <member name="M:AppControlManager.ViewModels.ViewFileCertificatesVM.FetchForCIP(System.String)">
+            <summary>
+            Get the certificates of the .CIP files
+            </summary>
+            <param name="file"></param>
+            <returns></returns>
+        </member>
+        <member name="M:AppControlManager.ViewModels.ViewFileCertificatesVM.FetchForCER(System.String)">
+            <summary>
+            Fetch for the .cer files
+            </summary>
+            <param name="file"></param>
+            <returns></returns>
         </member>
         <member name="T:AppControlManager.ViewModels.ViewModelBase">
             <summary>

--- a/AppControl Manager/CustomUIElements/SettingsCardV3.cs
+++ b/AppControl Manager/CustomUIElements/SettingsCardV3.cs
@@ -16,11 +16,11 @@
 //
 
 using System.Linq;
+using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Input;
 using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Input;
 
 namespace AppControlManager.CustomUIElements;
 

--- a/AppControl Manager/CustomUIElements/SigningDetailsDialog.xaml.cs
+++ b/AppControl Manager/CustomUIElements/SigningDetailsDialog.xaml.cs
@@ -23,7 +23,6 @@ using System.Threading.Tasks;
 using AppControlManager.IntelGathering;
 using AppControlManager.Main;
 using AppControlManager.Others;
-using AppControlManager.WindowComponents;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;

--- a/AppControl Manager/CustomUIElements/SigningDetailsDialogForRemoval.xaml.cs
+++ b/AppControl Manager/CustomUIElements/SigningDetailsDialogForRemoval.xaml.cs
@@ -23,7 +23,6 @@ using System.Threading.Tasks;
 using AppControlManager.IntelGathering;
 using AppControlManager.Main;
 using AppControlManager.Others;
-using AppControlManager.WindowComponents;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;

--- a/AppControl Manager/MicrosoftGraph/Main.cs
+++ b/AppControl Manager/MicrosoftGraph/Main.cs
@@ -633,7 +633,10 @@ DeviceEvents
 		httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
 		// Use GET instead of POST as the endpoint expects a GET request.
-		HttpResponseMessage response = await httpClient.GetAsync(new Uri("https://graph.microsoft.com/beta/deviceManagement/deviceConfigurations"));
+		// HttpResponseMessage response = await httpClient.GetAsync(new Uri("https://graph.microsoft.com/beta/deviceManagement/deviceConfigurations"));
+
+		// Applying a filter to retrieve only the policies for Windows custom configurations
+		HttpResponseMessage response = await httpClient.GetAsync(new Uri("https://graph.microsoft.com/beta/deviceManagement/deviceConfigurations?$filter=isof('microsoft.graph.windows10CustomConfiguration')"));
 
 		if (response.IsSuccessStatusCode)
 		{

--- a/AppControl Manager/Pages/AllowNewApps/AllowNewApps.xaml.cs
+++ b/AppControl Manager/Pages/AllowNewApps/AllowNewApps.xaml.cs
@@ -88,7 +88,7 @@ internal sealed partial class AllowNewApps : Page, IAnimatedIconsManager
 	public void SetVisibility(Visibility visibility)
 	{
 		// Light up the local page's button icons
-		AllowNewAppsStart.Instance.BrowseForXMLPolicyButtonLightAnimatedIconPub.Visibility = visibility;
+		ViewModel.BrowseForXMLPolicyButtonLightAnimatedIconVisibility = visibility;
 
 		sideBarVM.AssignActionPacks(
 		(param => LightUp1(), "Allow New Apps Base Policy"),

--- a/AppControl Manager/Pages/AllowNewApps/AllowNewAppsEventLogsDataGrid.xaml.cs
+++ b/AppControl Manager/Pages/AllowNewApps/AllowNewAppsEventLogsDataGrid.xaml.cs
@@ -50,7 +50,7 @@ internal sealed partial class AllowNewAppsEventLogsDataGrid : Page
 		this.InitializeComponent();
 
 		// Make sure navigating to/from this page maintains its state
-		this.NavigationCacheMode = NavigationCacheMode.Enabled;
+		this.NavigationCacheMode = NavigationCacheMode.Required;
 
 		this.DataContext = ViewModel;
 	}

--- a/AppControl Manager/Pages/AllowNewApps/AllowNewAppsLocalFilesDataGrid.xaml.cs
+++ b/AppControl Manager/Pages/AllowNewApps/AllowNewAppsLocalFilesDataGrid.xaml.cs
@@ -50,7 +50,7 @@ internal sealed partial class AllowNewAppsLocalFilesDataGrid : Page
 		this.InitializeComponent();
 
 		// Make sure navigating to/from this page maintains its state
-		this.NavigationCacheMode = NavigationCacheMode.Enabled;
+		this.NavigationCacheMode = NavigationCacheMode.Required;
 
 		this.DataContext = ViewModel;
 	}

--- a/AppControl Manager/Pages/AllowNewApps/AllowNewAppsStart.xaml
+++ b/AppControl Manager/Pages/AllowNewApps/AllowNewAppsStart.xaml
@@ -84,7 +84,7 @@
                             <Button.Content>
                                 <controls:WrapPanel Orientation="Horizontal">
 
-                                    <AnimatedIcon x:Name="BrowseForXMLPolicyButtonLightAnimatedIcon" Height="20" Margin="0,0,5,0" Width="20" Visibility="Collapsed">
+                                    <AnimatedIcon Visibility="{x:Bind ViewModel.BrowseForXMLPolicyButtonLightAnimatedIconVisibility, Mode=OneWay}" Height="20" Margin="0,0,5,0" Width="20">
                                         <AnimatedIcon.Source>
                                             <animatedvisuals:Light/>
                                         </AnimatedIcon.Source>
@@ -108,7 +108,11 @@
 
                     </controls:WrapPanel>
 
-                    <InfoBar x:Name="Step1InfoBar" Severity="Informational" IsOpen="False" IsClosable='False' Margin="0,20,0,0" Grid.Row="2"/>
+                    <InfoBar Severity="{x:Bind ViewModel.Step1InfoBar_Severity, Mode=OneWay}"
+                             IsOpen="{x:Bind ViewModel.Step1InfoBar_IsOpen, Mode=TwoWay}"
+                             IsClosable='{x:Bind ViewModel.Step1InfoBar_IsClosable, Mode=OneWay}'
+                             Message="{x:Bind ViewModel.Step1InfoBar_Message, Mode=OneWay}"
+                             Margin="0,20,0,0" Grid.Row="2"/>
 
                 </Grid>
             </Border>
@@ -161,7 +165,11 @@
 
                     </controls:WrapPanel>
 
-                    <InfoBar x:Name="Step2InfoBar" Severity="Informational" IsOpen="False" IsClosable='False' Margin="0,20,0,0" Grid.Row="2"/>
+                    <InfoBar Severity="{x:Bind ViewModel.Step2InfoBar_Severity, Mode=OneWay}"
+                        IsOpen="{x:Bind ViewModel.Step2InfoBar_IsOpen, Mode=TwoWay}"
+                        IsClosable='{x:Bind ViewModel.Step2InfoBar_IsClosable, Mode=OneWay}'
+                        Message="{x:Bind ViewModel.Step2InfoBar_Message, Mode=OneWay}"
+                        Margin="0,20,0,0" Grid.Row="2"/>
 
                 </Grid>
             </Border>
@@ -197,7 +205,12 @@
 
                         <Button x:Name="CreatePolicyButton" Click="{x:Bind CreatePolicyButton_Click}" x:Uid="AllowNewAppsCreatePolicyButton" Style="{StaticResource AccentButtonStyle}"/>
                     </controls:WrapPanel>
-                    <InfoBar x:Name="Step3InfoBar" Severity="Informational" IsOpen="False" IsClosable='False' Margin="0,20,0,0" Grid.Row="2">
+
+                    <InfoBar Severity="{x:Bind ViewModel.Step3InfoBar_Severity, Mode=OneWay}"
+                            IsOpen="{x:Bind ViewModel.Step3InfoBar_IsOpen, Mode=TwoWay}"
+                            IsClosable='{x:Bind ViewModel.Step3InfoBar_IsClosable, Mode=OneWay}'
+                            Message="{x:Bind ViewModel.Step3InfoBar_Message, Mode=OneWay}"
+                            Margin="0,20,0,0" Grid.Row="2">
                         <InfoBar.ActionButton>
                             <Button x:Uid="OpenInPolicyEditorButton" Visibility="{x:Bind ViewModel.OpenInPolicyEditorInfoBarActionButtonVisibility, Mode=OneWay}" Click="{x:Bind OpenInPolicyEditor}" />
                         </InfoBar.ActionButton>

--- a/AppControl Manager/Pages/ConfigurePolicyRuleOptions.xaml
+++ b/AppControl Manager/Pages/ConfigurePolicyRuleOptions.xaml
@@ -53,7 +53,7 @@
                 <Button.Content>
                     <controls:WrapPanel Orientation="Horizontal">
 
-                        <AnimatedIcon x:Name="PickPolicyFileButtonAnimatedIconLight" Height="20" Margin="0,0,5,0" Width="20" Visibility="Collapsed">
+                        <AnimatedIcon Visibility="{x:Bind ViewModel.BrowseForXMLPolicyButtonLightAnimatedIconVisibility, Mode=OneWay}" Height="20" Margin="0,0,5,0" Width="20">
                             <AnimatedIcon.Source>
                                 <animatedvisuals:Light/>
                             </AnimatedIcon.Source>

--- a/AppControl Manager/Pages/ConfigurePolicyRuleOptions.xaml.cs
+++ b/AppControl Manager/Pages/ConfigurePolicyRuleOptions.xaml.cs
@@ -69,13 +69,12 @@ internal sealed partial class ConfigurePolicyRuleOptions : Page, IAnimatedIconsM
 		SetPolicyTemplate.Click += SetPolicyTemplate_Click;
 	}
 
-
 	#region Augmentation Interface
 
 	public void SetVisibility(Visibility visibility)
 	{
 		// Light up the local page's button icons
-		PickPolicyFileButtonAnimatedIconLight.Visibility = visibility;
+		ViewModel.BrowseForXMLPolicyButtonLightAnimatedIconVisibility = visibility;
 
 		sideBarVM.AssignActionPacks(
 		(param => LightUp1(), GlobalVars.Rizz.GetString("ConfigurePolicyRuleOptions_ButtonContent")),

--- a/AppControl Manager/Pages/CreateDenyPolicy.xaml.cs
+++ b/AppControl Manager/Pages/CreateDenyPolicy.xaml.cs
@@ -25,7 +25,6 @@ using AppControlManager.IntelGathering;
 using AppControlManager.Main;
 using AppControlManager.Others;
 using AppControlManager.ViewModels;
-using AppControlManager.WindowComponents;
 using AppControlManager.XMLOps;
 using CommunityToolkit.WinUI;
 using CommunityToolkit.WinUI.Controls;

--- a/AppControl Manager/Pages/CreateDenyPolicyFilesAndFoldersScanResults.xaml.cs
+++ b/AppControl Manager/Pages/CreateDenyPolicyFilesAndFoldersScanResults.xaml.cs
@@ -49,7 +49,7 @@ internal sealed partial class CreateDenyPolicyFilesAndFoldersScanResults : Page
 		this.InitializeComponent();
 
 		// Make sure navigating to/from this page maintains its state
-		this.NavigationCacheMode = NavigationCacheMode.Enabled;
+		this.NavigationCacheMode = NavigationCacheMode.Required;
 
 		this.DataContext = ViewModel;
 	}

--- a/AppControl Manager/Pages/CreateSupplementalPolicy.xaml
+++ b/AppControl Manager/Pages/CreateSupplementalPolicy.xaml
@@ -265,7 +265,7 @@
                                 <Button.Content>
                                     <controls:WrapPanel Orientation="Horizontal">
 
-                                        <AnimatedIcon x:Name="FilesAndFoldersBasePolicyLightAnimatedIcon" Height="20" Margin="0,0,5,0" Width="20">
+                                        <AnimatedIcon Visibility="{x:Bind ViewModel.FilesAndFoldersBasePolicyLightAnimatedIconVisibility, Mode=OneWay}" Height="20" Margin="0,0,5,0" Width="20">
                                             <AnimatedIcon.Source>
                                                 <animatedvisuals:Light/>
                                             </AnimatedIcon.Source>
@@ -420,7 +420,7 @@
                                 <Button.Content>
                                     <controls:WrapPanel Orientation="Horizontal">
 
-                                        <AnimatedIcon x:Name="CertificatesBasePolicyPathLightAnimatedIcon" Height="20" Margin="0,0,5,0" Width="20">
+                                        <AnimatedIcon Visibility="{x:Bind ViewModel.CertificatesBasePolicyPathLightAnimatedIconVisibility, Mode=OneWay}" Height="20" Margin="0,0,5,0" Width="20">
                                             <AnimatedIcon.Source>
                                                 <animatedvisuals:Light/>
                                             </AnimatedIcon.Source>
@@ -514,7 +514,7 @@
                                 <Button.Content>
                                     <controls:WrapPanel Orientation="Horizontal">
 
-                                        <AnimatedIcon x:Name="ISGBasePolicyPathLightAnimatedIcon" Height="20" Margin="0,0,5,0" Width="20">
+                                        <AnimatedIcon Visibility="{x:Bind ViewModel.ISGBasePolicyPathLightAnimatedIconVisibility, Mode=OneWay}" Height="20" Margin="0,0,5,0" Width="20">
                                             <AnimatedIcon.Source>
                                                 <animatedvisuals:Light/>
                                             </AnimatedIcon.Source>
@@ -625,7 +625,7 @@
                                 <Button.Content>
                                     <controls:WrapPanel Orientation="Horizontal">
 
-                                        <AnimatedIcon x:Name="StrictKernelModeBasePolicyLightAnimatedIcon" Height="20" Margin="0,0,5,0" Width="20">
+                                        <AnimatedIcon Visibility="{x:Bind ViewModel.StrictKernelModeBasePolicyLightAnimatedIconVisibility, Mode=OneWay}" Height="20" Margin="0,0,5,0" Width="20">
                                             <AnimatedIcon.Source>
                                                 <animatedvisuals:Light/>
                                             </AnimatedIcon.Source>
@@ -725,7 +725,7 @@
                                 <Button.Content>
                                     <controls:WrapPanel Orientation="Horizontal">
 
-                                        <AnimatedIcon x:Name="PFNBasePolicyPathLightAnimatedIcon" Height="20" Margin="0,0,5,0" Width="20">
+                                        <AnimatedIcon Visibility="{x:Bind ViewModel.PFNBasePolicyPathLightAnimatedIconVisibility, Mode=OneWay}" Height="20" Margin="0,0,5,0" Width="20">
                                             <AnimatedIcon.Source>
                                                 <animatedvisuals:Light/>
                                             </AnimatedIcon.Source>

--- a/AppControl Manager/Pages/CreateSupplementalPolicy.xaml.cs
+++ b/AppControl Manager/Pages/CreateSupplementalPolicy.xaml.cs
@@ -102,11 +102,11 @@ internal sealed partial class CreateSupplementalPolicy : Page, IAnimatedIconsMan
 	public void SetVisibility(Visibility visibility)
 	{
 		// Light up the local page's button icons
-		FilesAndFoldersBasePolicyLightAnimatedIcon.Visibility = visibility;
-		CertificatesBasePolicyPathLightAnimatedIcon.Visibility = visibility;
-		ISGBasePolicyPathLightAnimatedIcon.Visibility = visibility;
-		StrictKernelModeBasePolicyLightAnimatedIcon.Visibility = visibility;
-		PFNBasePolicyPathLightAnimatedIcon.Visibility = visibility;
+		ViewModel.FilesAndFoldersBasePolicyLightAnimatedIconVisibility = visibility;
+		ViewModel.CertificatesBasePolicyPathLightAnimatedIconVisibility = visibility;
+		ViewModel.ISGBasePolicyPathLightAnimatedIconVisibility = visibility;
+		ViewModel.StrictKernelModeBasePolicyLightAnimatedIconVisibility = visibility;
+		ViewModel.PFNBasePolicyPathLightAnimatedIconVisibility = visibility;
 
 		sideBarVM.AssignActionPacks(
 			(param => LightUp1(), "Files And Folders Supplemental Policy"),

--- a/AppControl Manager/Pages/CreateSupplementalPolicyFilesAndFoldersScanResults.xaml.cs
+++ b/AppControl Manager/Pages/CreateSupplementalPolicyFilesAndFoldersScanResults.xaml.cs
@@ -49,7 +49,7 @@ internal sealed partial class CreateSupplementalPolicyFilesAndFoldersScanResults
 		this.InitializeComponent();
 
 		// Make sure navigating to/from this page maintains its state
-		this.NavigationCacheMode = NavigationCacheMode.Enabled;
+		this.NavigationCacheMode = NavigationCacheMode.Required;
 
 		this.DataContext = ViewModel;
 	}

--- a/AppControl Manager/Pages/DeploymentPage.xaml
+++ b/AppControl Manager/Pages/DeploymentPage.xaml
@@ -425,7 +425,7 @@
                             <Button.Content>
                                 <controls:WrapPanel Orientation="Horizontal">
 
-                                    <AnimatedIcon x:Name="UnsignedXMLFilesLightAnimatedIcon" Height="20" Margin="0,0,5,0" Width="20">
+                                    <AnimatedIcon Visibility="{x:Bind ViewModel.UnsignedXMLFilesLightAnimatedIcoVisibility, Mode=OneWay}" Height="20" Margin="0,0,5,0" Width="20">
                                         <AnimatedIcon.Source>
                                             <animatedvisuals:Light/>
                                         </AnimatedIcon.Source>
@@ -492,7 +492,7 @@
                             <Button.Content>
                                 <controls:WrapPanel Orientation="Horizontal">
 
-                                    <AnimatedIcon x:Name="SignedXMLFilesLightAnimatedIcon" Visibility="Collapsed" Height="20" Margin="0,0,5,0" Width="20">
+                                    <AnimatedIcon Visibility="{x:Bind ViewModel.SignedXMLFilesLightAnimatedIconVisibility, Mode=OneWay}" Height="20" Margin="0,0,5,0" Width="20">
                                         <AnimatedIcon.Source>
                                             <animatedvisuals:Light/>
                                         </AnimatedIcon.Source>

--- a/AppControl Manager/Pages/DeploymentPage.xaml
+++ b/AppControl Manager/Pages/DeploymentPage.xaml
@@ -425,7 +425,7 @@
                             <Button.Content>
                                 <controls:WrapPanel Orientation="Horizontal">
 
-                                    <AnimatedIcon Visibility="{x:Bind ViewModel.UnsignedXMLFilesLightAnimatedIcoVisibility, Mode=OneWay}" Height="20" Margin="0,0,5,0" Width="20">
+                                    <AnimatedIcon Visibility="{x:Bind ViewModel.UnsignedXMLFilesLightAnimatedIconVisibility, Mode=OneWay}" Height="20" Margin="0,0,5,0" Width="20">
                                         <AnimatedIcon.Source>
                                             <animatedvisuals:Light/>
                                         </AnimatedIcon.Source>

--- a/AppControl Manager/Pages/DeploymentPage.xaml.cs
+++ b/AppControl Manager/Pages/DeploymentPage.xaml.cs
@@ -123,7 +123,7 @@ internal sealed partial class DeploymentPage : Page, IAnimatedIconsManager, INot
 	public void SetVisibility(Visibility visibility)
 	{
 		// Light up the local page's button icons
-		ViewModel.UnsignedXMLFilesLightAnimatedIcoVisibility = visibility;
+		ViewModel.UnsignedXMLFilesLightAnimatedIconVisibility = visibility;
 		ViewModel.SignedXMLFilesLightAnimatedIconVisibility = visibility;
 
 		sideBarVM.AssignActionPacks(

--- a/AppControl Manager/Pages/DeploymentPage.xaml.cs
+++ b/AppControl Manager/Pages/DeploymentPage.xaml.cs
@@ -118,14 +118,13 @@ internal sealed partial class DeploymentPage : Page, IAnimatedIconsManager, INot
 		ViewModelMSGraph.AuthenticatedAccounts.CollectionChanged += AuthCompanionCLS.AuthenticatedAccounts_CollectionChanged;
 	}
 
-
 	#region Augmentation Interface
 
 	public void SetVisibility(Visibility visibility)
 	{
 		// Light up the local page's button icons
-		UnsignedXMLFilesLightAnimatedIcon.Visibility = visibility;
-		SignedXMLFilesLightAnimatedIcon.Visibility = visibility;
+		ViewModel.UnsignedXMLFilesLightAnimatedIcoVisibility = visibility;
+		ViewModel.SignedXMLFilesLightAnimatedIconVisibility = visibility;
 
 		sideBarVM.AssignActionPacks(
 			(param => LightUp1(), GlobalVars.Rizz.GetString("DeployUnsignedPolicy")),

--- a/AppControl Manager/Pages/PolicyEditor.xaml
+++ b/AppControl Manager/Pages/PolicyEditor.xaml
@@ -272,7 +272,7 @@
                                         <Grid.ContextFlyout>
                                             <MenuFlyout>
 
-                                                <MenuFlyoutItem x:Uid="DeleteRow" Click="FileBasedRulesListView_DeleteItems">
+                                                <MenuFlyoutItem x:Uid="DeleteRow" Click="{x:Bind ParentViewModel.FileBasedRulesListView_DeleteItems}">
                                                     <MenuFlyoutItem.Icon>
                                                         <FontIcon Glyph="&#xE74D;" />
                                                     </MenuFlyoutItem.Icon>
@@ -380,7 +380,7 @@
                                         <Grid.ContextFlyout>
                                             <MenuFlyout>
 
-                                                <MenuFlyoutItem x:Uid="DeleteRow" Click="SignatureBasedRulesListView_DeleteItems">
+                                                <MenuFlyoutItem x:Uid="DeleteRow" Click="{x:Bind ParentViewModel.SignatureBasedRulesListView_DeleteItems}">
                                                     <MenuFlyoutItem.Icon>
                                                         <FontIcon Glyph="&#xE74D;" />
                                                     </MenuFlyoutItem.Icon>

--- a/AppControl Manager/Pages/PolicyEditor.xaml.cs
+++ b/AppControl Manager/Pages/PolicyEditor.xaml.cs
@@ -15,19 +15,15 @@
 // See here for more information: https://github.com/HotCakeX/Harden-Windows-Security/blob/main/LICENSE
 //
 
-using System.Collections.Generic;
-using System.Linq;
 using AppControlManager.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
 
 namespace AppControlManager.Pages;
 
 /// <summary>
-/// The PolicyEditor class manages the UI for editing policies, including handling item deletions and enhancing ListView
-/// interactions.
+/// The PolicyEditor class manages the UI for editing policies.
 /// </summary>
 internal sealed partial class PolicyEditor : Page
 {
@@ -38,13 +34,12 @@ internal sealed partial class PolicyEditor : Page
 #pragma warning restore CA1822
 
 	/// <summary>
-	/// Initializes a new instance of the PolicyEditor class. Sets up the component, enables navigation caching, and
-	/// assigns the data context.
+	/// Initializes a new instance of the PolicyEditor class.
 	/// </summary>
 	internal PolicyEditor()
 	{
 		this.InitializeComponent();
-		this.NavigationCacheMode = NavigationCacheMode.Enabled;
+		this.NavigationCacheMode = NavigationCacheMode.Disabled;
 		DataContext = ViewModel;
 	}
 
@@ -52,40 +47,5 @@ internal sealed partial class PolicyEditor : Page
 	{
 		if (!BrowseForPolicyButton_Flyout.IsOpen)
 			BrowseForPolicyButton_Flyout.ShowAt(BrowseForPolicyButton);
-	}
-
-	/// <summary>
-	/// Event handler for deleting selected items from the FileBasedRulesListView's Items Source
-	/// </summary>
-	/// <param name="sender"></param>
-	/// <param name="e"></param>
-	private void FileBasedRulesListView_DeleteItems(object sender, RoutedEventArgs e)
-	{
-		// Collect the selected items to delete - without ToList() or [.. ], only half of the selected items are removed from the collection
-		IEnumerable<AppControlManager.PolicyEditor.FileBasedRulesForListView> itemsToDelete = [.. FileBasedRulesListView.SelectedItems.Cast<AppControlManager.PolicyEditor.FileBasedRulesForListView>()];
-
-		// Iterate over the copy to remove each item
-		foreach (AppControlManager.PolicyEditor.FileBasedRulesForListView item in itemsToDelete)
-		{
-			ViewModel.RemoveFileRuleFromCollection(item);
-		}
-	}
-
-
-	/// <summary>
-	/// Event handler for deleting selected items from the SignatureBasedRulesListView's Items Source
-	/// </summary>
-	/// <param name="sender"></param>
-	/// <param name="e"></param>
-	private void SignatureBasedRulesListView_DeleteItems(object sender, RoutedEventArgs e)
-	{
-		// Collect the selected items to delete - without ToList() or [.. ], only half of the selected items are removed from the collection
-		IEnumerable<AppControlManager.PolicyEditor.SignatureBasedRulesForListView> itemsToDelete = [.. SignatureBasedRulesListView.SelectedItems.Cast<AppControlManager.PolicyEditor.SignatureBasedRulesForListView>()];
-
-		// Iterate over the copy to remove each item
-		foreach (AppControlManager.PolicyEditor.SignatureBasedRulesForListView item in itemsToDelete)
-		{
-			ViewModel.RemoveSignatureRuleFromCollection(item);
-		}
 	}
 }

--- a/AppControl Manager/Pages/StrictKernelPolicyScanResults.xaml.cs
+++ b/AppControl Manager/Pages/StrictKernelPolicyScanResults.xaml.cs
@@ -54,7 +54,7 @@ internal sealed partial class StrictKernelPolicyScanResults : Page
 		// And we will lose the data that was previously displayed. We'd have to run the CalculateColumnWidths() method and then assignment of ItemsSource of ListView
 		// Inside of the OnNavigatedTo method of this class.
 		// Or better option is to move the column bindings from this class and put them in a separate ViewModel class that won't be affected nor requires navigation caching
-		this.NavigationCacheMode = NavigationCacheMode.Enabled;
+		this.NavigationCacheMode = NavigationCacheMode.Required;
 
 		this.DataContext = ViewModel;
 	}

--- a/AppControl Manager/Pages/UpdatePage.xaml.cs
+++ b/AppControl Manager/Pages/UpdatePage.xaml.cs
@@ -15,8 +15,8 @@
 // See here for more information: https://github.com/HotCakeX/Harden-Windows-Security/blob/main/LICENSE
 //
 
-using Microsoft.UI.Xaml.Controls;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
 
 namespace AppControlManager.Pages;

--- a/AppControl Manager/Pages/UpdatePageCustomMSIXPath.xaml.cs
+++ b/AppControl Manager/Pages/UpdatePageCustomMSIXPath.xaml.cs
@@ -15,9 +15,9 @@
 // See here for more information: https://github.com/HotCakeX/Harden-Windows-Security/blob/main/LICENSE
 //
 
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace AppControlManager.Pages;
 

--- a/AppControl Manager/ViewModels/AllowNewAppsVM.cs
+++ b/AppControl Manager/ViewModels/AllowNewAppsVM.cs
@@ -21,6 +21,7 @@ using AppControlManager.IntelGathering;
 using AppControlManager.Others;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 
 namespace AppControlManager.ViewModels;
 
@@ -28,17 +29,12 @@ namespace AppControlManager.ViewModels;
 // It's handled by Dependency Injection so this warning is a false-positive.
 internal sealed partial class AllowNewAppsVM : ViewModelBase
 {
-
 	internal EventLogUtility EventLogsUtil { get; } = App.AppHost.Services.GetRequiredService<EventLogUtility>();
 
 	#region
 
 	// To store the FileIdentities displayed on the Local Files ListView
-	internal ObservableCollection<FileIdentity> LocalFilesFileIdentities
-	{
-		get; set => SP(ref field, value);
-	} = [];
-
+	internal ObservableCollection<FileIdentity> LocalFilesFileIdentities { get; set => SP(ref field, value); } = [];
 
 	// Store all outputs for searching, used as a temporary storage for filtering
 	// If ObservableCollection were used directly, any filtering or modification could remove items permanently
@@ -46,7 +42,6 @@ internal sealed partial class AllowNewAppsVM : ViewModelBase
 	internal readonly List<FileIdentity> LocalFilesAllFileIdentities = [];
 
 	internal ListViewHelper.SortState SortStateLocalFiles { get; set; } = new();
-
 
 	// To store the FileIdentities displayed on the Event Logs ListView
 	internal readonly ObservableCollection<FileIdentity> EventLogsFileIdentities = [];
@@ -63,10 +58,9 @@ internal sealed partial class AllowNewAppsVM : ViewModelBase
 
 	#region UI-Bound Properties
 
-	internal Visibility OpenInPolicyEditorInfoBarActionButtonVisibility
-	{
-		get; set => SP(ref field, value);
-	} = Visibility.Collapsed;
+	internal Visibility BrowseForXMLPolicyButtonLightAnimatedIconVisibility { get; set => SP(ref field, value); } = Visibility.Collapsed;
+
+	internal Visibility OpenInPolicyEditorInfoBarActionButtonVisibility { get; set => SP(ref field, value); } = Visibility.Collapsed;
 
 	/// <summary>
 	/// Holds the state of the Event Logs menu item, indicating whether it is enabled or disabled.
@@ -100,14 +94,31 @@ internal sealed partial class AllowNewAppsVM : ViewModelBase
 	internal double EventLogsCountInfoBadgeOpacity { get; set => SP(ref field, value); }
 
 	/// <summary>
-	/// Toggle button to determine whether the new Supplemental policy should be deployed on the system after creation or not
+	/// Toggle button to determine whether the new Supplemental policy should be deployed on the system after creation or not.
 	/// </summary>
 	internal bool DeployPolicy { get; set => SP(ref field, value); }
 
+	/// <summary>
+	/// The Enabled/Disabled state of the DeployPolicy button.
+	/// </summary>
 	internal bool DeployPolicyState { get; set => SP(ref field, value); }
 
-	#endregion
+	internal InfoBarSeverity Step1InfoBar_Severity { get; set => SP(ref field, value); }
+	internal bool Step1InfoBar_IsOpen { get; set => SP(ref field, value); }
+	internal bool Step1InfoBar_IsClosable { get; set => SP(ref field, value); }
+	internal string? Step1InfoBar_Message { get; set => SP(ref field, value); }
 
+	internal InfoBarSeverity Step2InfoBar_Severity { get; set => SP(ref field, value); }
+	internal bool Step2InfoBar_IsOpen { get; set => SP(ref field, value); }
+	internal bool Step2InfoBar_IsClosable { get; set => SP(ref field, value); }
+	internal string? Step2InfoBar_Message { get; set => SP(ref field, value); }
+
+	internal InfoBarSeverity Step3InfoBar_Severity { get; set => SP(ref field, value); }
+	internal bool Step3InfoBar_IsOpen { get; set => SP(ref field, value); }
+	internal bool Step3InfoBar_IsClosable { get; set => SP(ref field, value); }
+	internal string? Step3InfoBar_Message { get; set => SP(ref field, value); }
+
+	#endregion
 
 	#region LISTVIEW IMPLEMENTATIONS FOR EVENT LOGS
 
@@ -327,7 +338,6 @@ internal sealed partial class AllowNewAppsVM : ViewModelBase
 		UpdateTotalFiles(true);
 	}
 
-
 	/// <summary>
 	/// Updates the total logs count displayed on the UI
 	/// </summary>
@@ -346,7 +356,6 @@ internal sealed partial class AllowNewAppsVM : ViewModelBase
 			LocalFilesCountInfoBadgeValue = LocalFilesFileIdentities.Count;
 		}
 	}
-
 
 	/// <summary>
 	/// Event handler for the Clear Data button

--- a/AppControl Manager/ViewModels/CodeIntegrityInfoVM.cs
+++ b/AppControl Manager/ViewModels/CodeIntegrityInfoVM.cs
@@ -16,9 +16,9 @@
 //
 
 using System;
-using AppControlManager.Others;
-using System.Threading.Tasks;
 using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using AppControlManager.Others;
 
 namespace AppControlManager.ViewModels;
 

--- a/AppControl Manager/ViewModels/ConfigurePolicyRuleOptionsVM.cs
+++ b/AppControl Manager/ViewModels/ConfigurePolicyRuleOptionsVM.cs
@@ -15,12 +15,16 @@
 // See here for more information: https://github.com/HotCakeX/Harden-Windows-Security/blob/main/LICENSE
 //
 
+using Microsoft.UI.Xaml;
+
 namespace AppControlManager.ViewModels;
 
 #pragma warning disable CA1812 // an internal class that is apparently never instantiated
 // It's handled by Dependency Injection so this warning is a false-positive.
 internal sealed partial class ConfigurePolicyRuleOptionsVM : ViewModelBase
 {
+
+	internal Visibility BrowseForXMLPolicyButtonLightAnimatedIconVisibility { get; set => SP(ref field, value); } = Visibility.Collapsed;
 
 #pragma warning disable CA1822 // Mark members as static
 	internal bool IsElevated => App.IsElevated;

--- a/AppControl Manager/ViewModels/CreateSupplementalPolicyVM.cs
+++ b/AppControl Manager/ViewModels/CreateSupplementalPolicyVM.cs
@@ -28,6 +28,12 @@ namespace AppControlManager.ViewModels;
 internal sealed partial class CreateSupplementalPolicyVM : ViewModelBase
 {
 
+	internal Visibility FilesAndFoldersBasePolicyLightAnimatedIconVisibility { get; set => SP(ref field, value); } = Visibility.Collapsed;
+	internal Visibility CertificatesBasePolicyPathLightAnimatedIconVisibility { get; set => SP(ref field, value); } = Visibility.Collapsed;
+	internal Visibility ISGBasePolicyPathLightAnimatedIconVisibility { get; set => SP(ref field, value); } = Visibility.Collapsed;
+	internal Visibility StrictKernelModeBasePolicyLightAnimatedIconVisibility { get; set => SP(ref field, value); } = Visibility.Collapsed;
+	internal Visibility PFNBasePolicyPathLightAnimatedIconVisibility { get; set => SP(ref field, value); } = Visibility.Collapsed;
+
 
 	#region Files and Folders scan
 

--- a/AppControl Manager/ViewModels/DeploymentVM.cs
+++ b/AppControl Manager/ViewModels/DeploymentVM.cs
@@ -28,7 +28,7 @@ internal sealed partial class DeploymentVM : ViewModelBase
 
 	#region UI-Bound Properties
 
-	internal Visibility UnsignedXMLFilesLightAnimatedIcoVisibility { get; set => SP(ref field, value); } = Visibility.Collapsed;
+	internal Visibility UnsignedXMLFilesLightAnimatedIconVisibility { get; set => SP(ref field, value); } = Visibility.Collapsed;
 	internal Visibility SignedXMLFilesLightAnimatedIconVisibility { get; set => SP(ref field, value); } = Visibility.Collapsed;
 
 	internal Visibility MainInfoBarVisibility

--- a/AppControl Manager/ViewModels/DeploymentVM.cs
+++ b/AppControl Manager/ViewModels/DeploymentVM.cs
@@ -28,6 +28,9 @@ internal sealed partial class DeploymentVM : ViewModelBase
 
 	#region UI-Bound Properties
 
+	internal Visibility UnsignedXMLFilesLightAnimatedIcoVisibility { get; set => SP(ref field, value); } = Visibility.Collapsed;
+	internal Visibility SignedXMLFilesLightAnimatedIconVisibility { get; set => SP(ref field, value); } = Visibility.Collapsed;
+
 	internal Visibility MainInfoBarVisibility
 	{
 		get; set => SP(ref field, value);

--- a/AppControl Manager/ViewModels/MainWindowVM.cs
+++ b/AppControl Manager/ViewModels/MainWindowVM.cs
@@ -20,13 +20,13 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Numerics;
-using AppControlManager.WindowComponents;
+using AnimatedVisuals;
 using AppControlManager.Others;
+using AppControlManager.WindowComponents;
 using Microsoft.UI.Composition.SystemBackdrops;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
-using AnimatedVisuals;
 
 namespace AppControlManager.ViewModels;
 

--- a/AppControl Manager/ViewModels/PolicyEditorVM.cs
+++ b/AppControl Manager/ViewModels/PolicyEditorVM.cs
@@ -22,7 +22,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using AppControlManager.Others;
 using AppControlManager.SiPolicy;
-using AppControlManager.WindowComponents;
 using AppControlManager.SiPolicyIntel;
 using AppControlManager.XMLOps;
 using CommunityToolkit.WinUI;
@@ -848,13 +847,11 @@ internal sealed partial class PolicyEditorVM : ViewModelBase
 
 			await Dispatcher.EnqueueAsync(() =>
 			{
-
 				MainInfoBarVisibility = Visibility.Visible;
 				MainInfoBarIsOpen = true;
 				MainInfoBarMessage = $"There was a problem loading the selected policy file: {ex.Message}";
 				MainInfoBarSeverity = InfoBarSeverity.Error;
 				MainInfoBarIsClosable = true;
-
 			});
 
 			Logger.Write(ErrorWriter.FormatException(ex));
@@ -1652,5 +1649,45 @@ internal sealed partial class PolicyEditorVM : ViewModelBase
 	}
 
 #pragma warning restore CA1822
+
+	/// <summary>
+	/// Event handler for deleting selected items from the FileBasedRulesListView's Items Source
+	/// </summary>
+	internal void FileBasedRulesListView_DeleteItems()
+	{
+		// Get the ListView ScrollViewer info
+		ListView? lv = ListViewHelper.GetListViewFromCache(ListViewHelper.ListViewsRegistry.PolicyEditor_FileBasedRules);
+
+		if (lv is null) return;
+
+		// Collect the selected items to delete - without ToList() or [.. ], only half of the selected items are removed from the collection
+		IEnumerable<PolicyEditor.FileBasedRulesForListView> itemsToDelete = [.. lv.SelectedItems.Cast<PolicyEditor.FileBasedRulesForListView>()];
+
+		// Iterate over the copy to remove each item
+		foreach (PolicyEditor.FileBasedRulesForListView item in itemsToDelete)
+		{
+			RemoveFileRuleFromCollection(item);
+		}
+	}
+
+	/// <summary>
+	/// Event handler for deleting selected items from the SignatureBasedRulesListView's Items Source
+	/// </summary>
+	internal void SignatureBasedRulesListView_DeleteItems()
+	{
+		// Get the ListView ScrollViewer info
+		ListView? lv = ListViewHelper.GetListViewFromCache(ListViewHelper.ListViewsRegistry.PolicyEditor_SignatureBasedRules);
+
+		if (lv is null) return;
+
+		// Collect the selected items to delete - without ToList() or [.. ], only half of the selected items are removed from the collection
+		IEnumerable<PolicyEditor.SignatureBasedRulesForListView> itemsToDelete = [.. lv.SelectedItems.Cast<PolicyEditor.SignatureBasedRulesForListView>()];
+
+		// Iterate over the copy to remove each item
+		foreach (PolicyEditor.SignatureBasedRulesForListView item in itemsToDelete)
+		{
+			RemoveSignatureRuleFromCollection(item);
+		}
+	}
 
 }

--- a/AppControl Manager/ViewModels/ViewFileCertificatesVM.cs
+++ b/AppControl Manager/ViewModels/ViewFileCertificatesVM.cs
@@ -18,8 +18,12 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
+using System.Security.Cryptography.Pkcs;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using System.Threading.Tasks;
 using AppControlManager.Others;
 using CommunityToolkit.WinUI;
 using Microsoft.UI.Xaml;
@@ -381,5 +385,101 @@ internal sealed partial class ViewFileCertificatesVM : ViewModelBase
 			.AppendLine(GlobalVars.Rizz.GetString("TBSHashHeader/Text") + ": " + row.TBSHash)
 			.AppendLine(GlobalVars.Rizz.GetString("ExtensionOIDsHeader/Text") + ": " + row.OIDs)
 			.ToString();
+	}
+
+
+	/// <summary>
+	/// Get the certificates of the .CIP files
+	/// </summary>
+	/// <param name="file"></param>
+	/// <returns></returns>
+	internal static async Task<List<FileCertificateInfoCol>> FetchForCIP(string file)
+	{
+		List<FileCertificateInfoCol> output = [];
+
+		await Task.Run(() =>
+		{
+
+			// Create a new SignedCms object to store the signed message
+			SignedCms signedCms = new();
+
+			// Decode the signed message from the file specified by cipFilePath
+			// The file is read as a byte array because the SignedCms.Decode() method expects a byte array as input
+			// https://learn.microsoft.com/dotnet/api/system.security.cryptography.pkcs.signedcms.decode
+			signedCms.Decode(File.ReadAllBytes(file));
+
+			X509Certificate2Collection certificates = signedCms.Certificates;
+			X509Certificate2[] certificateArray = new X509Certificate2[certificates.Count];
+			certificates.CopyTo(certificateArray, 0);
+
+			// Counter (in case the CIP file is signed by multiple certificates)
+			int i = 1;
+
+			// Loop over the array of X509Certificate2 objects that represent the certificates used to sign the message
+			foreach (X509Certificate2 signer in certificateArray)
+			{
+				output.Add(new FileCertificateInfoCol
+				{
+					SignerNumber = i,
+					Type = CertificateType.Leaf,
+					SubjectCN = CryptoAPI.GetNameString(signer.Handle, CryptoAPI.CERT_NAME_SIMPLE_DISPLAY_TYPE, null, false), // SubjectCN
+					IssuerCN = CryptoAPI.GetNameString(signer.Handle, CryptoAPI.CERT_NAME_SIMPLE_DISPLAY_TYPE, null, true), // IssuerCN
+					NotBefore = signer.NotBefore,
+					NotAfter = signer.NotAfter,
+					HashingAlgorithm = signer.SignatureAlgorithm.FriendlyName,
+					SerialNumber = signer.SerialNumber,
+					Thumbprint = signer.Thumbprint,
+					TBSHash = CertificateHelper.GetTBSCertificate(signer),
+					OIDs = string.Join(", ", signer.Extensions
+							.Select(ext =>
+								ext.Oid is not null ? $"{ext.Oid.Value} ({ext.Oid.FriendlyName})" : ext?.Oid?.Value)
+							.Where(oid => !string.IsNullOrWhiteSpace(oid)))
+				});
+
+				i++;
+			}
+
+		});
+
+		return output;
+	}
+
+
+	/// <summary>
+	/// Fetch for the .cer files
+	/// </summary>
+	/// <param name="file"></param>
+	/// <returns></returns>
+	internal static async Task<List<FileCertificateInfoCol>> FetchForCER(string file)
+	{
+		List<FileCertificateInfoCol> output = [];
+
+		await Task.Run(() =>
+		{
+			// Create a certificate object from the .cer file
+			X509Certificate2 CertObject = X509CertificateLoader.LoadCertificateFromFile(file);
+
+			// Add the certificate as leaf certificate
+			output.Add(new FileCertificateInfoCol
+			{
+				SignerNumber = 1,
+				Type = CertificateType.Leaf,
+				SubjectCN = CryptoAPI.GetNameString(CertObject.Handle, CryptoAPI.CERT_NAME_SIMPLE_DISPLAY_TYPE, null, false), // SubjectCN
+				IssuerCN = CryptoAPI.GetNameString(CertObject.Handle, CryptoAPI.CERT_NAME_SIMPLE_DISPLAY_TYPE, null, true), // IssuerCN
+				NotBefore = CertObject.NotBefore,
+				NotAfter = CertObject.NotAfter,
+				HashingAlgorithm = CertObject.SignatureAlgorithm.FriendlyName,
+				SerialNumber = CertObject.SerialNumber,
+				Thumbprint = CertObject.Thumbprint,
+				TBSHash = CertificateHelper.GetTBSCertificate(CertObject),
+				OIDs = string.Join(", ", CertObject.Extensions
+						.Select(ext =>
+							ext.Oid is not null ? $"{ext.Oid.Value} ({ext.Oid.FriendlyName})" : ext?.Oid?.Value)
+						.Where(oid => !string.IsNullOrWhiteSpace(oid)))
+			});
+
+		});
+
+		return output;
 	}
 }

--- a/AppControl Manager/ViewModels/ViewOnlinePoliciesVM.cs
+++ b/AppControl Manager/ViewModels/ViewOnlinePoliciesVM.cs
@@ -202,7 +202,13 @@ internal sealed partial class ViewOnlinePoliciesVM : ViewModelBase
 			if (result is not null && result.Value is not null)
 			{
 
-				foreach (DeviceConfigurationPolicy item in result.Value)
+				// Only keep App Control policies
+				IEnumerable<DeviceConfigurationPolicy> filteredResults = result.Value.Where(policy =>
+				policy.OmaSettings != null
+				&& policy.OmaSettings.Any(setting => setting.OmaUri?.Contains(@"Vendor/MSFT/ApplicationControl", StringComparison.OrdinalIgnoreCase) == true
+				));
+
+				foreach (DeviceConfigurationPolicy item in filteredResults)
 				{
 
 					(bool, CiPolicyInfo?) policyResult = CiPolicyInfo.FromJson(item.Description);
@@ -259,7 +265,6 @@ internal sealed partial class ViewOnlinePoliciesVM : ViewModelBase
 					// If the custom Intune policy doesn't have the necessary details in its description then create an entry with its name only
 					else
 					{
-
 						CiPolicyInfo policy = new(
 											policyID: null,
 											basePolicyID: null,


### PR DESCRIPTION
* When retrieving online policies from the Intune, only App Control policies will be displayed on the List View and not other types of policies.
* Improved user experience in the Allow New Apps page.
