### PR TITLE
Adding JSON export option to rest of the pages in AppControl Manager

### DIFF
--- a/AppControl Manager/App.xaml.cs
+++ b/AppControl Manager/App.xaml.cs
@@ -505,6 +505,8 @@ public partial class App : Application
 			{
 				if (Enum.TryParse(Settings.LaunchActivationAction, true, out ViewModelBase.LaunchProtocolActions parsedAction))
 				{
+					// TODO: Remove this suppression after implementing policy deployment through CLI properly.
+#pragma warning disable IDE0010
 					switch (parsedAction)
 					{
 						case ViewModelBase.LaunchProtocolActions.PolicyEditor:

--- a/AppControl Manager/Pages/AllowNewApps/AllowNewAppsEventLogsDataGrid.xaml
+++ b/AppControl Manager/Pages/AllowNewApps/AllowNewAppsEventLogsDataGrid.xaml
@@ -21,54 +21,75 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <Border Grid.Row="0" Margin="0,10,0,10" Style="{StaticResource GridCardStyle}" Padding="8">
+        <Expander Grid.Row="0" Margin="0,0,0,10" Padding="8" HorizontalAlignment="Stretch">
+            <Expander.Header>
 
-            <controls:WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalSpacing="10" VerticalSpacing="10">
+                <controls:WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalSpacing="10" VerticalSpacing="10">
 
-                <ProgressRing x:Name="SelectLogsProgressRing" Visibility="Collapsed" IsActive="False" />
+                    <ProgressRing x:Name="SelectLogsProgressRing" Visibility="Collapsed" IsActive="False" />
 
-                <DropDownButton x:Uid="ExtraActionsDropDownButton">
-                    <DropDownButton.Flyout>
+                    <DropDownButton x:Uid="ExtraActionsDropDownButton">
+                        <DropDownButton.Flyout>
 
-                        <MenuFlyout Placement="Bottom">
+                            <MenuFlyout Placement="Bottom">
 
-                            <MenuFlyoutItem x:Uid="SelectAllMenuFlyoutItem" Click="{x:Bind ViewModel.SelectAll_Click_EventLogs}">
-                                <MenuFlyoutItem.Icon>
-                                    <FontIcon Glyph="&#xE762;"/>
-                                </MenuFlyoutItem.Icon>
-                            </MenuFlyoutItem>
+                                <MenuFlyoutItem x:Uid="SelectAllMenuFlyoutItem" Click="{x:Bind ViewModel.SelectAll_Click_EventLogs}">
+                                    <MenuFlyoutItem.Icon>
+                                        <FontIcon Glyph="&#xE762;"/>
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
 
-                            <MenuFlyoutItem x:Uid="DeSelectAllMenuFlyoutItem" Click="{x:Bind ViewModel.DeSelectAll_Click_EventLogs}">
-                                <MenuFlyoutItem.Icon>
-                                    <FontIcon Glyph="&#xE8E6;"/>
-                                </MenuFlyoutItem.Icon>
-                            </MenuFlyoutItem>
+                                <MenuFlyoutItem x:Uid="DeSelectAllMenuFlyoutItem" Click="{x:Bind ViewModel.DeSelectAll_Click_EventLogs}">
+                                    <MenuFlyoutItem.Icon>
+                                        <FontIcon Glyph="&#xE8E6;"/>
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
 
-                            <MenuFlyoutItem Click="{x:Bind ViewModel.ClearEventLogsDataButton_Click}" x:Uid="ClearDataMenuFlyoutItem">
-                                <MenuFlyoutItem.Icon>
-                                    <SymbolIcon Symbol="Delete" />
-                                </MenuFlyoutItem.Icon>
-                            </MenuFlyoutItem>
+                                <MenuFlyoutItem Click="{x:Bind ViewModel.ClearEventLogsDataButton_Click}" x:Uid="ClearDataMenuFlyoutItem">
+                                    <MenuFlyoutItem.Icon>
+                                        <SymbolIcon Symbol="Delete" />
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
 
-                        </MenuFlyout>
+                            </MenuFlyout>
 
-                    </DropDownButton.Flyout>
-                </DropDownButton>
+                        </DropDownButton.Flyout>
+                    </DropDownButton>
 
-                <TextBox Text="{x:Bind ViewModel.EventLogsAllFileIdentitiesSearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                    <TextBox Text="{x:Bind ViewModel.EventLogsAllFileIdentitiesSearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                          Width="300"
                          x:Uid="SearchBoxTextBox"
                          VerticalAlignment="Center"
                          VerticalContentAlignment="Center" />
 
-            </controls:WrapPanel>
-        </Border>
+                </controls:WrapPanel>
+
+            </Expander.Header>
+
+            <Expander.Content>
+
+                <controls:WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalSpacing="10" VerticalSpacing="10">
+
+                    <Button Click="{x:Bind ViewModel.ExportEventLogsToJsonButton_Click}"
+                            x:Uid="ExportToJSONButton">
+                        <Button.Content>
+                            <StackPanel Orientation="Horizontal" Spacing="5">
+                                <FontIcon Glyph="&#xE96A;" />
+                                <TextBlock x:Uid="ExportToJSONButtonText" />
+                            </StackPanel>
+                        </Button.Content>
+                    </Button>
+
+                </controls:WrapPanel>
+
+            </Expander.Content>
+        </Expander>
 
         <customUI:ListViewV2 x:Name="FileIdentitiesListView"
-    RegistryKey="Allow_New_Apps_EventLogs_ScanResults"
-    Grid.Row="1"
-    SelectionMode="Extended"
-    ItemsSource="{x:Bind ViewModel.EventLogsFileIdentities, Mode=OneWay}">
+                             RegistryKey="Allow_New_Apps_EventLogs_ScanResults"
+                             Grid.Row="1"
+                             SelectionMode="Extended"
+                             ItemsSource="{x:Bind ViewModel.EventLogsFileIdentities, Mode=OneWay}">
 
             <customUI:ListViewV2.Header>
 
@@ -322,27 +343,27 @@
                         </Grid.ContextFlyout>
 
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs1}" />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs2}" />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs3}" />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs4}" />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs5}" />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs6}" />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs7}" />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs8}" />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs9}" />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs10}"  />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs11}"  />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs12}"  />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs13}"  />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs14}"  />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs15}"  />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs16}"  />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs17}"  />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs18}"  />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs19}"  />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs20}"  />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs21}"  />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs1, Mode=OneWay}" />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs2, Mode=OneWay}" />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs3, Mode=OneWay}" />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs4, Mode=OneWay}" />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs5, Mode=OneWay}" />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs6, Mode=OneWay}" />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs7, Mode=OneWay}" />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs8, Mode=OneWay}" />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs9, Mode=OneWay}" />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs10, Mode=OneWay}"  />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs11, Mode=OneWay}"  />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs12, Mode=OneWay}"  />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs13, Mode=OneWay}"  />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs14, Mode=OneWay}"  />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs15, Mode=OneWay}"  />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs16, Mode=OneWay}"  />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs17, Mode=OneWay}"  />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs18, Mode=OneWay}"  />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs19, Mode=OneWay}"  />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs20, Mode=OneWay}"  />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelAllowNewApps.ColumnWidthEventLogs21, Mode=OneWay}"  />
                         </Grid.ColumnDefinitions>
                         <TextBlock Text="{x:Bind FileName}" Style="{StaticResource ListViewCellTextBlock}" Grid.Column="0"/>
                         <TextBlock Text="{x:Bind TimeCreated}" Style="{StaticResource ListViewCellTextBlock}" Grid.Column="1"/>

--- a/AppControl Manager/Pages/AllowNewApps/AllowNewAppsLocalFilesDataGrid.xaml
+++ b/AppControl Manager/Pages/AllowNewApps/AllowNewAppsLocalFilesDataGrid.xaml
@@ -21,55 +21,75 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <Border Grid.Row="0" Margin="0,10,0,10" Style="{StaticResource GridCardStyle}" Padding="8">
+        <Expander Grid.Row="0" Margin="0,0,0,10" Padding="8" HorizontalAlignment="Stretch">
+            <Expander.Header>
 
-            <controls:WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalSpacing="10" VerticalSpacing="10">
+                <controls:WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalSpacing="10" VerticalSpacing="10">
 
