### PR TITLE
Internalizing policy templates

### DIFF
--- a/AppControl Manager/AppControl Manager.csproj
+++ b/AppControl Manager/AppControl Manager.csproj
@@ -361,7 +361,10 @@
     <None Remove="Pages\ValidatePolicy.xaml" />
     <None Remove="Pages\ViewCurrentPolicies.xaml" />
     <None Remove="Pages\ViewFileCertificates.xaml" />
+    <None Remove="Resources\Allow All Policy.xml" />
+    <None Remove="Resources\Allow Microsoft Template.xml" />
     <None Remove="Resources\AppControlManagerSupplementalPolicy.xml" />
+    <None Remove="Resources\Default Windows Template.xml" />
     <None Remove="Resources\EmptyPolicy.xml" />
     <None Remove="Resources\ISGBasedSupplementalPolicy.xml" />
     <None Remove="Resources\StrictKernelMode.xml" />
@@ -388,7 +391,16 @@
     <Content Include="CppInterop\ScheduledTaskManager-x64.exe">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="Resources\Allow All Policy.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Resources\Allow Microsoft Template.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="Resources\AppControlManagerSupplementalPolicy.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Resources\Default Windows Template.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="Resources\EmptyPolicy.xml">

--- a/AppControl Manager/AppControlManagerAPIDocumentation.xml
+++ b/AppControl Manager/AppControlManagerAPIDocumentation.xml
@@ -4393,6 +4393,11 @@
             for the SpcSpOpusInfo structure
             </summary>
         </member>
+        <member name="T:AppControlManager.Others.GlobalVars">
+            <summary>
+            This class defines constants and other variables used by the entire application
+            </summary>
+        </member>
         <member name="T:AppControlManager.Others.HashMismatchInCertificateException">
             <summary>
             a class to throw a custom exception when the certificate has HashMismatch

--- a/AppControl Manager/Main/BasePolicyCreator.cs
+++ b/AppControl Manager/Main/BasePolicyCreator.cs
@@ -461,9 +461,7 @@ Remove-Item -Path '.\VulnerableDriverBlockList.zip' -Force;""
 		if (PolicyIDToUse is null && DeployMicrosoftRecommendedBlockRules)
 			GetBlockRules(StagingArea, deploy);
 
-		Logger.Write("Copying the AllowMicrosoft.xml from Windows directory to the Staging Area");
-
-		File.Copy(@"C:\Windows\schemas\CodeIntegrity\ExamplePolicies\AllowMicrosoft.xml", tempPolicyPath, true);
+		File.Copy(GlobalVars.AllowMicrosoftTemplatePolicyPath, tempPolicyPath, true);
 
 		Logger.Write("Resetting the policy ID and assigning policy name");
 
@@ -551,9 +549,7 @@ Remove-Item -Path '.\VulnerableDriverBlockList.zip' -Force;""
 		if (PolicyIDToUse is null && DeployMicrosoftRecommendedBlockRules)
 			GetBlockRules(StagingArea, deploy);
 
-		Logger.Write("Copying the DefaultWindows.xml from Windows directory to the Staging Area");
-
-		File.Copy(@"C:\Windows\schemas\CodeIntegrity\ExamplePolicies\DefaultWindows_Enforced.xml", tempPolicyPath, true);
+		File.Copy(GlobalVars.DefaultWindowsTemplatePolicyPath, tempPolicyPath, true);
 
 		Logger.Write("Resetting the policy ID and assigning policy name");
 
@@ -738,10 +734,7 @@ Remove-Item -Path '.\VulnerableDriverBlockList.zip' -Force;""
 		if (PolicyIDToUse is null && DeployMicrosoftRecommendedBlockRules)
 			GetBlockRules(StagingArea, deploy);
 