-                <ProgressRing x:Name="SelectLogsProgressRing" Visibility="Collapsed" IsActive="False" />
+                    <ProgressRing x:Name="SelectLogsProgressRing" Visibility="Collapsed" IsActive="False" />
 
-                <DropDownButton x:Uid="ExtraActionsDropDownButton">
-                    <DropDownButton.Flyout>
+                    <DropDownButton x:Uid="ExtraActionsDropDownButton">
+                        <DropDownButton.Flyout>
 
-                        <MenuFlyout Placement="Bottom">
+                            <MenuFlyout Placement="Bottom">
 
-                            <MenuFlyoutItem x:Uid="SelectAllMenuFlyoutItem" Click="{x:Bind ViewModel.SelectAll_Click_LocalFiles}">
-                                <MenuFlyoutItem.Icon>
-                                    <FontIcon Glyph="&#xE762;"/>
-                                </MenuFlyoutItem.Icon>
-                            </MenuFlyoutItem>
+                                <MenuFlyoutItem x:Uid="SelectAllMenuFlyoutItem" Click="{x:Bind ViewModel.SelectAll_Click_LocalFiles}">
+                                    <MenuFlyoutItem.Icon>
+                                        <FontIcon Glyph="&#xE762;"/>
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
 
-                            <MenuFlyoutItem x:Uid="DeSelectAllMenuFlyoutItem" Click="{x:Bind ViewModel.DeSelectAll_Click_LocalFiles}">
-                                <MenuFlyoutItem.Icon>
-                                    <FontIcon Glyph="&#xE8E6;"/>
-                                </MenuFlyoutItem.Icon>
-                            </MenuFlyoutItem>
+                                <MenuFlyoutItem x:Uid="DeSelectAllMenuFlyoutItem" Click="{x:Bind ViewModel.DeSelectAll_Click_LocalFiles}">
+                                    <MenuFlyoutItem.Icon>
+                                        <FontIcon Glyph="&#xE8E6;"/>
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
 
-                            <MenuFlyoutItem Click="{x:Bind ViewModel.ClearLocalFilesDataButton_Click}" x:Uid="ClearDataMenuFlyoutItem">
-                                <MenuFlyoutItem.Icon>
-                                    <SymbolIcon Symbol="Delete" />
-                                </MenuFlyoutItem.Icon>
-                            </MenuFlyoutItem>
+                                <MenuFlyoutItem Click="{x:Bind ViewModel.ClearLocalFilesDataButton_Click}" x:Uid="ClearDataMenuFlyoutItem">
+                                    <MenuFlyoutItem.Icon>
+                                        <SymbolIcon Symbol="Delete" />
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
 
-                        </MenuFlyout>
+                            </MenuFlyout>
 
-                    </DropDownButton.Flyout>
-                </DropDownButton>
+                        </DropDownButton.Flyout>
+                    </DropDownButton>
 
-                <TextBox
+                    <TextBox
                     Width="300"
                     x:Uid="SearchBoxTextBox"
                     Text="{x:Bind ViewModel.LocalFilesAllFileIdentitiesSearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                     VerticalAlignment="Center"
                     VerticalContentAlignment="Center" />
 
-            </controls:WrapPanel>
-        </Border>
+                </controls:WrapPanel>
+            </Expander.Header>
+
+            <Expander.Content>
+
+                <controls:WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalSpacing="10" VerticalSpacing="10">
+
+                    <Button Click="{x:Bind ViewModel.ExportLocalFilesToJsonButton_Click}"
+                            x:Uid="ExportToJSONButton">
+                        <Button.Content>
+                            <StackPanel Orientation="Horizontal" Spacing="5">
+                                <FontIcon Glyph="&#xE96A;" />
+                                <TextBlock x:Uid="ExportToJSONButtonText" />
+                            </StackPanel>
+                        </Button.Content>
+                    </Button>
+
+                </controls:WrapPanel>
+
+            </Expander.Content>
+        </Expander>
 
         <customUI:ListViewV2 x:Name="FileIdentitiesListView"
-RegistryKey="Allow_New_Apps_LocalFiles_ScanResults"
-Grid.Row="1"
-SelectionMode="Extended"
-ItemsSource="{x:Bind ViewModel.LocalFilesFileIdentities, Mode=OneWay}">
+                             RegistryKey="Allow_New_Apps_LocalFiles_ScanResults"
+                             Grid.Row="1"
+                             SelectionMode="Extended"
+                             ItemsSource="{x:Bind ViewModel.LocalFilesFileIdentities, Mode=OneWay}">
 
             <customUI:ListViewV2.Header>
 

--- a/AppControl Manager/Pages/CreateDenyPolicyFilesAndFoldersScanResults.xaml
+++ b/AppControl Manager/Pages/CreateDenyPolicyFilesAndFoldersScanResults.xaml
@@ -28,54 +28,74 @@
 
         </controls:WrapPanel>
 
-        <Border Grid.Row="1" Margin="0,10,0,10" Style="{StaticResource GridCardStyle}" Padding="8">
+        <Expander Grid.Row="1" Margin="0,0,0,10" Padding="8" HorizontalAlignment="Stretch">
+            <Expander.Header>
 
-            <controls:WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalSpacing="10" VerticalSpacing="10">
+                <controls:WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalSpacing="10" VerticalSpacing="10">
 
-                <ProgressRing x:Name="SelectLogsProgressRing" Visibility="Collapsed" IsActive="False" />
+                    <ProgressRing x:Name="SelectLogsProgressRing" Visibility="Collapsed" IsActive="False" />
 
-                <DropDownButton x:Uid="ExtraActionsDropDownButton">
-                    <DropDownButton.Flyout>
+                    <DropDownButton x:Uid="ExtraActionsDropDownButton">
+                        <DropDownButton.Flyout>
 
-                        <MenuFlyout Placement="Bottom">
+                            <MenuFlyout Placement="Bottom">
 
-                            <MenuFlyoutItem x:Uid="SelectAllMenuFlyoutItem" Click="{x:Bind ViewModel.SelectAll_Click}">
-                                <MenuFlyoutItem.Icon>
-                                    <FontIcon Glyph="&#xE762;"/>
-                                </MenuFlyoutItem.Icon>
-                            </MenuFlyoutItem>
+                                <MenuFlyoutItem x:Uid="SelectAllMenuFlyoutItem" Click="{x:Bind ViewModel.SelectAll_Click}">
+                                    <MenuFlyoutItem.Icon>
+                                        <FontIcon Glyph="&#xE762;"/>
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
 
-                            <MenuFlyoutItem x:Uid="DeSelectAllMenuFlyoutItem" Click="{x:Bind ViewModel.DeSelectAll_Click}">
-                                <MenuFlyoutItem.Icon>
-                                    <FontIcon Glyph="&#xE8E6;"/>
-                                </MenuFlyoutItem.Icon>
-                            </MenuFlyoutItem>
+                                <MenuFlyoutItem x:Uid="DeSelectAllMenuFlyoutItem" Click="{x:Bind ViewModel.DeSelectAll_Click}">
+                                    <MenuFlyoutItem.Icon>
+                                        <FontIcon Glyph="&#xE8E6;"/>
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
 
-                            <MenuFlyoutItem Click="{x:Bind ViewModel.ClearDataButton_Click}" x:Uid="ClearDataMenuFlyoutItem">
-                                <MenuFlyoutItem.Icon>
-                                    <SymbolIcon Symbol="Delete" />
-                                </MenuFlyoutItem.Icon>
-                            </MenuFlyoutItem>
+                                <MenuFlyoutItem Click="{x:Bind ViewModel.ClearDataButton_Click}" x:Uid="ClearDataMenuFlyoutItem">
+                                    <MenuFlyoutItem.Icon>
+                                        <SymbolIcon Symbol="Delete" />
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
 
-                        </MenuFlyout>
+                            </MenuFlyout>
 
-                    </DropDownButton.Flyout>
-                </DropDownButton>
+                        </DropDownButton.Flyout>
+                    </DropDownButton>
 
-                <TextBox x:Uid="TotalLogsTextBlock"
+                    <TextBox x:Uid="TotalLogsTextBlock"
                          Text="{x:Bind ViewModel.TotalCountOfTheFilesTextBox, Mode=OneWay}"
                          IsReadOnly="True"
                          VerticalAlignment="Center"
                          VerticalContentAlignment="Center"/>
 
-                <TextBox Width="300"
+                    <TextBox Width="300"
                          x:Uid="SearchBoxTextBox"
                          Text="{x:Bind ViewModel.FilesAndFoldersScanResultsSearchTextBox, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                          VerticalAlignment="Center"
                          VerticalContentAlignment="Center" />
 
-            </controls:WrapPanel>
-        </Border>
+                </controls:WrapPanel>
+            </Expander.Header>
+
+            <Expander.Content>
+
+                <controls:WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalSpacing="10" VerticalSpacing="10">
+
+                    <Button Click="{x:Bind ViewModel.ExportFilesAndFoldersToJsonButton_Click}"
+                            x:Uid="ExportToJSONButton">
+                        <Button.Content>
+                            <StackPanel Orientation="Horizontal" Spacing="5">
+                                <FontIcon Glyph="&#xE96A;" />
+                                <TextBlock x:Uid="ExportToJSONButtonText" />
+                            </StackPanel>
+                        </Button.Content>
+                    </Button>
+
+                </controls:WrapPanel>
+
+            </Expander.Content>
+        </Expander>
 
         <customUI:ListViewV2 x:Name="FileIdentitiesListView"
           RegistryKey="DenyPolicy_FilesAndFolders_ScanResults"
@@ -302,24 +322,24 @@
                         </Grid.ContextFlyout>
 
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth1}" />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth2}" />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth3}" />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth4}" />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth5}" />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth6}" />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth7}" />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth8}" />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth9}" />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth10}" />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth11}" />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth12}" />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth13}" />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth14}" />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth15}" />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth16}" />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth17}" />
-                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth18}" />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth1, Mode=OneWay}" />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth2, Mode=OneWay}" />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth3, Mode=OneWay}" />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth4, Mode=OneWay}" />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth5, Mode=OneWay}" />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth6, Mode=OneWay}" />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth7, Mode=OneWay}" />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth8, Mode=OneWay}" />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth9, Mode=OneWay}" />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth10, Mode=OneWay}" />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth11, Mode=OneWay}" />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth12, Mode=OneWay}" />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth13, Mode=OneWay}" />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth14, Mode=OneWay}" />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth15, Mode=OneWay}" />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth16, Mode=OneWay}" />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth17, Mode=OneWay}" />
+                            <ColumnDefinition Width="{x:Bind ParentViewModelCreateDenyPolicyVM.ColumnWidth18, Mode=OneWay}" />
                         </Grid.ColumnDefinitions>
                         <TextBlock Text="{x:Bind FileName}" Style="{StaticResource ListViewCellTextBlock}" Grid.Column="0"/>
                         <TextBlock Text="{x:Bind SignatureStatus}" Style="{StaticResource ListViewCellTextBlock}" Grid.Column="1"/>

--- a/AppControl Manager/Pages/CreateSupplementalPolicyFilesAndFoldersScanResults.xaml
+++ b/AppControl Manager/Pages/CreateSupplementalPolicyFilesAndFoldersScanResults.xaml
@@ -28,59 +28,78 @@
 
         </controls:WrapPanel>
 
-        <Border Grid.Row="1" Margin="0,10,0,10" Style="{StaticResource GridCardStyle}" Padding="8">
+        <Expander Grid.Row="1" Margin="0,0,0,10" Padding="8" HorizontalAlignment="Stretch">
+            <Expander.Header>
 
-            <controls:WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalSpacing="10" VerticalSpacing="10">
+                <controls:WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalSpacing="10" VerticalSpacing="10">
 
-                <DropDownButton x:Uid="ExtraActionsDropDownButton">
-                    <DropDownButton.Flyout>
+                    <DropDownButton x:Uid="ExtraActionsDropDownButton">
+                        <DropDownButton.Flyout>
 
-                        <MenuFlyout Placement="Bottom">
+                            <MenuFlyout Placement="Bottom">
 
-                            <MenuFlyoutItem x:Uid="SelectAllMenuFlyoutItem" Click="{x:Bind ViewModel.SelectAll_Click}">
-                                <MenuFlyoutItem.Icon>
-                                    <FontIcon Glyph="&#xE762;"/>
-                                </MenuFlyoutItem.Icon>
-                            </MenuFlyoutItem>
+                                <MenuFlyoutItem x:Uid="SelectAllMenuFlyoutItem" Click="{x:Bind ViewModel.SelectAll_Click}">
+                                    <MenuFlyoutItem.Icon>
+                                        <FontIcon Glyph="&#xE762;"/>
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
 
-                            <MenuFlyoutItem x:Uid="DeSelectAllMenuFlyoutItem" Click="{x:Bind ViewModel.DeSelectAll_Click}">
-                                <MenuFlyoutItem.Icon>
-                                    <FontIcon Glyph="&#xE8E6;"/>
-                                </MenuFlyoutItem.Icon>
-                            </MenuFlyoutItem>
+                                <MenuFlyoutItem x:Uid="DeSelectAllMenuFlyoutItem" Click="{x:Bind ViewModel.DeSelectAll_Click}">
+                                    <MenuFlyoutItem.Icon>
+                                        <FontIcon Glyph="&#xE8E6;"/>
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
 
-                            <MenuFlyoutItem Click="{x:Bind ViewModel.ClearDataButton_Click}" x:Uid="ClearDataMenuFlyoutItem">
-                                <MenuFlyoutItem.Icon>
-                                    <SymbolIcon Symbol="Delete" />
-                                </MenuFlyoutItem.Icon>
-                            </MenuFlyoutItem>
+                                <MenuFlyoutItem Click="{x:Bind ViewModel.ClearDataButton_Click}" x:Uid="ClearDataMenuFlyoutItem">
+                                    <MenuFlyoutItem.Icon>
+                                        <SymbolIcon Symbol="Delete" />
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
 
-                        </MenuFlyout>
+                            </MenuFlyout>
 
-                    </DropDownButton.Flyout>
-                </DropDownButton>
+                        </DropDownButton.Flyout>
+                    </DropDownButton>
 
-                <TextBox x:Uid="TotalLogsTextBlock"
+                    <TextBox x:Uid="TotalLogsTextBlock"
                          Text="{x:Bind ViewModel.TotalCountOfTheFilesTextBox, Mode=OneWay}"
                          IsReadOnly="True"
                          VerticalAlignment="Center"
                          VerticalContentAlignment="Center"/>
 
-                <TextBox Width="300"
+                    <TextBox Width="300"
                          x:Uid="SearchBoxTextBox"
                          VerticalAlignment="Center"
                          Text="{x:Bind ViewModel.FilesAndFoldersScanResultsSearchTextBox, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                          VerticalContentAlignment="Center" />
 
-            </controls:WrapPanel>
-        </Border>
+                </controls:WrapPanel>
+            </Expander.Header>
 
+            <Expander.Content>
+
+                <controls:WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalSpacing="10" VerticalSpacing="10">
+
+                    <Button Click="{x:Bind ViewModel.ExportFilesAndFoldersToJsonButton_Click}"
+                    x:Uid="ExportToJSONButton">
+                        <Button.Content>
+                            <StackPanel Orientation="Horizontal" Spacing="5">
+                                <FontIcon Glyph="&#xE96A;" />
+                                <TextBlock x:Uid="ExportToJSONButtonText" />
+                            </StackPanel>
+                        </Button.Content>
+                    </Button>
+
+                </controls:WrapPanel>
+
+            </Expander.Content>
+        </Expander>
 
         <customUI:ListViewV2 x:Name="FileIdentitiesListView"
-RegistryKey="SupplementalPolicy_FilesAndFolders_ScanResults"
-ItemsSource="{x:Bind ViewModel.FilesAndFoldersScanResults, Mode=OneWay}"
-Grid.Row="2"
-SelectionMode="Extended">
+                             RegistryKey="SupplementalPolicy_FilesAndFolders_ScanResults"
+                             ItemsSource="{x:Bind ViewModel.FilesAndFoldersScanResults, Mode=OneWay}"
+                             Grid.Row="2"
+                             SelectionMode="Extended">
 
             <customUI:ListViewV2.Header>
 