-		Logger.Write("Copying the AllowMicrosoft.xml from Windows directory to the Staging Area");
-
-		File.Copy(@"C:\Windows\schemas\CodeIntegrity\ExamplePolicies\AllowMicrosoft.xml", tempPolicyPath, true);
-
+		File.Copy(GlobalVars.AllowMicrosoftTemplatePolicyPath, tempPolicyPath, true);
 
 		CiRuleOptions.Set(
 			tempPolicyPath,

--- a/AppControl Manager/Others/AppUpdate.cs
+++ b/AppControl Manager/Others/AppUpdate.cs
@@ -36,7 +36,7 @@ internal static class AppUpdate
 	/// </summary>
 	internal static event EventHandler<UpdateAvailableEventArgs>? UpdateAvailable;
 
-	private static ViewModels.UpdateVM UpdateVM { get; } = App.AppHost.Services.GetRequiredService<ViewModels.UpdateVM>();
+	private static UpdateVM UpdateVM { get; } = App.AppHost.Services.GetRequiredService<ViewModels.UpdateVM>();
 
 	internal static StoreContext? _StoreContext;
 

--- a/AppControl Manager/Others/GlobalVars.cs
+++ b/AppControl Manager/Others/GlobalVars.cs
@@ -22,7 +22,9 @@ using Microsoft.Windows.ApplicationModel.Resources;
 
 namespace AppControlManager.Others;
 
-// This class defines constants and other variables used by the entire application
+/// <summary>
+/// This class defines constants and other variables used by the entire application
+/// </summary>
 internal static class GlobalVars
 {
 	// Instantiate the ResourceLoader object to access the strings in the Resource.resw file
@@ -78,6 +80,15 @@ internal static class GlobalVars
 
 	// Path to the ISGBasedSupplementalPolicy.xml file
 	internal static readonly string ISGOnlySupplementalPolicyPath = Path.Combine(AppContext.BaseDirectory, "Resources", "ISGBasedSupplementalPolicy.xml");
+
+	// Path to the Allow All template policy file
+	internal static readonly string AllowAllTemplatePolicyPath = Path.Combine(AppContext.BaseDirectory, "Resources", "Allow All Policy.xml");
+
+	// Path to the Allow Microsoft template policy file
+	internal static readonly string AllowMicrosoftTemplatePolicyPath = Path.Combine(AppContext.BaseDirectory, "Resources", "Allow Microsoft Template.xml");
+
+	// Path to the Default Windows template policy file
+	internal static readonly string DefaultWindowsTemplatePolicyPath = Path.Combine(AppContext.BaseDirectory, "Resources", "Default Windows Template.xml");
 
 	// Path to the empty policy file in app resources
 	internal static readonly string EmptyPolicyPath = Path.Combine(AppContext.BaseDirectory, "Resources", "EmptyPolicy.xml");

--- a/AppControl Manager/Pages/UpdatePage.xaml
+++ b/AppControl Manager/Pages/UpdatePage.xaml
@@ -93,8 +93,8 @@
                     <ToggleSwitch IsOn="{x:Bind AppSettings.AutoCheckForUpdateAtStartup, Mode=TwoWay}"/>
                 </customUI:SettingsCardV2>
 
-                <customUI:SettingsCardV2 x:Uid="HardenedUpdateProcedureSettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xF552;}">
-                    <ToggleSwitch IsOn="{x:Bind ViewModel.UseHardenedInstallationProcess, Mode=TwoWay}" Visibility="{x:Bind ViewModel.HardenedProcedureSectionVisibility, Mode=OneWay}" />
+                <customUI:SettingsCardV2 x:Uid="HardenedUpdateProcedureSettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xF552;}" Visibility="{x:Bind ViewModel.HardenedProcedureSectionVisibility, Mode=OneWay}">
+                    <ToggleSwitch IsOn="{x:Bind ViewModel.UseHardenedInstallationProcess, Mode=TwoWay}" />
                 </customUI:SettingsCardV2>
 
                 <controls:SettingsCard

--- a/AppControl Manager/Resources/Allow All Policy.xml
+++ b/AppControl Manager/Resources/Allow All Policy.xml
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<SiPolicy PolicyType="Base Policy" xmlns="urn:schemas-microsoft-com:sipolicy">
+  <VersionEx>1.0.0.0</VersionEx>
+  <PolicyID>{0B769010-94AA-4505-ADE2-799F41362905}</PolicyID>
+  <BasePolicyID>{0B769010-94AA-4505-ADE2-799F41362905}</BasePolicyID>
+  <PlatformID>{2E07F7E4-194C-4D20-B7C9-6F44A6C5A234}</PlatformID>
+  <Rules>
+    <Rule>
+      <Option>Enabled:Unsigned System Integrity Policy</Option>
+    </Rule>
+    <Rule>
+      <Option>Enabled:Advanced Boot Options Menu</Option>
+    </Rule>
+    <Rule>
+      <Option>Enabled:UMCI</Option>
+    </Rule>
+    <Rule>
+      <Option>Enabled:Update Policy No Reboot</Option>
+    </Rule>
+    <Rule>
+      <Option>Enabled:Inherit Default Policy</Option>
+    </Rule>
+    <Rule>
+      <Option>Enabled:Revoked Expired As Unsigned</Option>
+    </Rule>
+    <Rule>
+      <Option>Disabled:Script Enforcement</Option>
+    </Rule>
+  </Rules>
+  <EKUs />
+  <FileRules>
+    <Allow ID="ID_ALLOW_A_0196C2F2BB537A558B835E34A6FDEFD8" FileName="*" />
+    <Allow ID="ID_ALLOW_A_0196C2F2BB5471AA8979D7832F7CEA7E" FileName="*" />
+  </FileRules>
+  <Signers />
+  <SigningScenarios>
+    <SigningScenario Value="12" ID="ID_SIGNINGSCENARIO_WINDOWS" FriendlyName="User Mode Code Integrity">
+      <ProductSigners>
+        <FileRulesRef>
+          <FileRuleRef RuleID="ID_ALLOW_A_0196C2F2BB5471AA8979D7832F7CEA7E" />
+        </FileRulesRef>
+      </ProductSigners>
+    </SigningScenario>
+    <SigningScenario Value="131" ID="ID_SIGNINGSCENARIO_DRIVERS_1" FriendlyName="Kernel Mode Code Integrity">
+      <ProductSigners>
+        <FileRulesRef>
+          <FileRuleRef RuleID="ID_ALLOW_A_0196C2F2BB537A558B835E34A6FDEFD8" />
+        </FileRulesRef>
+      </ProductSigners>
+    </SigningScenario>
+  </SigningScenarios>
+  <UpdatePolicySigners />
+  <CiSigners />
+  <HvciOptions>2</HvciOptions>
+  <Settings>
+    <Setting Provider="AllHostIds" Key="AllKeys" ValueName="EnterpriseDefinedClsId">
+      <Value>
+        <Boolean>true</Boolean>
+      </Value>
+    </Setting>
+    <Setting Provider="PolicyInfo" Key="Information" ValueName="Name">
+      <Value>
+        <String>Allow All Template</String>
+      </Value>
+    </Setting>
+    <Setting Provider="PolicyInfo" Key="Information" ValueName="Id">
+      <Value>
+        <String>022422</String>
+      </Value>
+    </Setting>
+  </Settings>
+</SiPolicy>

--- a/AppControl Manager/Resources/Allow Microsoft Template.xml
+++ b/AppControl Manager/Resources/Allow Microsoft Template.xml
@@ -1,0 +1,141 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<SiPolicy PolicyType="Base Policy" xmlns="urn:schemas-microsoft-com:sipolicy">
+  <VersionEx>1.0.0.0</VersionEx>
+  <PolicyID>{3F257CAD-2E49-4403-90D3-F202232DAE25}</PolicyID>
+  <BasePolicyID>{3F257CAD-2E49-4403-90D3-F202232DAE25}</BasePolicyID>
+  <PlatformID>{2E07F7E4-194C-4D20-B7C9-6F44A6C5A234}</PlatformID>
+  <Rules>
+    <Rule>
+      <Option>Enabled:Unsigned System Integrity Policy</Option>
+    </Rule>
+    <Rule>
+      <Option>Enabled:Advanced Boot Options Menu</Option>
+    </Rule>
+    <Rule>
+      <Option>Enabled:UMCI</Option>
+    </Rule>
+    <Rule>
+      <Option>Enabled:Inherit Default Policy</Option>
+    </Rule>
+    <Rule>
+      <Option>Enabled:Dynamic Code Security</Option>
+    </Rule>
+    <Rule>
+      <Option>Enabled:Update Policy No Reboot</Option>
+    </Rule>
+    <Rule>
+      <Option>Enabled:Allow Supplemental Policies</Option>
+    </Rule>
+  </Rules>
+  <EKUs>
+    <EKU ID="ID_EKU_E_0196C2FB9D8B7B5D867C49363FD091E0" FriendlyName="Windows Store EKU - 1.3.6.1.4.1.311.76.3.1 Windows Store" Value="010A2B0601040182374C0301" />
+  </EKUs>
+  <FileRules />
+  <Signers>
+    <Signer ID="ID_SIGNER_A_0196C2FB9D897E7285F50F1744180B38" Name="MincryptKnownRootMicrosoftProductRoot1997">
+      <CertRoot Type="Wellknown" Value="04" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB9D8A7ED1ABF0B3869B5CAED7" Name="MincryptKnownRootMicrosoftProductRoot2001">
+      <CertRoot Type="Wellknown" Value="05" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB9D8A7DE6B3481387FF1120FC" Name="MincryptKnownRootMicrosoftProductRoot2010">
+      <CertRoot Type="Wellknown" Value="06" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB9D8A7309AB1D470C8A58E3FC" Name="MincryptKnownRootMicrosoftStandardRoot2011">
+      <CertRoot Type="Wellknown" Value="07" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB9D8A709A81CF55481C298BA2" Name="MincryptKnownRootMicrosoftCodeVerificationRoot2006">
+      <CertRoot Type="Wellknown" Value="08" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB9D8A7CEAA568F084D400C432" Name="MincryptKnownRootMicrosoftDMDRoot2005">
+      <CertRoot Type="Wellknown" Value="0C" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB9D8A72479DC26DCE6FB9F142" Name="MincryptKnownRootMicrosoftFlightRoot2014">
+      <CertRoot Type="Wellknown" Value="0E" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB9D8A75A69B21B840BD0E87E5" Name="MincryptKnownRootMicrosoftTestRoot2010">
+      <CertRoot Type="Wellknown" Value="0A" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB9D8A7B91B655EE00075DFFC8" Name="MincryptKnownRootMicrosoftProductRoot1997">
+      <CertRoot Type="Wellknown" Value="04" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB9D8A7183A9C90AE79FCE5692" Name="MincryptKnownRootMicrosoftProductRoot2001">
+      <CertRoot Type="Wellknown" Value="05" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB9D8A7A248A7AE245DE30C739" Name="MincryptKnownRootMicrosoftProductRoot2010">
+      <CertRoot Type="Wellknown" Value="06" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB9D8A7152B81CEBFC2F1C6D66" Name="MincryptKnownRootMicrosoftStandardRoot2011">
+      <CertRoot Type="Wellknown" Value="07" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB9D8A7D6DA3DA1E5D7E3B8C1D" Name="MincryptKnownRootMicrosoftCodeVerificationRoot2006">
+      <CertRoot Type="Wellknown" Value="08" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB9D8A7DF2B49899EEA3366ECE" Name="MincryptKnownRootMicrosoftDMDRoot2005">
+      <CertRoot Type="Wellknown" Value="0C" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB9D8A7817839E74F749E987F9" Name="MincryptKnownRootMicrosoftFlightRoot2014">
+      <CertRoot Type="Wellknown" Value="0E" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB9D8D78B4BCA648CE2DA91829" Name="MincryptKnownRootMicrosoftTestRoot2010">
+      <CertRoot Type="Wellknown" Value="0A" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB9D8B7D789FDA15415901E68F" Name="Microsoft MarketPlace PCA 2011">
+      <CertRoot Type="TBS" Value="FC9EDE3DCCA09186B2D3BF9B738A2050CB1A554DA2DCADB55F3F72EE17721378" />
+      <CertEKU ID="ID_EKU_E_0196C2FB9D8B7B5D867C49363FD091E0" />
+    </Signer>
+  </Signers>
+  <SigningScenarios>
+    <SigningScenario Value="12" ID="ID_SIGNINGSCENARIO_WINDOWS" FriendlyName="User Mode Code Integrity">
+      <ProductSigners>
+        <AllowedSigners>
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB9D8A7B91B655EE00075DFFC8" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB9D8A7183A9C90AE79FCE5692" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB9D8A7A248A7AE245DE30C739" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB9D8A7152B81CEBFC2F1C6D66" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB9D8A7D6DA3DA1E5D7E3B8C1D" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB9D8A7DF2B49899EEA3366ECE" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB9D8A7817839E74F749E987F9" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB9D8D78B4BCA648CE2DA91829" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB9D8B7D789FDA15415901E68F" />
+        </AllowedSigners>
+      </ProductSigners>
+    </SigningScenario>
+    <SigningScenario Value="131" ID="ID_SIGNINGSCENARIO_DRIVERS_1" FriendlyName="Kernel Mode Code Integrity">
+      <ProductSigners>
+        <AllowedSigners>
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB9D897E7285F50F1744180B38" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB9D8A7ED1ABF0B3869B5CAED7" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB9D8A7DE6B3481387FF1120FC" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB9D8A7309AB1D470C8A58E3FC" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB9D8A709A81CF55481C298BA2" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB9D8A7CEAA568F084D400C432" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB9D8A72479DC26DCE6FB9F142" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB9D8A75A69B21B840BD0E87E5" />
+        </AllowedSigners>
+      </ProductSigners>
+    </SigningScenario>
+  </SigningScenarios>
+  <UpdatePolicySigners />
+  <CiSigners>
+    <CiSigner SignerId="ID_SIGNER_A_0196C2FB9D8B7D789FDA15415901E68F" />
+  </CiSigners>
+  <HvciOptions>2</HvciOptions>
+  <Settings>
+    <Setting Provider="AllHostIds" Key="{0468C085-CA5B-11D0-AF08-00609797F0E0}" ValueName="EnterpriseDefinedClsId">
+      <Value>
+        <Boolean>true</Boolean>
+      </Value>
+    </Setting>
+    <Setting Provider="PolicyInfo" Key="Information" ValueName="Name">
+      <Value>
+        <String>Allow Microsoft Template</String>
+      </Value>
+    </Setting>
+    <Setting Provider="PolicyInfo" Key="Information" ValueName="Id">
+      <Value>
+        <String>022422</String>
+      </Value>
+    </Setting>
+  </Settings>
+</SiPolicy>

--- a/AppControl Manager/Resources/Default Windows Template.xml
+++ b/AppControl Manager/Resources/Default Windows Template.xml
@@ -1,0 +1,233 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<SiPolicy PolicyType="Base Policy" xmlns="urn:schemas-microsoft-com:sipolicy">
+  <VersionEx>1.0.0.0</VersionEx>
+  <PolicyID>{F1DE99D7-CF38-4BBA-8B42-39D0EC3BA26E}</PolicyID>
+  <BasePolicyID>{F1DE99D7-CF38-4BBA-8B42-39D0EC3BA26E}</BasePolicyID>
+  <PlatformID>{2E07F7E4-194C-4D20-B7C9-6F44A6C5A234}</PlatformID>
+  <Rules>
+    <Rule>
+      <Option>Enabled:Unsigned System Integrity Policy</Option>
+    </Rule>
+    <Rule>
+      <Option>Enabled:Audit Mode</Option>
+    </Rule>
+    <Rule>
+      <Option>Enabled:Advanced Boot Options Menu</Option>
+    </Rule>
+    <Rule>
+      <Option>Enabled:UMCI</Option>
+    </Rule>
+    <Rule>
+      <Option>Enabled:Inherit Default Policy</Option>
+    </Rule>
+    <Rule>
+      <Option>Enabled:Update Policy No Reboot</Option>
+    </Rule>
+    <Rule>
+      <Option>Enabled:Dynamic Code Security</Option>
+    </Rule>
+    <Rule>
+      <Option>Enabled:Revoked Expired As Unsigned</Option>
+    </Rule>
+    <Rule>
+      <Option>Enabled:Allow Supplemental Policies</Option>
+    </Rule>
+  </Rules>
+  <EKUs>
+    <EKU ID="ID_EKU_E_0196C2FB45C776098FC3054E9CE9E1D0" FriendlyName="Windows EKU - 1.3.6.1.4.1.311.10.3.6" Value="010A2B0601040182370A0306" />
+    <EKU ID="ID_EKU_E_0196C2FB45C8734189A2421A2221449A" FriendlyName="Early Launch AntiMalware EKU - 1.3.6.1.4.1.311.61.4.1" Value="010A2B0601040182373D0401" />
+    <EKU ID="ID_EKU_E_0196C2FB45C87A388E1509DF365D2110" FriendlyName="Hardware Abstraction Layer EKU - 1.3.6.1.4.1.311.61.5.1" Value="010A2B0601040182373D0501" />
+    <EKU ID="ID_EKU_E_0196C2FB45C8750BBE352CDC384D9B19" FriendlyName="WHQL EKU - 1.3.6.1.4.1.311.10.3.5" Value="010A2B0601040182370A0305" />
+    <EKU ID="ID_EKU_E_0196C2FB45C973BBA6A3F98B08A4D23D" FriendlyName="Windows Store EKU - 1.3.6.1.4.1.311.76.3.1" Value="010A2B0601040182374C0301" />
+    <EKU ID="ID_EKU_E_0196C2FB45C970E582370D042534107F" FriendlyName="Windows RT EKU - 1.3.6.1.4.1.311.10.3.21" Value="010A2B0601040182370A0315" />
+    <EKU ID="ID_EKU_E_0196C2FB45C974CDAB7B56B50CAF4074" FriendlyName="Dynamic Code Generation EKU - 1.3.6.1.4.1.311.76.5.1" Value="010A2B0601040182374C0501" />
+    <EKU ID="ID_EKU_E_0196C2FB45C970C690D92302EAC5A765" FriendlyName="AntiMalware EKU - 1.3.6.1.4.1.311.76.11.1" Value="010A2B0601040182374C0B01" />
+    <EKU ID="ID_EKU_E_0196C2FB45C977BFAA57D217C1949156" FriendlyName="Enclave EKU - 1.3.6.1.4.1.311.10.3.42" Value="010A2B0601040182370A032A" />
+  </EKUs>
+  <FileRules />
+  <Signers>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C876F5926E4522EAC70419" Name="MincryptKnownRootMicrosoftTestRoot2010">
+      <CertRoot Type="Wellknown" Value="0A" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C9764AB3FD5124889C23FE" Name="MincryptKnownRootMicrosoftDMDRoot2005">
+      <CertRoot Type="Wellknown" Value="0C" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45CA706F888587E454BB230B" Name="MincryptKnownRootMicrosoftTestRoot2010">
+      <CertRoot Type="Wellknown" Value="0A" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C77AD0999BAD667F733174" Name="Microsoft Product Root 2010 Windows EKU">
+      <CertRoot Type="Wellknown" Value="06" />
+      <CertEKU ID="ID_EKU_E_0196C2FB45C776098FC3054E9CE9E1D0" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C870DA913FFF4DD24BEF9D" Name="Microsoft Product Root 2010 ELAM EKU">
+      <CertRoot Type="Wellknown" Value="06" />
+      <CertEKU ID="ID_EKU_E_0196C2FB45C8734189A2421A2221449A" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C876EF81640E3180E17C33" Name="Microsoft Product Root 2010 HAL EKU">
+      <CertRoot Type="Wellknown" Value="06" />
+      <CertEKU ID="ID_EKU_E_0196C2FB45C87A388E1509DF365D2110" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C879F3B147C69E42433269" Name="Microsoft Product Root 2010 WHQL EKU">
+      <CertRoot Type="Wellknown" Value="06" />
+      <CertEKU ID="ID_EKU_E_0196C2FB45C8750BBE352CDC384D9B19" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C877C88F721B28C0B6EFD1" Name="Microsoft Product Root WHQL EKU SHA1">
+      <CertRoot Type="Wellknown" Value="05" />
+      <CertEKU ID="ID_EKU_E_0196C2FB45C8750BBE352CDC384D9B19" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C87810BFF73CC26D530C67" Name="Microsoft Product Root WHQL EKU MD5">
+      <CertRoot Type="Wellknown" Value="04" />
+      <CertEKU ID="ID_EKU_E_0196C2FB45C8750BBE352CDC384D9B19" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C87E0CB4D90357D58275A3" Name="Microsoft Flighting Root 2014 Windows EKU">
+      <CertRoot Type="Wellknown" Value="0E" />
+      <CertEKU ID="ID_EKU_E_0196C2FB45C776098FC3054E9CE9E1D0" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C877A6BC2F6D6F745061A4" Name="Microsoft Flighting Root 2014 ELAM EKU">
+      <CertRoot Type="Wellknown" Value="0E" />
+      <CertEKU ID="ID_EKU_E_0196C2FB45C8734189A2421A2221449A" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C87061854DF91BD191F31B" Name="Microsoft Flighting Root 2014 HAL EKU">
+      <CertRoot Type="Wellknown" Value="0E" />
+      <CertEKU ID="ID_EKU_E_0196C2FB45C87A388E1509DF365D2110" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C87F8A9D9726F627E047B1" Name="Microsoft Flighting Root 2014 WHQL EKU">
+      <CertRoot Type="Wellknown" Value="0E" />
+      <CertEKU ID="ID_EKU_E_0196C2FB45C8750BBE352CDC384D9B19" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C97B8D934F0AA75DC7D7EB" Name="Microsoft Product Root 2010 Windows EKU">
+      <CertRoot Type="Wellknown" Value="06" />
+      <CertEKU ID="ID_EKU_E_0196C2FB45C776098FC3054E9CE9E1D0" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C97A82980A27B2CA2953BC" Name="Microsoft Product Root 2010 ELAM EKU">
+      <CertRoot Type="Wellknown" Value="06" />
+      <CertEKU ID="ID_EKU_E_0196C2FB45C8734189A2421A2221449A" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C97A77A347D197FF80AD8F" Name="Microsoft Product Root 2010 HAL EKU">
+      <CertRoot Type="Wellknown" Value="06" />
+      <CertEKU ID="ID_EKU_E_0196C2FB45C87A388E1509DF365D2110" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C9784C87D28BAEB2400AAD" Name="Microsoft Product Root 2010 WHQL EKU">
+      <CertRoot Type="Wellknown" Value="06" />
+      <CertEKU ID="ID_EKU_E_0196C2FB45C8750BBE352CDC384D9B19" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C97A9D8FA93547B2A07476" Name="Microsoft Product Root WHQL EKU SHA1">
+      <CertRoot Type="Wellknown" Value="05" />
+      <CertEKU ID="ID_EKU_E_0196C2FB45C8750BBE352CDC384D9B19" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C97645951E5D1C199AF919" Name="Microsoft Product Root WHQL EKU MD5">
+      <CertRoot Type="Wellknown" Value="04" />
+      <CertEKU ID="ID_EKU_E_0196C2FB45C8750BBE352CDC384D9B19" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C974FBAD4E070ACCFA36DB" Name="Microsoft Flighting Root 2014 Windows EKU">
+      <CertRoot Type="Wellknown" Value="0E" />
+      <CertEKU ID="ID_EKU_E_0196C2FB45C776098FC3054E9CE9E1D0" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C97F73BE9F7AD7A9BCF285" Name="Microsoft Flighting Root 2014 ELAM EKU">
+      <CertRoot Type="Wellknown" Value="0E" />
+      <CertEKU ID="ID_EKU_E_0196C2FB45C8734189A2421A2221449A" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C97040AB41233F4EB5D43B" Name="Microsoft Flighting Root 2014 HAL EKU">
+      <CertRoot Type="Wellknown" Value="0E" />
+      <CertEKU ID="ID_EKU_E_0196C2FB45C87A388E1509DF365D2110" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C97E24BC12091E4183A1C0" Name="Microsoft Flighting Root 2014 WHQL EKU">
+      <CertRoot Type="Wellknown" Value="0E" />
+      <CertEKU ID="ID_EKU_E_0196C2FB45C8750BBE352CDC384D9B19" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C971448F44DBF408A496FF" Name="Microsoft MarketPlace PCA 2011">
+      <CertRoot Type="TBS" Value="FC9EDE3DCCA09186B2D3BF9B738A2050CB1A554DA2DCADB55F3F72EE17721378" />
+      <CertEKU ID="ID_EKU_E_0196C2FB45C973BBA6A3F98B08A4D23D" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C9703882554D18DB2F48E5" Name="Microsoft Flighting Root 2014 Store EKU">
+      <CertRoot Type="Wellknown" Value="0E" />
+      <CertEKU ID="ID_EKU_E_0196C2FB45C973BBA6A3F98B08A4D23D" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C97396BF1991C4DC0DDC38" Name="Microsoft Product Root 2010 RT EKU">
+      <CertRoot Type="Wellknown" Value="06" />
+      <CertEKU ID="ID_EKU_E_0196C2FB45C970E582370D042534107F" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C977FC98096F4767713696" Name="MincryptKnownRootMicrosoftProductRoot2010">
+      <CertRoot Type="Wellknown" Value="06" />
+      <CertEKU ID="ID_EKU_E_0196C2FB45C974CDAB7B56B50CAF4074" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C97FF180D84249283A78D4" Name="MincryptKnownRootMicrosoftStandardRoot2011">
+      <CertRoot Type="Wellknown" Value="07" />
+      <CertEKU ID="ID_EKU_E_0196C2FB45C970C690D92302EAC5A765" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C973A8A8525E98782518A5" Name="Microsoft Flighting Root 2014 RT EKU">
+      <CertRoot Type="Wellknown" Value="0E" />
+      <CertEKU ID="ID_EKU_E_0196C2FB45C970E582370D042534107F" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C9789B83057B060C2F941F" Name="Microsoft Standard Root 2011 RT EKU">
+      <CertRoot Type="Wellknown" Value="07" />
+      <CertEKU ID="ID_EKU_E_0196C2FB45C970E582370D042534107F" />
+    </Signer>
+    <Signer ID="ID_SIGNER_A_0196C2FB45C974FC9064AC8F068A4033" Name="Microsoft Standard Root 2011 Enclave EKU">
+      <CertRoot Type="Wellknown" Value="07" />
+      <CertEKU ID="ID_EKU_E_0196C2FB45C977BFAA57D217C1949156" />
+    </Signer>
+  </Signers>
+  <SigningScenarios>
+    <SigningScenario Value="12" ID="ID_SIGNINGSCENARIO_WINDOWS" FriendlyName="User Mode Code Integrity">
+      <ProductSigners>
+        <AllowedSigners>
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C9764AB3FD5124889C23FE" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45CA706F888587E454BB230B" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C97B8D934F0AA75DC7D7EB" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C97A82980A27B2CA2953BC" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C97A77A347D197FF80AD8F" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C9784C87D28BAEB2400AAD" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C97A9D8FA93547B2A07476" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C97645951E5D1C199AF919" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C974FBAD4E070ACCFA36DB" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C97F73BE9F7AD7A9BCF285" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C97040AB41233F4EB5D43B" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C97E24BC12091E4183A1C0" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C971448F44DBF408A496FF" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C9703882554D18DB2F48E5" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C97396BF1991C4DC0DDC38" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C977FC98096F4767713696" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C97FF180D84249283A78D4" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C973A8A8525E98782518A5" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C9789B83057B060C2F941F" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C974FC9064AC8F068A4033" />
+        </AllowedSigners>
+      </ProductSigners>
+    </SigningScenario>
+    <SigningScenario Value="131" ID="ID_SIGNINGSCENARIO_DRIVERS_1" FriendlyName="Kernel Mode Code Integrity">
+      <ProductSigners>
+        <AllowedSigners>
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C876F5926E4522EAC70419" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C77AD0999BAD667F733174" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C870DA913FFF4DD24BEF9D" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C876EF81640E3180E17C33" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C879F3B147C69E42433269" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C877C88F721B28C0B6EFD1" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C87810BFF73CC26D530C67" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C87E0CB4D90357D58275A3" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C877A6BC2F6D6F745061A4" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C87061854DF91BD191F31B" />
+          <AllowedSigner SignerId="ID_SIGNER_A_0196C2FB45C87F8A9D9726F627E047B1" />
+        </AllowedSigners>
+      </ProductSigners>
+    </SigningScenario>
+  </SigningScenarios>
+  <UpdatePolicySigners />
+  <CiSigners>
+    <CiSigner SignerId="ID_SIGNER_A_0196C2FB45C971448F44DBF408A496FF" />
+  </CiSigners>
+  <HvciOptions>2</HvciOptions>
+  <Settings>
+    <Setting Provider="PolicyInfo" Key="Information" ValueName="Name">
+      <Value>
+        <String>Default Windows Template</String>
+      </Value>
+    </Setting>
+    <Setting Provider="PolicyInfo" Key="Information" ValueName="Id">
+      <Value>
+        <String>04122024</String>
+      </Value>
+    </Setting>
+  </Settings>
+</SiPolicy>

--- a/AppControl Manager/XMLOps/Master.cs
+++ b/AppControl Manager/XMLOps/Master.cs
@@ -15,7 +15,6 @@
 // See here for more information: https://github.com/HotCakeX/Harden-Windows-Security/blob/main/LICENSE
 //
 
-using System;
 using System.IO;
 using AppControlManager.Others;
 
@@ -53,12 +52,8 @@ internal static class Master
 			NewFilePathRules.CreateDeny(xmlFilePath, incomingData.FilePaths);
 			NewPFNLevelRules.CreateDeny(xmlFilePath, incomingData.PFNRules);
 
-			// Path to the AllowAll XML file on the system
-			string AllowAllFilePath = Path.Combine(Path.GetPathRoot(Environment.SystemDirectory)!, @"Windows\schemas\CodeIntegrity\ExamplePolicies\AllowAll.xml");
-
-			// Copy it to the staging area since it's inaccessible in the system directory
 			string finalAllowAllFilePath = Path.Combine(stagingArea!, "AllowAll.xml");
-			File.Copy(AllowAllFilePath, finalAllowAllFilePath, true);
+			File.Copy(GlobalVars.AllowAllTemplatePolicyPath, finalAllowAllFilePath, true);
 
 			// Merge the policy with the AllowAll XML policy since this is a Deny policy type
 			SiPolicy.Merger.Merge(xmlFilePath, [xmlFilePath, finalAllowAllFilePath]);


### PR DESCRIPTION
Created template policies for Allow Microsoft, Default Windows and Allow All. They've been created to be secure by default. This also means the AppControl Manager no longer depends on any template policies on the OS, increasing security and success rate.