--- a/AppControl Manager/Pages/EventLogsPolicyCreation.xaml
+++ b/AppControl Manager/Pages/EventLogsPolicyCreation.xaml
@@ -69,283 +69,302 @@
             </customUI:InfoBarV2.ActionButton>
         </customUI:InfoBarV2>
 
-        <Border Grid.Row="2" Margin="0,10,0,10"
-            Style="{StaticResource GridCardStyle}" Padding="8">
+        <Expander Grid.Row="2" Margin="0,10,0,10" Padding="8" HorizontalAlignment="Stretch">
+            <Expander.Header>
 
-            <controls:WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalSpacing="10" VerticalSpacing="10">
+                <controls:WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalSpacing="10" VerticalSpacing="10">
 
-                <ProgressRing Visibility="{x:Bind ViewModel.ScanLogsProgressRingVisibility, Mode=OneWay}"
+                    <ProgressRing Visibility="{x:Bind ViewModel.ScanLogsProgressRingVisibility, Mode=OneWay}"
                               IsActive="{x:Bind ViewModel.ScanLogsProgressRingIsActive, Mode=OneWay}" />
 
-                <!-- Scan button -->
-                <Button x:Uid="ScanLogsButton"
+                    <!-- Scan button -->
+                    <Button x:Uid="ScanLogsButton"
                         Style="{StaticResource AccentButtonStyle}"
                         IsEnabled="{x:Bind ViewModel.AreElementsEnabled, Mode=OneWay}"
                         Click="{x:Bind ViewModel.ScanLogs_Click}" >
-                    <Button.Content>
-                        <StackPanel Orientation="Horizontal">
-                            <FontIcon Glyph="&#xEE6F;" />
-                            <TextBlock x:Uid="ScanLogsTextBlock" Margin="5,0,0,0" />
-                        </StackPanel>
-                    </Button.Content>
-                </Button>
+                        <Button.Content>
+                            <StackPanel Orientation="Horizontal">
+                                <FontIcon Glyph="&#xEE6F;" />
+                                <TextBlock x:Uid="ScanLogsTextBlock" Margin="5,0,0,0" />
+                            </StackPanel>
+                        </Button.Content>
+                    </Button>
 
-                <SplitButton ToolTipService.ToolTip="Create the supplemental policy"
+                    <SplitButton ToolTipService.ToolTip="Create the supplemental policy"
                              IsEnabled="{x:Bind ViewModel.AreElementsEnabled, Mode=OneWay}"
                              Click="{x:Bind ViewModel.CreatePolicyButton_Click}">
 
-                    <SplitButton.Content>
-                        <StackPanel Orientation="Horizontal">
-                            <FontIcon Glyph="&#xECCD;" />
-                            <TextBlock Text="{x:Bind ViewModel.CreatePolicyButtonContent, Mode=OneWay}" Margin="5,0,0,0" />
-                        </StackPanel>
-                    </SplitButton.Content>
+                        <SplitButton.Content>
+                            <StackPanel Orientation="Horizontal">
+                                <FontIcon Glyph="&#xECCD;" />
+                                <TextBlock Text="{x:Bind ViewModel.CreatePolicyButtonContent, Mode=OneWay}" Margin="5,0,0,0" />
+                            </StackPanel>
+                        </SplitButton.Content>
 
-                    <SplitButton.Flyout>
-                        <Flyout Placement="Bottom">
+                        <SplitButton.Flyout>
+                            <Flyout Placement="Bottom">
 
-                            <Flyout.FlyoutPresenterStyle>
-                                <Style TargetType="FlyoutPresenter">
-                                    <Setter Property="Padding" Value="0" />
-                                    <!-- Same corner radius as the one in PanelStyle  -->
-                                    <Setter Property="CornerRadius" Value="8" />
+                                <Flyout.FlyoutPresenterStyle>
+                                    <Style TargetType="FlyoutPresenter">
+                                        <Setter Property="Padding" Value="0" />
+                                        <!-- Same corner radius as the one in PanelStyle  -->
+                                        <Setter Property="CornerRadius" Value="8" />
 
-                                    <!--
+                                        <!--
                                     Important: the "resolution order" for widths (at least in winui) is minwidth, maxwidth, width
                                     Width does not override MaxWidth
                                     https://learn.microsoft.com/uwp/api/windows.ui.xaml.frameworkelement.maxwidth?view=winrt-26100#remarks
                                     -->
-                                    <Setter Property="MaxWidth" Value="1234" />
-                                </Style>
-                            </Flyout.FlyoutPresenterStyle>
+                                        <Setter Property="MaxWidth" Value="1234" />
+                                    </Style>
+                                </Flyout.FlyoutPresenterStyle>
 
-                            <StackPanel VerticalAlignment="Top" Orientation="Vertical" Spacing="8">
-                                <controls:Segmented x:Name="segmentedControl"
+                                <StackPanel VerticalAlignment="Top" Orientation="Vertical" Spacing="8">
+                                    <controls:Segmented x:Name="segmentedControl"
                                                     HorizontalAlignment="Stretch"
                                                     SelectedIndex="{x:Bind ViewModel.SelectedCreationMethod, Mode=TwoWay}">
-                                    <controls:SegmentedItem x:Uid="AddToPolicySegmentedItem"
+                                        <controls:SegmentedItem x:Uid="AddToPolicySegmentedItem"
                                                             Tag="AddToPolicy"
                                                             Width="160"
                                                             Icon="{ui:FontIcon Glyph=&#xEB49;}" />
-                                    <controls:SegmentedItem x:Uid="BasePolicyFileSegmentedItem"
+                                        <controls:SegmentedItem x:Uid="BasePolicyFileSegmentedItem"
                                                             Tag="BasePolicyFile"
                                                             Width="160"
                                                             Icon="{ui:FontIcon Glyph=&#xEB49;}"/>
-                                    <controls:SegmentedItem x:Uid="BasePolicyGUIDSegmentedItem"
+                                        <controls:SegmentedItem x:Uid="BasePolicyGUIDSegmentedItem"
                                                             Tag="BaseGUID"
                                                             Width="160"
                                                             Icon="{ui:FontIcon Glyph=&#xEB49;}"/>
-                                </controls:Segmented>
-                                <controls:SwitchPresenter Value="{x:Bind ((controls:SegmentedItem)segmentedControl.SelectedItem).Tag, Mode=OneWay}" HorizontalAlignment="Center">
+                                    </controls:Segmented>
+                                    <controls:SwitchPresenter Value="{x:Bind ((controls:SegmentedItem)segmentedControl.SelectedItem).Tag, Mode=OneWay}" HorizontalAlignment="Center">
 
-                                    <controls:Case Value="AddToPolicy">
-                                        <StackPanel animations:Implicit.HideAnimations="{StaticResource HideTransitions}"
+                                        <controls:Case Value="AddToPolicy">
+                                            <StackPanel animations:Implicit.HideAnimations="{StaticResource HideTransitions}"
                                             animations:Implicit.ShowAnimations="{StaticResource ShowTransitions}"
                                             Style="{StaticResource PanelStyle}">
 
-                                            <TextBlock Margin="5"
+                                                <TextBlock Margin="5"
                                                        VerticalAlignment="Center"
                                                        x:Uid="AddToPolicyDescription"
                                                        Width="310"
                                                        TextWrapping="WrapWholeWords"/>
 
-                                            <Button Margin="5"
+                                                <Button Margin="5"
                                                     x:Uid="FileBrowseButton"
                                                     Style="{StaticResource AccentButtonStyle}"
                                                     Click="{x:Bind ViewModel.AddToPolicyButton_Click}" />
 
-                                        </StackPanel>
-                                    </controls:Case>
-                                    <controls:Case Value="BasePolicyFile">
-                                        <StackPanel animations:Implicit.HideAnimations="{StaticResource HideTransitions}"
+                                            </StackPanel>
+                                        </controls:Case>
+                                        <controls:Case Value="BasePolicyFile">
+                                            <StackPanel animations:Implicit.HideAnimations="{StaticResource HideTransitions}"
                                                     animations:Implicit.ShowAnimations="{StaticResource ShowTransitions}"
                                                     Style="{StaticResource PanelStyle}">
 
-                                            <TextBlock Margin="5"
+                                                <TextBlock Margin="5"
                                                        VerticalAlignment="Center"
                                                        x:Uid="BasePolicyFileDescription"
                                                        TextWrapping="WrapWholeWords"
                                                        Width="310" />
 
-                                            <Button Margin="5"
+                                                <Button Margin="5"
                                                     x:Uid="FileBrowseButton"
                                                     Style="{StaticResource AccentButtonStyle}"
                                                     Click="{x:Bind ViewModel.BasePolicyFileButton_Click}" />
-                                        </StackPanel>
-                                    </controls:Case>
+                                            </StackPanel>
+                                        </controls:Case>
 
-                                    <controls:Case Value="BaseGUID">
-                                        <StackPanel animations:Implicit.HideAnimations="{StaticResource HideTransitions}"
+                                        <controls:Case Value="BaseGUID">
+                                            <StackPanel animations:Implicit.HideAnimations="{StaticResource HideTransitions}"
                                              animations:Implicit.ShowAnimations="{StaticResource ShowTransitions}"
                                              Style="{StaticResource PanelStyle}">
 
-                                            <TextBox x:Uid="BasePolicyGUIDDescription"
+                                                <TextBox x:Uid="BasePolicyGUIDDescription"
                                                      Width="300" Margin="10"
                                                      Text="{x:Bind ViewModel.BasePolicyGUID, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                                      VerticalAlignment="Center"
                                                      VerticalContentAlignment="Center" />
 
-                                            <Button Margin="5"
+                                                <Button Margin="5"
                                                     x:Uid="SubmitButton"
                                                     Style="{StaticResource AccentButtonStyle}"
                                                     Click="{x:Bind ViewModel.BaseGUIDSubmitButton_Click}" />
-                                        </StackPanel>
-                                    </controls:Case>
-                                </controls:SwitchPresenter>
-                            </StackPanel>
-                        </Flyout>
-                    </SplitButton.Flyout>
-                </SplitButton>
+                                            </StackPanel>
+                                        </controls:Case>
+                                    </controls:SwitchPresenter>
+                                </StackPanel>
+                            </Flyout>
+                        </SplitButton.Flyout>
+                    </SplitButton>
 
-                <customUI:ButtonV2 Content="Select Code Integrity EVTX Files"
+                    <customUI:ButtonV2 Content="Select Code Integrity EVTX Files"
                                    IsEnabled="{x:Bind ViewModel.AreElementsEnabled, Mode=OneWay}"
                                    Click="{x:Bind ViewModel.SelectCodeIntegrityEVTXFiles_Click}">
-                    <customUI:ButtonV2.Flyout>
-                        <Flyout>
-                            <controls:WrapPanel Orientation="Vertical" HorizontalSpacing="15" VerticalSpacing="15">
+                        <customUI:ButtonV2.Flyout>
+                            <Flyout>
+                                <controls:WrapPanel Orientation="Vertical" HorizontalSpacing="15" VerticalSpacing="15">
 
-                                <Button x:Uid="ClearButton" Click="{x:Bind ViewModel.SelectedCodeIntegrityEVTXFilesFlyout_Clear_Click}" />
+                                    <Button x:Uid="ClearButton" Click="{x:Bind ViewModel.SelectedCodeIntegrityEVTXFilesFlyout_Clear_Click}" />
 
-                                <TextBlock x:Uid="ViewSelectedFilesTextBlock" TextWrapping="WrapWholeWords" />
+                                    <TextBlock x:Uid="ViewSelectedFilesTextBlock" TextWrapping="WrapWholeWords" />
 
-                                <TextBox Text="{x:Bind ViewModel.CodeIntegrityEVTX, Mode=OneWay}"
+                                    <TextBox Text="{x:Bind ViewModel.CodeIntegrityEVTX, Mode=OneWay}"
                                          TextWrapping="Wrap"
                                          AcceptsReturn="True"
                                          IsSpellCheckEnabled="False"
                                          MinWidth="400"
                                          IsReadOnly="True" />
 
-                            </controls:WrapPanel>
-                        </Flyout>
-                    </customUI:ButtonV2.Flyout>
-                </customUI:ButtonV2>
+                                </controls:WrapPanel>
+                            </Flyout>
+                        </customUI:ButtonV2.Flyout>
+                    </customUI:ButtonV2>
 
-                <customUI:ButtonV2 Content="Select AppLocker EVTX Files"
+                    <customUI:ButtonV2 Content="Select AppLocker EVTX Files"
                                    IsEnabled="{x:Bind ViewModel.AreElementsEnabled, Mode=OneWay}"
                                    Click="{x:Bind ViewModel.SelectAppLockerEVTXFiles_Click}">
-                    <customUI:ButtonV2.Flyout>
-                        <Flyout>
-                            <controls:WrapPanel Orientation="Vertical" HorizontalSpacing="15" VerticalSpacing="15">
+                        <customUI:ButtonV2.Flyout>
+                            <Flyout>
+                                <controls:WrapPanel Orientation="Vertical" HorizontalSpacing="15" VerticalSpacing="15">
 
-                                <Button x:Uid="ClearButton" Click="{x:Bind ViewModel.SelectedAppLockerEVTXFilesFlyout_Clear_Click}" />
+                                    <Button x:Uid="ClearButton" Click="{x:Bind ViewModel.SelectedAppLockerEVTXFilesFlyout_Clear_Click}" />
 
-                                <TextBlock x:Uid="ViewSelectedFilesTextBlock" TextWrapping="WrapWholeWords" />
+                                    <TextBlock x:Uid="ViewSelectedFilesTextBlock" TextWrapping="WrapWholeWords" />
 
-                                <TextBox Text="{x:Bind ViewModel.AppLockerEVTX, Mode=OneWay}"
+                                    <TextBox Text="{x:Bind ViewModel.AppLockerEVTX, Mode=OneWay}"
                                          TextWrapping="Wrap"
                                          AcceptsReturn="True"
                                          IsSpellCheckEnabled="False"
                                          MinWidth="400"
                                          IsReadOnly="True" />
 
-                            </controls:WrapPanel>
-                        </Flyout>
-                    </customUI:ButtonV2.Flyout>
-                </customUI:ButtonV2>
+                                </controls:WrapPanel>
+                            </Flyout>
+                        </customUI:ButtonV2.Flyout>
+                    </customUI:ButtonV2>
 
-                <DropDownButton x:Uid="ExtraActionsDropDownButton"
+                    <DropDownButton x:Uid="ExtraActionsDropDownButton"
                                 IsEnabled="{x:Bind ViewModel.AreElementsEnabled, Mode=OneWay}">
-                    <DropDownButton.Flyout>
+                        <DropDownButton.Flyout>
 
-                        <MenuFlyout Placement="Bottom">
+                            <MenuFlyout Placement="Bottom">
 
-                            <MenuFlyoutItem x:Uid="SelectAllMenuFlyoutItem" Click="{x:Bind ViewModel.SelectAll_Click}">
-                                <MenuFlyoutItem.Icon>
-                                    <FontIcon Glyph="&#xE762;"/>
-                                </MenuFlyoutItem.Icon>
-                            </MenuFlyoutItem>
+                                <MenuFlyoutItem x:Uid="SelectAllMenuFlyoutItem" Click="{x:Bind ViewModel.SelectAll_Click}">
+                                    <MenuFlyoutItem.Icon>
+                                        <FontIcon Glyph="&#xE762;"/>
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
 
-                            <MenuFlyoutItem x:Uid="DeSelectAllMenuFlyoutItem" Click="{x:Bind ViewModel.DeSelectAll_Click}">
-                                <MenuFlyoutItem.Icon>
-                                    <FontIcon Glyph="&#xE8E6;"/>
-                                </MenuFlyoutItem.Icon>
-                            </MenuFlyoutItem>
+                                <MenuFlyoutItem x:Uid="DeSelectAllMenuFlyoutItem" Click="{x:Bind ViewModel.DeSelectAll_Click}">
+                                    <MenuFlyoutItem.Icon>
+                                        <FontIcon Glyph="&#xE8E6;"/>
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
 
-                            <MenuFlyoutItem Click="{x:Bind ViewModel.ClearDataButton_Click}" x:Uid="ClearDataMenuFlyoutItem">
-                                <MenuFlyoutItem.Icon>
-                                    <SymbolIcon Symbol="Delete" />
-                                </MenuFlyoutItem.Icon>
-                            </MenuFlyoutItem>
+                                <MenuFlyoutItem Click="{x:Bind ViewModel.ClearDataButton_Click}" x:Uid="ClearDataMenuFlyoutItem">
+                                    <MenuFlyoutItem.Icon>
+                                        <SymbolIcon Symbol="Delete" />
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
 
-                            <MenuFlyoutSeparator/>
+                                <MenuFlyoutSeparator/>
 
-                            <ToggleMenuFlyoutItem x:Uid="DeployAfterCreationMenuFlyoutItem" IsChecked="{x:Bind ViewModel.DeployPolicyToggle, Mode=TwoWay}">
-                                <ToggleMenuFlyoutItem.Icon>
-                                    <FontIcon Glyph="&#xE896;"/>
-                                </ToggleMenuFlyoutItem.Icon>
+                                <ToggleMenuFlyoutItem x:Uid="DeployAfterCreationMenuFlyoutItem" IsChecked="{x:Bind ViewModel.DeployPolicyToggle, Mode=TwoWay}">
+                                    <ToggleMenuFlyoutItem.Icon>
+                                        <FontIcon Glyph="&#xE896;"/>
+                                    </ToggleMenuFlyoutItem.Icon>
 
-                            </ToggleMenuFlyoutItem>
+                                </ToggleMenuFlyoutItem>
 
-                        </MenuFlyout>
+                            </MenuFlyout>
 
-                    </DropDownButton.Flyout>
-                </DropDownButton>
+                        </DropDownButton.Flyout>
+                    </DropDownButton>
 
-                <TextBox x:Uid="TotalLogsTextBlock"
+                    <TextBox x:Uid="TotalLogsTextBlock"
                          Text="{x:Bind ViewModel.TotalCountOfTheFilesTextBox, Mode=OneWay}"
                          IsReadOnly="True"
                          VerticalAlignment="Center"
                          VerticalContentAlignment="Center"/>
 
-                <TextBox Width="300"
+                    <TextBox Width="300"
                          IsEnabled="{x:Bind ViewModel.AreElementsEnabled, Mode=OneWay}"
                          x:Uid="SearchBoxTextBox"
                          Text="{x:Bind ViewModel.SearchBoxText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                          VerticalAlignment="Center"
                          VerticalContentAlignment="Center" />
 
-                <Button x:Uid="PolicyNameColumnHeaderBtn" IsEnabled="{x:Bind ViewModel.AreElementsEnabled, Mode=OneWay}">
-                    <Button.Flyout>
-                        <Flyout>
-                            <Flyout.FlyoutPresenterStyle>
-                                <Style TargetType="FlyoutPresenter">
-                                    <Setter Property="CornerRadius" Value="8" />
-                                    <Setter Property="MaxWidth" Value="1234" />
-                                </Style>
-                            </Flyout.FlyoutPresenterStyle>
+                    <Button x:Uid="PolicyNameColumnHeaderBtn" IsEnabled="{x:Bind ViewModel.AreElementsEnabled, Mode=OneWay}">
+                        <Button.Flyout>
+                            <Flyout>
+                                <Flyout.FlyoutPresenterStyle>
+                                    <Style TargetType="FlyoutPresenter">
+                                        <Setter Property="CornerRadius" Value="8" />
+                                        <Setter Property="MaxWidth" Value="1234" />
+                                    </Style>
+                                </Flyout.FlyoutPresenterStyle>
 
-                            <controls:WrapPanel Orientation="Vertical" HorizontalSpacing="3" VerticalSpacing="8">
-                                <TextBox Width="300"
+                                <controls:WrapPanel Orientation="Vertical" HorizontalSpacing="3" VerticalSpacing="8">
+                                    <TextBox Width="300"
                                          Header="Optional: Choose a policy name"
                                          Text="{x:Bind ViewModel.PolicyNameTextBox, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                          PlaceholderText="Policy Name..."/>
-                            </controls:WrapPanel>
-                        </Flyout>
-                    </Button.Flyout>
-                </Button>
+                                </controls:WrapPanel>
+                            </Flyout>
+                        </Button.Flyout>
+                    </Button>
 
-                <CalendarDatePicker x:Uid="FilterByDateCalendarDatePicker"
+                    <CalendarDatePicker x:Uid="FilterByDateCalendarDatePicker"
                                     Date="{x:Bind ViewModel.DatePickerDate, Mode=TwoWay}"
                                     IsEnabled="{x:Bind ViewModel.AreElementsEnabled, Mode=OneWay}" />
 
-                <ComboBox x:Uid="ScanLevelComboBox"
+                    <ComboBox x:Uid="ScanLevelComboBox"
                           IsEnabled="{x:Bind ViewModel.AreElementsEnabled, Mode=OneWay}"
                           SelectedItem="{x:Bind ViewModel.ScanLevelComboBoxSelectedItem, Mode=TwoWay}"
                           SelectedIndex="0"
                           ItemsSource="{x:Bind ViewModel.ScanLevelsSourceForLogs}">
-                    <ComboBox.ItemTemplate>
-                        <DataTemplate x:DataType="intelgathering:ScanLevelsComboBoxType">
-                            <StackPanel Orientation="Horizontal" Spacing="5">
-                                <TextBlock Text="{x:Bind FriendlyName}" Margin="0,0,4,0" VerticalAlignment="Center"/>
-                                <RatingControl IsReadOnly="True" Value="{x:Bind Rating}" VerticalAlignment="Center"/>
-                            </StackPanel>
-                        </DataTemplate>
-                    </ComboBox.ItemTemplate>
-                </ComboBox>
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate x:DataType="intelgathering:ScanLevelsComboBoxType">
+                                <StackPanel Orientation="Horizontal" Spacing="5">
+                                    <TextBlock Text="{x:Bind FriendlyName}" Margin="0,0,4,0" VerticalAlignment="Center"/>
+                                    <RatingControl IsReadOnly="True" Value="{x:Bind Rating}" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
 
 
-                <ToggleButton IsChecked="{x:Bind ViewModel.OnlyIncludeSelectedItemsToggleButton, Mode=TwoWay}"
+                    <ToggleButton IsChecked="{x:Bind ViewModel.OnlyIncludeSelectedItemsToggleButton, Mode=TwoWay}"
                               IsEnabled="{x:Bind ViewModel.AreElementsEnabled, Mode=OneWay}"
                               x:Uid="OnlyIncludeSelectedItemsToggleButton" />
 
-            </controls:WrapPanel>
-        </Border>
+                </controls:WrapPanel>
+            </Expander.Header>
+
+            <Expander.Content>
+
+                <controls:WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalSpacing="10" VerticalSpacing="10">
+
+                    <Button Click="{x:Bind ViewModel.ExportToJsonButton_Click}"
+                            x:Uid="ExportToJSONButton">
+                        <Button.Content>
+                            <StackPanel Orientation="Horizontal" Spacing="5">
+                                <FontIcon Glyph="&#xE96A;" />
+                                <TextBlock x:Uid="ExportToJSONButtonText" />
+                            </StackPanel>
+                        </Button.Content>
+                    </Button>
+
+                </controls:WrapPanel>
+
+            </Expander.Content>
+        </Expander>
 
         <customUI:ListViewV2 x:Name="FileIdentitiesListView"
-          RegistryKey="Event_Logs"
-          Grid.Row="3"
-          SelectionMode="Extended"
-          ItemsSource="{x:Bind ViewModel.FileIdentities, Mode=OneWay}">
+                             RegistryKey="Event_Logs"
+                             Grid.Row="3"
+                             SelectionMode="Extended"
+                             ItemsSource="{x:Bind ViewModel.FileIdentities, Mode=OneWay}">
 
             <customUI:ListViewV2.Header>
 

--- a/AppControl Manager/Pages/MDEAHPolicyCreation.xaml
+++ b/AppControl Manager/Pages/MDEAHPolicyCreation.xaml
@@ -785,6 +785,16 @@
                         </Button.Content>
                     </Button>
 
+                    <Button Click="{x:Bind ViewModel.ExportToJsonButton_Click}"
+                            x:Uid="ExportToJSONButton">
+                        <Button.Content>
+                            <StackPanel Orientation="Horizontal" Spacing="5">
+                                <FontIcon Glyph="&#xE96A;" />
+                                <TextBlock x:Uid="ExportToJSONButtonText" />
+                            </StackPanel>
+                        </Button.Content>
+                    </Button>
+
                 </controls:WrapPanel>
 
             </Expander.Content>

--- a/AppControl Manager/Pages/StrictKernelPolicyScanResults.xaml
+++ b/AppControl Manager/Pages/StrictKernelPolicyScanResults.xaml
@@ -28,58 +28,78 @@
 
         </controls:WrapPanel>
 
-        <Border Grid.Row="1" Margin="0,10,0,10" Style="{StaticResource GridCardStyle}" Padding="8">
+        <Expander Grid.Row="1" Margin="0,0,0,10" Padding="8" HorizontalAlignment="Stretch">
+            <Expander.Header>
 
-            <controls:WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalSpacing="10" VerticalSpacing="10">
+                <controls:WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalSpacing="10" VerticalSpacing="10">
 
-                <DropDownButton x:Uid="ExtraActionsDropDownButton">
-                    <DropDownButton.Flyout>
+                    <DropDownButton x:Uid="ExtraActionsDropDownButton">
+                        <DropDownButton.Flyout>
 
-                        <MenuFlyout Placement="Bottom">
+                            <MenuFlyout Placement="Bottom">
 
-                            <MenuFlyoutItem x:Uid="SelectAllMenuFlyoutItem" Click="{x:Bind ViewModel.StrictKernel_SelectAll_Click}">
-                                <MenuFlyoutItem.Icon>
-                                    <FontIcon Glyph="&#xE762;"/>
-                                </MenuFlyoutItem.Icon>
-                            </MenuFlyoutItem>
+                                <MenuFlyoutItem x:Uid="SelectAllMenuFlyoutItem" Click="{x:Bind ViewModel.StrictKernel_SelectAll_Click}">
+                                    <MenuFlyoutItem.Icon>
+                                        <FontIcon Glyph="&#xE762;"/>
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
 
-                            <MenuFlyoutItem x:Uid="DeSelectAllMenuFlyoutItem" Click="{x:Bind ViewModel.StrictKernel_DeSelectAll_Click}">
-                                <MenuFlyoutItem.Icon>
-                                    <FontIcon Glyph="&#xE8E6;"/>
-                                </MenuFlyoutItem.Icon>
-                            </MenuFlyoutItem>
+                                <MenuFlyoutItem x:Uid="DeSelectAllMenuFlyoutItem" Click="{x:Bind ViewModel.StrictKernel_DeSelectAll_Click}">
+                                    <MenuFlyoutItem.Icon>
+                                        <FontIcon Glyph="&#xE8E6;"/>
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
 
-                            <MenuFlyoutItem Click="{x:Bind ViewModel.StrictKernel_ClearDataButton_Click}" x:Uid="ClearDataMenuFlyoutItem">
-                                <MenuFlyoutItem.Icon>
-                                    <SymbolIcon Symbol="Delete" />
-                                </MenuFlyoutItem.Icon>
-                            </MenuFlyoutItem>
+                                <MenuFlyoutItem Click="{x:Bind ViewModel.StrictKernel_ClearDataButton_Click}" x:Uid="ClearDataMenuFlyoutItem">
+                                    <MenuFlyoutItem.Icon>
+                                        <SymbolIcon Symbol="Delete" />
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
 
-                        </MenuFlyout>
+                            </MenuFlyout>
 
-                    </DropDownButton.Flyout>
-                </DropDownButton>
+                        </DropDownButton.Flyout>
+                    </DropDownButton>
 
-                <TextBox x:Uid="TotalLogsTextBlock"
+                    <TextBox x:Uid="TotalLogsTextBlock"
                 Text="{x:Bind ViewModel.TotalCountOfTheFilesStrictKernelModeTextBox, Mode=OneWay}"
                 IsReadOnly="True"
                 VerticalAlignment="Center"
                 VerticalContentAlignment="Center"/>
 
-                <TextBox Width="300"
+                    <TextBox Width="300"
                          x:Uid="SearchBoxTextBox"
                          Text="{x:Bind ViewModel.StrictKernelModeResultsSearchTextBox, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                          VerticalAlignment="Center"
                          VerticalContentAlignment="Center" />
 
-            </controls:WrapPanel>
-        </Border>
+                </controls:WrapPanel>
+            </Expander.Header>
+
+            <Expander.Content>
+
+                <controls:WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalSpacing="10" VerticalSpacing="10">
+
+                    <Button Click="{x:Bind ViewModel.ExportStrictKernelModeToJsonButton_Click}"
+                            x:Uid="ExportToJSONButton">
+                        <Button.Content>
+                            <StackPanel Orientation="Horizontal" Spacing="5">
+                                <FontIcon Glyph="&#xE96A;" />
+                                <TextBlock x:Uid="ExportToJSONButtonText" />
+                            </StackPanel>
+                        </Button.Content>
+                    </Button>
+
+                </controls:WrapPanel>
+
+            </Expander.Content>
+        </Expander>
 
         <customUI:ListViewV2 x:Name="FileIdentitiesListView"
-RegistryKey="SupplementalPolicy_StrictKernelMode_ScanResults"
-Grid.Row="2"
-SelectionMode="Extended"
-ItemsSource="{x:Bind ViewModel.StrictKernelModeScanResults, Mode=OneWay}">
+                             RegistryKey="SupplementalPolicy_StrictKernelMode_ScanResults"
+                             Grid.Row="2"
+                             SelectionMode="Extended"
+                             ItemsSource="{x:Bind ViewModel.StrictKernelModeScanResults, Mode=OneWay}">
 
             <customUI:ListViewV2.Header>
 

--- a/AppControl Manager/Strings/en-US/Resources.resw
+++ b/AppControl Manager/Strings/en-US/Resources.resw
@@ -5728,4 +5728,20 @@ NOTE: This option is always enforced if any App Control UMCI policy enables it. 
   <data name="OpenLogsDirectoryButtonText.Text" xml:space="preserve">
     <value>Open Logs Directory</value>
   </data>
+  <!--New-->
+  <data name="ExportToJSONButtonText.Text" xml:space="preserve">
+    <value>Export To JSON File</value>
+  </data>
+    <data name="ExportToJSONButton.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Export all of the data in the ListView to JSON.</value>
+  </data>
+    <data name="ExportToJSONButton.ToolTipService.ToolTip" xml:space="preserve">
+     <value>Export all of the data in the ListView to JSON.</value>
+  </data>
+  <data name="ExportingToJSONMsg" xml:space="preserve">
+     <value>Exporting data to JSON file, please wait...</value>
+  </data>
+    <data name="SuccessfullyExportedDataToJSON" xml:space="preserve">
+     <value>Successfully exported {0} data to JSON and saved them in: '{1}'</value>
+  </data>
 </root>

--- a/AppControl Manager/ViewModels/AllowNewAppsVM.cs
+++ b/AppControl Manager/ViewModels/AllowNewAppsVM.cs
@@ -1660,4 +1660,34 @@ internal sealed partial class AllowNewAppsVM : ViewModelBase
 		_OpenInFileExplorer_EventLogs();
 		args.Handled = true;
 	}
+
+	/// <summary>
+	/// Exports Event Logs data to JSON.
+	/// </summary>
+	internal async void ExportEventLogsToJsonButton_Click()
+	{
+		try
+		{
+			await FileIdentity.ExportToJson(EventLogsFileIdentities, Step1InfoBar);
+		}
+		catch (Exception ex)
+		{
+			Step1InfoBar.WriteError(ex);
+		}
+	}
+
+	/// <summary>
+	/// Exports Local Files data to JSON.
+	/// </summary>
+	internal async void ExportLocalFilesToJsonButton_Click()
+	{
+		try
+		{
+			await FileIdentity.ExportToJson(LocalFilesFileIdentities, Step1InfoBar);
+		}
+		catch (Exception ex)
+		{
+			Step1InfoBar.WriteError(ex);
+		}
+	}
 }

--- a/AppControl Manager/ViewModels/CreateDenyPolicyVM.cs
+++ b/AppControl Manager/ViewModels/CreateDenyPolicyVM.cs
@@ -619,6 +619,21 @@ internal sealed partial class CreateDenyPolicyVM : ViewModelBase
 		UpdateTotalFiles();
 	}
 
+	/// <summary>
+	/// Exports data to JSON.
+	/// </summary>
+	internal async void ExportFilesAndFoldersToJsonButton_Click()
+	{
+		try
+		{
+			await FileIdentity.ExportToJson(FilesAndFoldersScanResults, FilesAndFoldersInfoBar);
+		}
+		catch (Exception ex)
+		{
+			FilesAndFoldersInfoBar.WriteError(ex);
+		}
+	}
+
 	#endregion
 
 	#region Package Family Names

--- a/AppControl Manager/ViewModels/CreatePolicyVM.cs
+++ b/AppControl Manager/ViewModels/CreatePolicyVM.cs
@@ -20,6 +20,7 @@ using System.IO;
 using System.Threading.Tasks;
 using AppControlManager.Main;
 using AppControlManager.Others;
+using AppControlManager.Pages;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
@@ -760,6 +761,11 @@ internal sealed partial class CreatePolicyVM : ViewModelBase
 	/// </summary>
 	internal async void RMMBlockingPolicyCreateButton_Click()
 	{
+		await RMMBlockingPolicyCreateButton_Private();
+	}
+
+	private async Task RMMBlockingPolicyCreateButton_Private()
+	{
 		bool errorsOccurred = false;
 
 		try
@@ -807,6 +813,46 @@ internal sealed partial class CreatePolicyVM : ViewModelBase
 	internal async void OpenInDefaultFileHandler_RMMBlockingPolicy() => await OpenInDefaultFileHandler(_policyPathRMMBlocking);
 
 	internal async void OpenInConfigurePolicyRuleOptions_RMMBlockingPolicy() => await ConfigurePolicyRuleOptionsViewModel.OpenInConfigurePolicyRuleOptions(_policyPathRMMBlocking);
+
+	/// <summary>
+	/// The method used to open the <see cref="CreatePolicy"/> page from other parts of the application.
+	/// </summary>
+	/// <param name="type"></param>
+	/// <returns></returns>
+	internal async Task OpenInCreatePolicy(LaunchProtocolActions type)
+	{
+		try
+		{
+			App._nav.Navigate(typeof(CreatePolicy), null);
+
+			switch (type)
+			{
+				case LaunchProtocolActions.DeployRMMAuditPolicy:
+					{
+						RMMBlockingCreateAndDeploy = true;
+						RMMBlockingAudit = true;
+						await RMMBlockingPolicyCreateButton_Private();
+						break;
+					}
+				case LaunchProtocolActions.DeployRMMBlockPolicy:
+					{
+						RMMBlockingCreateAndDeploy = true;
+						RMMBlockingAudit = false;
+						await RMMBlockingPolicyCreateButton_Private();
+						break;
+					}
+				case LaunchProtocolActions.PolicyEditor:
+				case LaunchProtocolActions.FileSignature:
+				case LaunchProtocolActions.FileHashes:
+				default:
+					break;
+			}
+		}
+		catch (Exception ex)
+		{
+			RMMBlockingInfoBar.WriteError(ex);
+		}
+	}
 
 	#endregion
 

--- a/AppControl Manager/ViewModels/CreateSupplementalPolicyVM.cs
+++ b/AppControl Manager/ViewModels/CreateSupplementalPolicyVM.cs
@@ -749,6 +749,21 @@ internal sealed partial class CreateSupplementalPolicyVM : ViewModelBase
 		args.Handled = true;
 	}
 
+	/// <summary>
+	/// Exports data to JSON.
+	/// </summary>
+	internal async void ExportFilesAndFoldersToJsonButton_Click()
+	{
+		try
+		{
+			await FileIdentity.ExportToJson(FilesAndFoldersScanResults, FilesAndFoldersInfoBar);
+		}
+		catch (Exception ex)
+		{
+			FilesAndFoldersInfoBar.WriteError(ex);
+		}
+	}
+
 	#endregion
 
 	#region Certificates scan
@@ -1872,6 +1887,21 @@ internal sealed partial class CreateSupplementalPolicyVM : ViewModelBase
 	{
 		_OpenInFileExplorerStrictKernelMode();
 		args.Handled = true;
+	}
+
+	/// <summary>
+	/// Exports data to JSON.
+	/// </summary>
+	internal async void ExportStrictKernelModeToJsonButton_Click()
+	{
+		try
+		{
+			await FileIdentity.ExportToJson(StrictKernelModeScanResults, StrictKernelModeInfoBar);
+		}
+		catch (Exception ex)
+		{
+			StrictKernelModeInfoBar.WriteError(ex);
+		}
 	}
 
 	#endregion

--- a/AppControl Manager/ViewModels/EventLogsPolicyCreationVM.cs
+++ b/AppControl Manager/ViewModels/EventLogsPolicyCreationVM.cs
@@ -814,4 +814,19 @@ internal sealed partial class EventLogsPolicyCreationVM : ViewModelBase
 			}
 		}
 	}
+
+	/// <summary>
+	/// Exports data to JSON.
+	/// </summary>
+	internal async void ExportToJsonButton_Click()
+	{
+		try
+		{
+			await FileIdentity.ExportToJson(FileIdentities, MainInfoBar);
+		}
+		catch (Exception ex)
+		{
+			MainInfoBar.WriteError(ex);
+		}
+	}
 }

--- a/AppControl Manager/ViewModels/GetCIHashesVM.cs
+++ b/AppControl Manager/ViewModels/GetCIHashesVM.cs
@@ -256,11 +256,11 @@ internal sealed partial class GetCIHashesVM : ViewModelBase
 	}
 
 	/// <summary>
-	/// The method used to open the GetCIHashes page from other parts of the application.
+	/// The method used to open the <see cref="GetCIHashes"/> page from other parts of the application.
 	/// </summary>
 	/// <param name="filePath"></param>
 	/// <returns></returns>
-	internal async Task OpenInGetCIHashes(string filePath)
+	internal async Task OpenInGetCIHashes(string? filePath)
 	{
 		try
 		{

--- a/AppControl Manager/ViewModels/MDEAHPolicyCreationVM.cs
+++ b/AppControl Manager/ViewModels/MDEAHPolicyCreationVM.cs
@@ -1048,4 +1048,27 @@ DeviceEvents
 		AuthCompanionCLS?.Dispose();
 	}
 
+	/// <summary>
+	/// Event handler for the Export To JSON button
+	/// </summary>
+	internal async void ExportToJsonButton_Click()
+	{
+		try
+		{
+			AreElementsEnabled = false;
+			MainInfoBarIsClosable = false;
+
+			await FileIdentity.ExportToJson(FileIdentities, MainInfoBar);
+		}
+		catch (Exception ex)
+		{
+			MainInfoBar.WriteError(ex);
+		}
+		finally
+		{
+			AreElementsEnabled = true;
+			MainInfoBarIsClosable = true;
+		}
+	}
+
 }

--- a/AppControl Manager/ViewModels/ViewFileCertificatesVM.cs
+++ b/AppControl Manager/ViewModels/ViewFileCertificatesVM.cs
@@ -621,7 +621,7 @@ internal sealed partial class ViewFileCertificatesVM : ViewModelBase
 	/// </summary>
 	/// <param name="filePath"></param>
 	/// <returns></returns>
-	internal async Task OpenInViewFileCertificatesVM(string filePath)
+	internal async Task OpenInViewFileCertificatesVM(string? filePath)
 	{
 		try
 		{

--- a/AppControl Manager/ViewModels/ViewModelBase.cs
+++ b/AppControl Manager/ViewModels/ViewModelBase.cs
@@ -251,7 +251,9 @@ internal abstract class ViewModelBase : INotifyPropertyChanged
 	{
 		PolicyEditor,
 		FileSignature,
-		FileHashes
+		FileHashes,
+		DeployRMMAuditPolicy,
+		DeployRMMBlockPolicy
 	}
 
 


### PR DESCRIPTION
All of the pages that use FileIdentity type now have the option to export the ListView items to JSON file.

Completes this feature request: https://github.com/HotCakeX/Harden-Windows-Security/issues/794

