### PR TITLE
AppControl Manager v2.0.52.0

### DIFF
--- a/AppControl Manager/CustomUIElements/ListBoxV2.xaml
+++ b/AppControl Manager/CustomUIElements/ListBoxV2.xaml
@@ -1,0 +1,40 @@
+<UserControl
+    x:Class="AppControlManager.CustomUIElements.ListBoxV2"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:customUI="using:AppControlManager.CustomUIElements">
+
+    <Grid>
+        <ListBox MinWidth="{x:Bind MinWidth, Mode=OneWay}"
+                 ItemsSource="{x:Bind ItemsSource, Mode=OneWay}"
+                 SelectionMode="{x:Bind SelectionMode, Mode=OneWay}"
+                 HorizontalContentAlignment="Stretch">
+            <ListBox.ItemTemplate>
+                <DataTemplate x:DataType="x:String">
+                    <Grid ColumnSpacing="8" HorizontalAlignment="Stretch">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock Grid.Column="0"
+                                   Text="{x:Bind}"
+                                   TextWrapping="WrapWholeWords"
+                                   VerticalAlignment="Center" />
+
+                        <Button Grid.Column="1"
+                                Padding="6,2"
+                                HorizontalAlignment="Right"
+                                VerticalAlignment="Center"
+                                ToolTipService.ToolTip="Remove"
+                                Tag="{x:Bind}"
+                                Click="DeleteItem_Click"
+                                MinWidth="32">
+                            <FontIcon Glyph="&#xE711;" Foreground="Red" />
+                        </Button>
+                    </Grid>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+    </Grid>
+</UserControl>

--- a/AppControl Manager/CustomUIElements/ListBoxV2.xaml.cs
+++ b/AppControl Manager/CustomUIElements/ListBoxV2.xaml.cs
@@ -1,0 +1,127 @@
+// MIT License
+//
+// Copyright (c) 2023-Present - Violet Hansen - (aka HotCakeX on GitHub) - Email Address: spynetgirl@outlook.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// See here for more information: https://github.com/HotCakeX/Harden-Windows-Security/blob/main/LICENSE
+//
+
+using System.Collections;
+using System.Collections.ObjectModel;
+using AppControlManager.Others;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace AppControlManager.CustomUIElements;
+
+/// <summary>
+/// A UserControl wrapping a ListBox that adds a delete button to the right of each string item.
+/// Works with UniqueStringObservableCollection, ObservableCollection<string>, or any IList containing strings.
+/// </summary>
+internal sealed partial class ListBoxV2 : UserControl
+{
+	public static readonly DependencyProperty ItemsSourceProperty =
+		DependencyProperty.Register(
+			nameof(ItemsSource),
+			typeof(IEnumerable),
+			typeof(ListBoxV2),
+			new PropertyMetadata(null));
+
+	public static readonly DependencyProperty SelectionModeProperty =
+		DependencyProperty.Register(
+			nameof(SelectionMode),
+			typeof(SelectionMode),
+			typeof(ListBoxV2),
+			new PropertyMetadata(SelectionMode.Single));
+
+	public IEnumerable? ItemsSource
+	{
+		get { return (IEnumerable?)GetValue(ItemsSourceProperty); }
+		set { SetValue(ItemsSourceProperty, value); }
+	}
+
+	public SelectionMode SelectionMode
+	{
+		get { return (SelectionMode)GetValue(SelectionModeProperty); }
+		set { SetValue(SelectionModeProperty, value); }
+	}
+
+	internal ListBoxV2()
+	{
+		InitializeComponent();
+	}
+
+	/// <summary>
+	/// Click handler for the delete button. Removes the item from the bound collection.
+	/// </summary>
+	internal void DeleteItem_Click(object sender, RoutedEventArgs e)
+	{
+		string? path = ((Button)sender).Tag as string;
+		if (string.IsNullOrEmpty(path))
+			return;
+
+		// Fast path for UniqueStringObservableCollection
+		UniqueStringObservableCollection? uniqueCollection = ItemsSource as UniqueStringObservableCollection;
+		if (uniqueCollection is not null)
+		{
+			_ = uniqueCollection.Remove(path);
+			return;
+		}
+
+		// ObservableCollection<string>
+		ObservableCollection<string>? observableStrings = ItemsSource as ObservableCollection<string>;
+		if (observableStrings is not null)
+		{
+			RemoveFromObservable(observableStrings, path);
+			return;
+		}
+
+		// IList (generic fallback)
+		if (ItemsSource is not IList list)
+			return;
+
+		RemoveFromIList(list, path);
+	}
+
+	/// <summary>
+	/// Removes a string from an ObservableCollection<string>.
+	/// </summary>
+	private static void RemoveFromObservable(ObservableCollection<string> collection, string target)
+	{
+		for (int i = 0; i < collection.Count; i++)
+		{
+			string current = collection[i];
+			if (string.Equals(current, target, StringComparison.OrdinalIgnoreCase))
+			{
+				collection.RemoveAt(i);
+				break;
+			}
+		}
+	}
+
+	/// <summary>
+	/// Removes a matching string from an IList.
+	/// </summary>
+	private static void RemoveFromIList(IList list, string target)
+	{
+		for (int i = 0; i < list.Count; i++)
+		{
+			object? entry = list[i];
+			string? value = entry as string;
+			if (value is not null && string.Equals(value, target, StringComparison.OrdinalIgnoreCase))
+			{
+				list.Remove(entry);
+				break;
+			}
+		}
+	}
+}

--- a/AppControl Manager/IncrementalCollection/GenericIncrementalCollection.cs
+++ b/AppControl Manager/IncrementalCollection/GenericIncrementalCollection.cs
@@ -20,6 +20,7 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Common.Collections;
@@ -363,10 +364,10 @@ internal sealed partial class GenericIncrementalCollection<TDataSource, TDataTyp
 					// Suppress per-item notifications to avoid reentrancy during incremental loads.
 					using (BeginBulkUpdate())
 					{
-						for (int i = 0; i < batch.Count; i++)
+						foreach (TDataType item in CollectionsMarshal.AsSpan(batch))
 						{
 							// Add will be suppressed; a single Reset is emitted when the scope disposes.
-							Add(batch[i]);
+							Add(item);
 						}
 					}
 
@@ -613,9 +614,9 @@ internal sealed partial class GenericIncrementalCollection<TDataSource, TDataTyp
 						// Populate page 1 items without per-item events; emit a single Reset to avoid reentrancy.
 						using (BeginBulkUpdate())
 						{
-							for (int i = 0; i < batch.Count; i++)
+							foreach (TDataType item in CollectionsMarshal.AsSpan(batch))
 							{
-								Add(batch[i]);
+								Add(item);
 							}
 						}
 

--- a/AppControl Manager/IncrementalCollection/IncrementalCollection.cs
+++ b/AppControl Manager/IncrementalCollection/IncrementalCollection.cs
@@ -21,6 +21,7 @@ using System.ComponentModel;
 using System.IO;
 using System.IO.MemoryMappedFiles;
 using System.Runtime;
+using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Text;
 using System.Threading;
@@ -563,7 +564,7 @@ internal sealed partial class IncrementalCollection<T>(
 						}
 					}, cancellationToken);
 
-					foreach (T item in itemsToAdd)
+					foreach (T item in CollectionsMarshal.AsSpan(itemsToAdd))
 					{
 						if (cancellationToken.IsCancellationRequested || _disposed)
 							break;

--- a/AppControl Manager/IntelGathering/CatRootScanner.cs
+++ b/AppControl Manager/IntelGathering/CatRootScanner.cs
@@ -77,12 +77,9 @@ internal static class CatRootScanner
 			HashSet<string> catHashes = MeowParser.GetHashes(file);
 
 			// If the security catalog file has hashes, then add them to the dictionary
-			if (catHashes.Count > 0)
+			foreach (string hash in catHashes)
 			{
-				foreach (string hash in catHashes)
-				{
-					_ = output.TryAdd(hash, file);
-				}
+				_ = output.TryAdd(hash, file);
 			}
 		});
 

--- a/AppControl Manager/IntelGathering/DriveLetterMapper.cs
+++ b/AppControl Manager/IntelGathering/DriveLetterMapper.cs
@@ -16,6 +16,7 @@
 //
 
 using System.Collections.Generic;
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace AppControlManager.IntelGathering;
@@ -48,25 +49,22 @@ internal static partial class DriveLetterMapper
 
 		// Scan volumes and pick the first one that contains an "EFI" directory at its root.
 		// This works even when the partition has no drive letter.
-		for (int i = 0; i < drives.Count; i++)
+		foreach (DriveMapping drive in CollectionsMarshal.AsSpan(drives))
 		{
-			string? volume = drives[i].VolumeName;
-			if (string.IsNullOrEmpty(volume))
-			{
+			if (string.IsNullOrEmpty(drive.VolumeName))
 				continue;
-			}
 
 			// Volume names returned by FindFirst/NextVolume usually include a trailing backslash.
 			// Build the path to the well-known "EFI" directory.
-			string efiDirPath = string.Concat(volume, "EFI");
+			string efiDirPath = string.Concat(drive.VolumeName, "EFI");
 
 			try
 			{
 				// Directory.Exists will return false on inaccessible or non-existent paths.
-				if (System.IO.Directory.Exists(efiDirPath))
+				if (Directory.Exists(efiDirPath))
 				{
 					// Found the ESP. Return its root Volume GUID path.
-					return volume;
+					return drive.VolumeName;
 				}
 			}
 			catch

--- a/AppControl Manager/IntelGathering/LocalFilesScan.cs
+++ b/AppControl Manager/IntelGathering/LocalFilesScan.cs
@@ -52,9 +52,7 @@ internal static class LocalFilesScan
 
 		// Make sure scalability is always at least 2
 		if (scalability < 2)
-		{
 			scalability = 2;
-		}
 
 		try
 		{
@@ -126,7 +124,6 @@ internal static class LocalFilesScan
 
 							// Get the extended file attributes
 							ExFileInfo ExtendedFileInfo = GetExtendedFileAttrib.Get(file);
-
 
 							// To store all certificates of the file
 							List<AllFileSigners> FileSignatureResults = [];
@@ -455,7 +452,7 @@ internal static class LocalFilesScan
 	/// <returns></returns>
 	private static bool DetermineWHQL(X509ExtensionCollection Collection)
 	{
-		foreach (var ext in Collection)
+		foreach (X509Extension ext in Collection)
 		{
 			if (ext is X509EnhancedKeyUsageExtension eku)
 			{

--- a/AppControl Manager/IntelGathering/OptimizeMDECSVData.cs
+++ b/AppControl Manager/IntelGathering/OptimizeMDECSVData.cs
@@ -32,11 +32,7 @@ internal static partial class OptimizeMDECSVData
 	/// </summary>
 	/// <param name="CSVFilePath"></param>
 	/// <returns></returns>
-	internal static List<MDEAdvancedHuntingData> Optimize(string CSVFilePath)
-	{
-		List<MDEAdvancedHuntingData> csvRecords = ReadCsv(CSVFilePath);
-		return csvRecords;
-	}
+	internal static List<MDEAdvancedHuntingData> Optimize(string CSVFilePath) => ReadCsv(CSVFilePath);
 
 	/// <summary>
 	/// Converts an entire MDE Advanced Hunting CSV file into a list of classes.

--- a/AppControl Manager/Others/GetOpusData.cs
+++ b/AppControl Manager/Others/GetOpusData.cs
@@ -41,7 +41,7 @@ internal static partial class Opus
 	// Returns a List of OpusInfoObj, taking a SignedCms parameter
 	// https://learn.microsoft.com/windows/win32/seccrypto/example-c-program--verifying-the-signature-of-a-pe-file
 	// https://view.officeapps.live.com/op/view.aspx?src=https%3A%2F%2Fdownload.microsoft.com%2Fdownload%2F9%2Fc%2F5%2F9c5b2167-8017-4bae-9fde-d599bac8184a%2FAuthenticode_PE.docx
-	internal unsafe static List<OpusInfoObj> GetOpusData(SignedCms signature)
+	internal static List<OpusInfoObj> GetOpusData(SignedCms signature)
 	{
 		// Initializing a new List of OpusInfoObj to store the output data to return
 		List<OpusInfoObj> OEMOpusData = [];

--- a/AppControl Manager/Pages/AllowNewApps/AllowNewAppsStart.xaml
+++ b/AppControl Manager/Pages/AllowNewApps/AllowNewAppsStart.xaml
@@ -198,7 +198,7 @@
 
                                         <TextBlock x:Uid="ViewSelectedFoldersTextBlock" TextWrapping="WrapWholeWords" Width="400" />
 
-                                        <ListBox MinWidth="400" SelectionMode="Single" ItemsSource="{x:Bind ViewModel.selectedDirectoriesToScan, Mode=OneWay}" />
+                                        <customUI:ListBoxV2 MinWidth="400" SelectionMode="Single" ItemsSource="{x:Bind ViewModel.selectedDirectoriesToScan, Mode=OneWay}" />
 
                                     </controls:WrapPanel>
 

--- a/AppControl Manager/Pages/CreateDenyPolicy.xaml
+++ b/AppControl Manager/Pages/CreateDenyPolicy.xaml
@@ -561,7 +561,7 @@
 
                                             <TextBlock x:Uid="ViewSelectedFilesTextBlock" TextWrapping="WrapWholeWords" />
 
-                                            <ListBox MinWidth="400" SelectionMode="Single" ItemsSource="{x:Bind ViewModel.filesAndFoldersFilePaths, Mode=OneWay}" />
+                                            <customUI:ListBoxV2 MinWidth="400" SelectionMode="Single" ItemsSource="{x:Bind ViewModel.filesAndFoldersFilePaths, Mode=OneWay}" />
 
                                         </controls:WrapPanel>
 
@@ -597,7 +597,7 @@
 
                                             <TextBlock x:Uid="ViewSelectedFoldersTextBlock" TextWrapping="WrapWholeWords" />
 
-                                            <ListBox MinWidth="400" SelectionMode="Single" ItemsSource="{x:Bind ViewModel.filesAndFoldersFolderPaths, Mode=OneWay}" />
+                                            <customUI:ListBoxV2 MinWidth="400" SelectionMode="Single" ItemsSource="{x:Bind ViewModel.filesAndFoldersFolderPaths, Mode=OneWay}" />
 
                                         </controls:WrapPanel>
 

--- a/AppControl Manager/Pages/CreateSupplementalPolicy.xaml
+++ b/AppControl Manager/Pages/CreateSupplementalPolicy.xaml
@@ -567,7 +567,7 @@
 
                                             <TextBlock x:Uid="ViewSelectedFilesTextBlock" TextWrapping="WrapWholeWords" />
 
-                                            <ListBox MinWidth="400" SelectionMode="Single" ItemsSource="{x:Bind ViewModel.filesAndFoldersFilePaths, Mode=OneWay}" />
+                                            <customUI:ListBoxV2 MinWidth="400" SelectionMode="Single" ItemsSource="{x:Bind ViewModel.filesAndFoldersFilePaths, Mode=OneWay}" />
 
                                         </controls:WrapPanel>
 
@@ -603,7 +603,7 @@
 
                                             <TextBlock x:Uid="ViewSelectedFoldersTextBlock" TextWrapping="WrapWholeWords" />
 
-                                            <ListBox MinWidth="400" SelectionMode="Single" ItemsSource="{x:Bind ViewModel.filesAndFoldersFolderPaths, Mode=OneWay}" />
+                                            <customUI:ListBoxV2 MinWidth="400" SelectionMode="Single" ItemsSource="{x:Bind ViewModel.filesAndFoldersFolderPaths, Mode=OneWay}" />
 
                                         </controls:WrapPanel>
 

--- a/AppControl Manager/Pages/DeploymentPage.xaml
+++ b/AppControl Manager/Pages/DeploymentPage.xaml
@@ -125,7 +125,7 @@
 
                                         <TextBlock x:Uid="ViewSelectedXMLFileTextBlock" TextWrapping="WrapWholeWords" />
 
-                                        <ListBox MinWidth="400"
+                                        <customUI:ListBoxV2 MinWidth="400"
                                                  SelectionMode="Single"
                                                  ItemsSource="{x:Bind ViewModel.XMLFiles, Mode=OneWay}" />
 
@@ -195,7 +195,7 @@
 
                                         <TextBlock x:Uid="ViewSelectedXMLFileTextBlock" TextWrapping="WrapWholeWords" />
 
-                                        <ListBox MinWidth="400"
+                                        <customUI:ListBoxV2 MinWidth="400"
                                                  SelectionMode="Single"
                                                  ItemsSource="{x:Bind ViewModel.SignedXMLFiles, Mode=OneWay}" />
 
@@ -263,7 +263,7 @@
                                         <TextBlock x:Uid="ViewSelectedCIPFilesTextBlock"
                                                    TextWrapping="WrapWholeWords" />
 
-                                        <ListBox MinWidth="400"
+                                        <customUI:ListBoxV2 MinWidth="400"
                                                  SelectionMode="Single"
                                                  ItemsSource="{x:Bind ViewModel.CIPFiles, Mode=OneWay}" />
 
@@ -320,7 +320,7 @@
                                         <TextBlock x:Uid="ViewSelectedXMLFilesTextBlock"
                                                    TextWrapping="WrapWholeWords" />
 
-                                        <ListBox MinWidth="400"
+                                        <customUI:ListBoxV2 MinWidth="400"
                                                  SelectionMode="Single"
                                                  ItemsSource="{x:Bind ViewModel.XMLFilesToConvertToCIP, Mode=OneWay}" />
 

--- a/AppControl Manager/Pages/EventLogsPolicyCreation.xaml
+++ b/AppControl Manager/Pages/EventLogsPolicyCreation.xaml
@@ -273,6 +273,18 @@
 
                                 </ToggleMenuFlyoutItem>
 
+                                <MenuFlyoutSeparator/>
+
+                                <MenuFlyoutSubItem x:Uid="ClearOperationSystemLogsMenuFlyoutItem">
+                                    <MenuFlyoutSubItem.Icon>
+                                        <FontIcon Glyph="&#xE814;"/>
+                                    </MenuFlyoutSubItem.Icon>
+                                    <MenuFlyoutItem Click="{x:Bind ViewModel.ClearCodeIntegrityOSLogs}"
+                                                    x:Uid="ClearOSCodeIntegrityLogsMenuFlyoutItem" />
+                                    <MenuFlyoutItem Click="{x:Bind ViewModel.ClearAppLockerOSLogs}"
+                                                    x:Uid="ClearOSAppLockerLogsMenuFlyoutItem" />
+                                </MenuFlyoutSubItem>
+
                             </MenuFlyout>
 
                         </DropDownButton.Flyout>

--- a/AppControl Manager/Pages/MergePolicies.xaml
+++ b/AppControl Manager/Pages/MergePolicies.xaml
@@ -110,7 +110,7 @@
 
                                         <TextBlock x:Uid="ViewTheSelectedOtherPolicies" TextWrapping="WrapWholeWords" />
 
-                                        <ListBox MinWidth="400" SelectionMode="Single" ItemsSource="{x:Bind ViewModel.OtherPolicies, Mode=OneWay}" />
+                                        <customUI:ListBoxV2 MinWidth="400" SelectionMode="Single" ItemsSource="{x:Bind ViewModel.OtherPolicies, Mode=OneWay}" />
 
                                     </controls:WrapPanel>
 

--- a/AppControl Manager/Pages/Simulation.xaml
+++ b/AppControl Manager/Pages/Simulation.xaml
@@ -100,7 +100,9 @@
 
                                     <TextBlock x:Uid="ViewSelectedFilesTextBlock" TextWrapping="WrapWholeWords" />
 
-                                    <ListBox MinWidth="400" SelectionMode="Single" ItemsSource="{x:Bind ViewModel.FilePaths, Mode=OneWay}" />
+                                    <customUI:ListBoxV2 MinWidth="400"
+                                                        SelectionMode="Single"
+                                                        ItemsSource="{x:Bind ViewModel.FilePaths, Mode=OneWay}" />
 
                                 </controls:WrapPanel>
 
@@ -133,7 +135,9 @@
 
                                     <TextBlock x:Uid="ViewSelectedFoldersTextBlock" TextWrapping="WrapWholeWords" />
 
-                                    <ListBox MinWidth="400" SelectionMode="Single" ItemsSource="{x:Bind ViewModel.FolderPaths, Mode=OneWay}" />
+                                    <customUI:ListBoxV2 MinWidth="400"
+                                                        SelectionMode="Single"
+                                                        ItemsSource="{x:Bind ViewModel.FolderPaths, Mode=OneWay}" />
 
                                 </controls:WrapPanel>
 

--- a/AppControl Manager/ReleaseNotes.txt
+++ b/AppControl Manager/ReleaseNotes.txt
@@ -1,5 +1,7 @@
-* Fixed an issue with WebView2 content in the app. Now they load correctly when Administrator Protection is enabled and the app is running with elevated privileges. See this for more info: https://github.com/HotCakeX/Harden-Windows-Security/issues/916
-
-* In this update, the WebView2 profile directory is saved under `ProgramData` and it is completely cleared upon app exit, ensuring no residual data is ever left behind. It explicitly uses InPrivate mode and extensions disabled.
-
 * Updated dependencies to the latest version.
+
+* Added new options under the "Actions" button in Event Logs policy creation page that offers the ability to clear the entire system logs for Code Integrity and App Locker categories. There will be a confirmation dialog that you have to accept before the logs are cleared. Completes part of this feature request: https://github.com/HotCakeX/Harden-Windows-Security/issues/783
+
+* Made various performance improvements across the board.
+
+* Added a delete option to the selected files/folders previews across the app so that in addition to "clear all" button, you can remove the files or folders you've selected individually and easily.

--- a/AppControl Manager/SiPolicy/CustomDeserialization.cs
+++ b/AppControl Manager/SiPolicy/CustomDeserialization.cs
@@ -1336,7 +1336,7 @@ internal static class CustomDeserialization
 			return;
 
 		// At this point both are non-null/non-empty, so attempt to parse:
-		if (!Version.TryParse(minimumVersion, out var minVer))
+		if (!Version.TryParse(minimumVersion, out Version? minVer))
 			throw new ArgumentException(
 				string.Format(
 					GlobalVars.GetStr("ValidateVersionRangeInvalidMinVersionMessage"),
@@ -1344,7 +1344,7 @@ internal static class CustomDeserialization
 					minimumVersion),
 				nameof(minimumVersion));
 
-		if (!Version.TryParse(maximumVersion, out var maxVer))
+		if (!Version.TryParse(maximumVersion, out Version? maxVer))
 			throw new ArgumentException(
 				string.Format(
 					GlobalVars.GetStr("ValidateVersionRangeInvalidMaxVersionMessage"),

--- a/AppControl Manager/SiPolicy/Merger.Aggregate.cs
+++ b/AppControl Manager/SiPolicy/Merger.Aggregate.cs
@@ -17,6 +17,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using AppControlManager.SiPolicyIntel;
 
 namespace AppControlManager.SiPolicy;
@@ -35,7 +36,7 @@ internal static class Factory
 		HashSet<AllowRule> allowRules = new(new AllowRuleComparer());
 
 		// Loop over each policy input data
-		foreach (SiPolicy siPolicy in siPolicies)
+		foreach (SiPolicy siPolicy in CollectionsMarshal.AsSpan(siPolicies))
 		{
 
 			// Index Allow rules by their ID for quick lookup
@@ -120,7 +121,7 @@ internal static class Factory
 		HashSet<DenyRule> denyRules = new(new DenyRuleComparer());
 
 		// Loop over each policy input data
-		foreach (SiPolicy siPolicy in siPolicies)
+		foreach (SiPolicy siPolicy in CollectionsMarshal.AsSpan(siPolicies))
 		{
 			// Index Deny rules by their ID for quick lookup
 			// ID will be key and Deny rule itself will be the value
@@ -201,7 +202,7 @@ internal static class Factory
 		HashSet<FileRuleRule> fileRuleRules = new(new FileRuleRuleComparer());
 
 		// Loop over each policy input data
-		foreach (SiPolicy siPolicy in siPolicies)
+		foreach (SiPolicy siPolicy in CollectionsMarshal.AsSpan(siPolicies))
 		{
 
 			// Index FileRules by their ID for quick lookup
@@ -289,7 +290,7 @@ internal static class Factory
 		HashSet<SupplementalPolicySignerRule> supplementalPolicySignerRules = new(new SupplementalPolicySignerRuleComparer());
 
 		// Loop over each policy input data
-		foreach (SiPolicy siPolicy in siPolicies)
+		foreach (SiPolicy siPolicy in CollectionsMarshal.AsSpan(siPolicies))
 		{
 
 			// Index elements for efficient lookup

--- a/AppControl Manager/SimulationMethods/GetSignerInfo.cs
+++ b/AppControl Manager/SimulationMethods/GetSignerInfo.cs
@@ -18,6 +18,7 @@
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Xml;
 using AppControlManager.Others;
 using AppControlManager.SiPolicy;
@@ -182,9 +183,9 @@ internal static class GetSignerInfo
 			// These are all root certificates, they have no leaf or intermediate certificates in their chains, that's why they're called Trusted Roots
 
 			// Get the CertRoot node of the current Signer
-			string? certRootValue = CustomSerialization.ConvertByteArrayToHex(signer.CertRoot.Value);
+			string certRootValue = CustomSerialization.ConvertByteArrayToHex(signer.CertRoot.Value);
 
-			if (certRootValue is not null && wellKnownIDs.Contains(certRootValue))
+			if (wellKnownIDs.Contains(certRootValue))
 			{
 				switch (certRootValue)
 				{
@@ -267,7 +268,7 @@ internal static class GetSignerInfo
 
 				// Iterate through the rule IDs and find matching FileAttrib nodes in the dictionary that holds the FileAttrib nodes in the <FileRules> node
 				// Get all the FileAttribs associated with the signer
-				foreach (string id in ruleIds)
+				foreach (string id in CollectionsMarshal.AsSpan(ruleIds))
 				{
 					if (fileAttribDictionary.TryGetValue(id, out FileAttrib? matchingFileAttrib))
 					{
@@ -355,9 +356,7 @@ internal static class GetSignerInfo
 
 			foreach (string EkuID in CertEKUIDs)
 			{
-				_ = EKUAndValuesCorrelation.TryGetValue(EkuID, out string? EkuValue);
-
-				if (EkuValue is not null)
+				if (EKUAndValuesCorrelation.TryGetValue(EkuID, out string? EkuValue))
 				{
 					// Check if the current EKU of the signer is WHQL
 					if (string.Equals(EkuValue, WHQLEkuHex, StringComparison.OrdinalIgnoreCase))
@@ -379,7 +378,7 @@ internal static class GetSignerInfo
 				new SignerX(
 				   id: signer.ID,
 					name: signer.Name,
-					certRoot: certRootValue!,
+					certRoot: certRootValue,
 					certPublisher: signer.CertPublisher?.Value,
 					certIssuer: signer.CertIssuer?.Value,
 					certEKU: [.. CertEKUs],

--- a/AppControl Manager/Strings/AR/Resources.resw
+++ b/AppControl Manager/Strings/AR/Resources.resw
@@ -6146,4 +6146,46 @@
   <data name="UseV2CIManagementSettingsCard.AutomationProperties.HelpText" xml:space="preserve">
     <value>قم بتمكين هذه الميزة لإتاحة طرق بديلة لنشر وإزالة نهج App Control. هذه الطرق لا تعتمد على الملف التنفيذي CiTool ويمكن استخدامها إذا كان CiTool محجوباً أو غير متاح.</value>
   </data>
+    <data name="ClearOperationSystemLogsMenuFlyoutItem.Text" xml:space="preserve">
+    <value>مسح سجلات النظام</value>
+  </data>
+  <data name="ClearOperationSystemLogsMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>مسح سجلات مختلفة في نظام التشغيل. هذا الإجراء غير قابل للاسترجاع.</value>
+  </data>
+  <data name="ClearOperationSystemLogsMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>مسح سجلات مختلفة في نظام التشغيل. هذا الإجراء غير قابل للاسترجاع.</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsMenuFlyoutItem.Text" xml:space="preserve">
+    <value>مسح سجلات Code Integrity</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>مسح جميع سجلات التشغيل الخاصة بـ Code Integrity من النظام.</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>مسح جميع سجلات التشغيل الخاصة بـ Code Integrity من النظام.</value>
+  </data>
+  <data name="ClearOSAppLockerLogsMenuFlyoutItem.Text" xml:space="preserve">
+    <value>مسح سجلات App Locker</value>
+  </data>
+  <data name="ClearOSAppLockerLogsMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>مسح جميع سجلات App Locker من النظام.</value>
+  </data>
+  <data name="ClearOSAppLockerLogsMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>مسح جميع سجلات App Locker من النظام.</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsSuccessMsg" xml:space="preserve">
+    <value>تم مسح جميع سجلات التشغيل الخاصة بـ Code Integrity من النظام بنجاح.</value>
+  </data>
+  <data name="ClearOSAppLockerLogsSuccessMsg" xml:space="preserve">
+    <value>تم مسح جميع سجلات App Locker من النظام بنجاح.</value>
+  </data>
+  <data name="OSLogsDeletionContentDialogMsg" xml:space="preserve">
+    <value>هل أنت متأكد من أنك تريد مسح السجلات المحددة؟ هذا الإجراء غير قابل للاسترجاع.</value>
+  </data>
+  <data name="OSCodeIntegrityLogsDeletionContentDialogTitle" xml:space="preserve">
+    <value>حذف سجلات Code Integrity</value>
+  </data>
+  <data name="OSAppLockerLogsDeletionContentDialogTitle" xml:space="preserve">
+    <value>حذف سجلات App Locker</value>
+  </data>
 </root>

--- a/AppControl Manager/Strings/ES/Resources.resw
+++ b/AppControl Manager/Strings/ES/Resources.resw
@@ -6146,4 +6146,46 @@ NOTA: Esta opción siempre se aplica si alguna directiva UMCI de App Control la 
   <data name="UseV2CIManagementSettingsCard.AutomationProperties.HelpText" xml:space="preserve">
     <value>Habilite esta característica para poner a disposición métodos alternativos para implementar y quitar directivas de App Control. Estos métodos no dependen del ejecutable CiTool y pueden usarse si CiTool está bloqueado o no está disponible.</value>
   </data>
+    <data name="ClearOperationSystemLogsMenuFlyoutItem.Text" xml:space="preserve">
+    <value>Borrar registros del sistema</value>
+  </data>
+  <data name="ClearOperationSystemLogsMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Borrar distintos registros en el sistema operativo. Esta acción es irreversible.</value>
+  </data>
+  <data name="ClearOperationSystemLogsMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Borrar distintos registros en el sistema operativo. Esta acción es irreversible.</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsMenuFlyoutItem.Text" xml:space="preserve">
+    <value>Borrar registros de Code Integrity</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Borrar todos los registros operativos de Code Integrity del sistema.</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Borrar todos los registros operativos de Code Integrity del sistema.</value>
+  </data>
+  <data name="ClearOSAppLockerLogsMenuFlyoutItem.Text" xml:space="preserve">
+    <value>Borrar registros de App Locker</value>
+  </data>
+  <data name="ClearOSAppLockerLogsMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Borrar todos los registros de App Locker del sistema.</value>
+  </data>
+  <data name="ClearOSAppLockerLogsMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Borrar todos los registros de App Locker del sistema.</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsSuccessMsg" xml:space="preserve">
+    <value>Se borraron correctamente todos los registros operativos de Code Integrity del sistema.</value>
+  </data>
+  <data name="ClearOSAppLockerLogsSuccessMsg" xml:space="preserve">
+    <value>Se borraron correctamente todos los registros de App Locker del sistema.</value>
+  </data>
+  <data name="OSLogsDeletionContentDialogMsg" xml:space="preserve">
+    <value>¿Está seguro de que desea borrar los registros seleccionados? Esta acción es irreversible.</value>
+  </data>
+  <data name="OSCodeIntegrityLogsDeletionContentDialogTitle" xml:space="preserve">
+    <value>Eliminación de registros de Code Integrity</value>
+  </data>
+  <data name="OSAppLockerLogsDeletionContentDialogTitle" xml:space="preserve">
+    <value>Eliminación de registros de App Locker</value>
+  </data>
 </root>

--- a/AppControl Manager/Strings/de-DE/Resources.resw
+++ b/AppControl Manager/Strings/de-DE/Resources.resw
@@ -6146,4 +6146,46 @@ HINWEIS: Diese Option wird immer erzwungen, wenn eine beliebige App Control-UMCI
   <data name="UseV2CIManagementSettingsCard.AutomationProperties.HelpText" xml:space="preserve">
     <value>Aktivieren Sie diese Funktion, um alternative Methoden zum Bereitstellen und Entfernen von App-Control-Richtlinien verfügbar zu machen. Diese Methoden sind nicht vom CiTool-Programm abhängig und können verwendet werden, wenn CiTool blockiert oder nicht verfügbar ist.</value>
   </data>
+    <data name="ClearOperationSystemLogsMenuFlyoutItem.Text" xml:space="preserve">
+    <value>Systemprotokolle löschen</value>
+  </data>
+  <data name="ClearOperationSystemLogsMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Verschiedene Protokolle im Betriebssystem löschen. Dieser Vorgang ist unwiderruflich.</value>
+  </data>
+  <data name="ClearOperationSystemLogsMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Verschiedene Protokolle im Betriebssystem löschen. Dieser Vorgang ist unwiderruflich.</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsMenuFlyoutItem.Text" xml:space="preserve">
+    <value>Code-Integrity-Protokolle löschen</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Alle Code-Integrity-Betriebsprotokolle aus dem System löschen.</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Alle Code-Integrity-Betriebsprotokolle aus dem System löschen.</value>
+  </data>
+  <data name="ClearOSAppLockerLogsMenuFlyoutItem.Text" xml:space="preserve">
+    <value>App Locker-Protokolle löschen</value>
+  </data>
+  <data name="ClearOSAppLockerLogsMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Alle App Locker-Protokolle aus dem System löschen.</value>
+  </data>
+  <data name="ClearOSAppLockerLogsMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Alle App Locker-Protokolle aus dem System löschen.</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsSuccessMsg" xml:space="preserve">
+    <value>Alle Code-Integrity-Betriebsprotokolle wurden erfolgreich aus dem System gelöscht.</value>
+  </data>
+  <data name="ClearOSAppLockerLogsSuccessMsg" xml:space="preserve">
+    <value>Alle App Locker-Protokolle wurden erfolgreich aus dem System gelöscht.</value>
+  </data>
+  <data name="OSLogsDeletionContentDialogMsg" xml:space="preserve">
+    <value>Sind Sie sicher, dass Sie die ausgewählten Protokolle löschen möchten? Dieser Vorgang ist unwiderruflich.</value>
+  </data>
+  <data name="OSCodeIntegrityLogsDeletionContentDialogTitle" xml:space="preserve">
+    <value>Löschen von Code-Integrity-Protokollen</value>
+  </data>
+  <data name="OSAppLockerLogsDeletionContentDialogTitle" xml:space="preserve">
+    <value>Löschen von App Locker-Protokollen</value>
+  </data>
 </root>

--- a/AppControl Manager/Strings/el-GR/Resources.resw
+++ b/AppControl Manager/Strings/el-GR/Resources.resw
@@ -6146,4 +6146,46 @@
   <data name="UseV2CIManagementSettingsCard.AutomationProperties.HelpText" xml:space="preserve">
     <value>Ενεργοποιήστε αυτήν τη δυνατότητα για να καταστήσετε διαθέσιμες εναλλακτικές μεθόδους ανάπτυξης και κατάργησης πολιτικών App Control. Αυτές οι μέθοδοι δεν εξαρτώνται από το εκτελέσιμο CiTool και μπορούν να χρησιμοποιηθούν αν το CiTool είναι μπλοκαρισμένο ή μη διαθέσιμο.</value>
   </data>
+    <data name="ClearOperationSystemLogsMenuFlyoutItem.Text" xml:space="preserve">
+    <value>Καθαρισμός αρχείων καταγραφής συστήματος</value>
+  </data>
+  <data name="ClearOperationSystemLogsMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Καθαρισμός διαφόρων αρχείων καταγραφής στο λειτουργικό σύστημα. Η ενέργεια αυτή είναι μη αναστρέψιμη.</value>
+  </data>
+  <data name="ClearOperationSystemLogsMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Καθαρισμός διαφόρων αρχείων καταγραφής στο λειτουργικό σύστημα. Η ενέργεια αυτή είναι μη αναστρέψιμη.</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsMenuFlyoutItem.Text" xml:space="preserve">
+    <value>Καθαρισμός αρχείων καταγραφής Code Integrity</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Καθαρισμός όλων των λειτουργικών αρχείων καταγραφής Code Integrity από το σύστημα.</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Καθαρισμός όλων των λειτουργικών αρχείων καταγραφής Code Integrity από το σύστημα.</value>
+  </data>
+  <data name="ClearOSAppLockerLogsMenuFlyoutItem.Text" xml:space="preserve">
+    <value>Καθαρισμός αρχείων καταγραφής App Locker</value>
+  </data>
+  <data name="ClearOSAppLockerLogsMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Καθαρισμός όλων των αρχείων καταγραφής App Locker από το σύστημα.</value>
+  </data>
+  <data name="ClearOSAppLockerLogsMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Καθαρισμός όλων των αρχείων καταγραφής App Locker από το σύστημα.</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsSuccessMsg" xml:space="preserve">
+    <value>Όλα τα λειτουργικά αρχεία καταγραφής Code Integrity καθαρίστηκαν επιτυχώς από το σύστημα.</value>
+  </data>
+  <data name="ClearOSAppLockerLogsSuccessMsg" xml:space="preserve">
+    <value>Όλα τα αρχεία καταγραφής App Locker καθαρίστηκαν επιτυχώς από το σύστημα.</value>
+  </data>
+  <data name="OSLogsDeletionContentDialogMsg" xml:space="preserve">
+    <value>Είστε βέβαιοι ότι θέλετε να καθαρίσετε τα επιλεγμένα αρχεία καταγραφής; Η ενέργεια αυτή είναι μη αναστρέψιμη.</value>
+  </data>
+  <data name="OSCodeIntegrityLogsDeletionContentDialogTitle" xml:space="preserve">
+    <value>Διαγραφή αρχείων καταγραφής Code Integrity</value>
+  </data>
+  <data name="OSAppLockerLogsDeletionContentDialogTitle" xml:space="preserve">
+    <value>Διαγραφή αρχείων καταγραφής App Locker</value>
+  </data>
 </root>

--- a/AppControl Manager/Strings/en-US/Resources.resw
+++ b/AppControl Manager/Strings/en-US/Resources.resw
@@ -6146,4 +6146,46 @@ NOTE: This option is always enforced if any App Control UMCI policy enables it. 
   <data name="UseV2CIManagementSettingsCard.AutomationProperties.HelpText" xml:space="preserve">
     <value>Enable this feature to make alternative methods available for deploying and removing App Control policies. These methods do not depend on the CiTool executable and can be used if CiTool is blocked or unavailable.</value>
   </data>
+  <data name="ClearOperationSystemLogsMenuFlyoutItem.Text" xml:space="preserve">
+    <value>Clear System Logs</value>
+  </data>
+  <data name="ClearOperationSystemLogsMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Clear different logs in the operation system. This action is irreversible.</value>
+  </data>
+  <data name="ClearOperationSystemLogsMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Clear different logs in the operation system. This action is irreversible.</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsMenuFlyoutItem.Text" xml:space="preserve">
+    <value>Clear Code Integrity Logs</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Clear all of the Code Integrity Operational logs from the system.</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Clear all of the Code Integrity Operational logs from the system.</value>
+  </data>
+  <data name="ClearOSAppLockerLogsMenuFlyoutItem.Text" xml:space="preserve">
+    <value>Clear App Locker Logs</value>
+  </data>
+  <data name="ClearOSAppLockerLogsMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Clear all of the App Locker logs from the system.</value>
+  </data>
+  <data name="ClearOSAppLockerLogsMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Clear all of the App Locker logs from the system.</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsSuccessMsg" xml:space="preserve">
+    <value>Successfully cleared all of the Code Integrity Operational logs from the system.</value>
+  </data>
+  <data name="ClearOSAppLockerLogsSuccessMsg" xml:space="preserve">
+    <value>Successfully cleared all of the App Locker logs from the system.</value>
+  </data>
+  <data name="OSLogsDeletionContentDialogMsg" xml:space="preserve">
+    <value>Are you sure you want to clear the entire selected log data? This action is irreversible.</value>
+  </data>
+  <data name="OSCodeIntegrityLogsDeletionContentDialogTitle" xml:space="preserve">
+    <value>Deleting Code Integrity Logs</value>
+  </data>
+  <data name="OSAppLockerLogsDeletionContentDialogTitle" xml:space="preserve">
+    <value>Deleting App Locker Logs</value>
+  </data>
 </root>

--- a/AppControl Manager/Strings/he-IL/Resources.resw
+++ b/AppControl Manager/Strings/he-IL/Resources.resw
@@ -6147,4 +6147,46 @@
   <data name="UseV2CIManagementSettingsCard.AutomationProperties.HelpText" xml:space="preserve">
     <value>יש להפעיל תכונה זו כדי להפוך שיטות חלופיות לפריסה ולהסרה של מדיניות App Control לזמינות. שיטות אלה אינן תלויות בקובץ ההפעלה CiTool וניתן להשתמש בהן אם CiTool חסום או אינו זמין.</value>
   </data>
+    <data name="ClearOperationSystemLogsMenuFlyoutItem.Text" xml:space="preserve">
+    <value>נקה יומני מערכת</value>
+  </data>
+  <data name="ClearOperationSystemLogsMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>נקה מגוון יומנים במערכת ההפעלה. פעולה זו אינה ניתנת לביטול.</value>
+  </data>
+  <data name="ClearOperationSystemLogsMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>נקה מגוון יומנים במערכת ההפעלה. פעולה זו אינה ניתנת לביטול.</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsMenuFlyoutItem.Text" xml:space="preserve">
+    <value>נקה יומני Code Integrity</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>נקה את כל יומני Code Integrity Operational מן המערכת.</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>נקה את כל יומני Code Integrity Operational מן המערכת.</value>
+  </data>
+  <data name="ClearOSAppLockerLogsMenuFlyoutItem.Text" xml:space="preserve">
+    <value>נקה יומני App Locker</value>
+  </data>
+  <data name="ClearOSAppLockerLogsMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>נקה את כל יומני App Locker מן המערכת.</value>
+  </data>
+  <data name="ClearOSAppLockerLogsMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>נקה את כל יומני App Locker מן המערכת.</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsSuccessMsg" xml:space="preserve">
+    <value>כל יומני Code Integrity Operational נוקו בהצלחה מן המערכת.</value>
+  </data>
+  <data name="ClearOSAppLockerLogsSuccessMsg" xml:space="preserve">
+    <value>כל יומני App Locker נוקו בהצלחה מן המערכת.</value>
+  </data>
+  <data name="OSLogsDeletionContentDialogMsg" xml:space="preserve">
+    <value>האם אתה בטוח שברצונך לנקות את היומנים שנבחרו? פעולה זו אינה ניתנת לביטול.</value>
+  </data>
+  <data name="OSCodeIntegrityLogsDeletionContentDialogTitle" xml:space="preserve">
+    <value>מחיקת יומני Code Integrity</value>
+  </data>
+  <data name="OSAppLockerLogsDeletionContentDialogTitle" xml:space="preserve">
+    <value>מחיקת יומני App Locker</value>
+  </data>
 </root>

--- a/AppControl Manager/Strings/hi-IN/Resources.resw
+++ b/AppControl Manager/Strings/hi-IN/Resources.resw
@@ -6146,4 +6146,46 @@ NOTE: यदि कोई भी App Control UMCI नीति इसे सक�
   <data name="UseV2CIManagementSettingsCard.AutomationProperties.HelpText" xml:space="preserve">
     <value>App Control पॉलिसियों को परिनियोजित और हटाने के लिए वैकल्पिक विधियाँ उपलब्ध कराने हेतु इस फ़ीचर को सक्षम करें। ये विधियाँ CiTool निष्पादन योग्य पर निर्भर नहीं हैं और यदि CiTool अवरुद्ध या अनुपलब्ध है तो उपयोग की जा सकती हैं.</value>
   </data>
+    <data name="ClearOperationSystemLogsMenuFlyoutItem.Text" xml:space="preserve">
+    <value>सिस्टम लॉग साफ करें</value>
+  </data>
+  <data name="ClearOperationSystemLogsMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>ऑपरेटिंग सिस्टम में विभिन्न लॉग साफ करें। यह क्रिया अपरिवर्तनीय है।</value>
+  </data>
+  <data name="ClearOperationSystemLogsMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>ऑपरेटिंग सिस्टम में विभिन्न लॉग साफ करें। यह क्रिया अपरिवर्तनीय है।</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsMenuFlyoutItem.Text" xml:space="preserve">
+    <value>Code Integrity लॉग साफ करें</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>सिस्टम से सभी Code Integrity परिचालन लॉग साफ करें।</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>सिस्टम से सभी Code Integrity परिचालन लॉग साफ करें।</value>
+  </data>
+  <data name="ClearOSAppLockerLogsMenuFlyoutItem.Text" xml:space="preserve">
+    <value>App Locker लॉग साफ करें</value>
+  </data>
+  <data name="ClearOSAppLockerLogsMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>सिस्टम से सभी App Locker लॉग साफ करें।</value>
+  </data>
+  <data name="ClearOSAppLockerLogsMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>सिस्टम से सभी App Locker लॉग साफ करें।</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsSuccessMsg" xml:space="preserve">
+    <value>सिस्टम से सभी Code Integrity परिचालन लॉग सफलतापूर्वक साफ किए गए।</value>
+  </data>
+  <data name="ClearOSAppLockerLogsSuccessMsg" xml:space="preserve">
+    <value>सिस्टम से सभी App Locker लॉग सफलतापूर्वक साफ किए गए।</value>
+  </data>
+  <data name="OSLogsDeletionContentDialogMsg" xml:space="preserve">
+    <value>क्या आप निश्चित हैं कि आप चयनित लॉग साफ करना चाहते हैं? यह क्रिया अपरिवर्तनीय है।</value>
+  </data>
+  <data name="OSCodeIntegrityLogsDeletionContentDialogTitle" xml:space="preserve">
+    <value>Code Integrity लॉग हटाना</value>
+  </data>
+  <data name="OSAppLockerLogsDeletionContentDialogTitle" xml:space="preserve">
+    <value>App Locker लॉग हटाना</value>
+  </data>
 </root>

--- a/AppControl Manager/Strings/ml-IN/Resources.resw
+++ b/AppControl Manager/Strings/ml-IN/Resources.resw
@@ -6146,4 +6146,46 @@
   <data name="UseV2CIManagementSettingsCard.AutomationProperties.HelpText" xml:space="preserve">
     <value>App Control നയങ്ങൾ വിന്യസിക്കാൻയും നീക്കം ചെയ്യാനും ബദൽ രീതികൾ ലഭ്യമാക്കാൻ ഈ സവിശേഷത സജീവമാക്കുക. ഈ രീതികൾ CiTool എക്സിക്യൂട്ടബിളിനെ ആശ്രയിക്കുന്നതല്ല, CiTool തടഞ്ഞിട്ടുണ്ടെങ്കിൽ അല്ലെങ്കിൽ ലഭ്യമല്ലെങ്കിൽ അവ ഉപയോഗിക്കാം.</value>
   </data>
+    <data name="ClearOperationSystemLogsMenuFlyoutItem.Text" xml:space="preserve">
+    <value>സിസ്റ്റം ലോഗുകൾ മായ്ച്ചുകളയുക</value>
+  </data>
+  <data name="ClearOperationSystemLogsMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>ഓപ്പറേറ്റിങ് സിസ്റ്റത്തിലെ വിവിധ ലോഗുകൾ മായ്ക്കുക. ഈ പ്രവർത്തി മാറ്റിനിര്‍ത്താനാവില്ല.</value>
+  </data>
+  <data name="ClearOperationSystemLogsMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>ഓപ്പറേറ്റിങ് സിസ്റ്റത്തിലെ വിവിധ ലോഗുകൾ മായ്ക്കുക. ഈ പ്രവർത്തി മാറ്റിനിര്‍ത്താനാവില്ല.</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsMenuFlyoutItem.Text" xml:space="preserve">
+    <value>Code Integrity ലോഗുകൾ മായ്ച്ചുകളയുക</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>സിസ്റ്റത്തിൽ നിന്ന് എല്ലാ Code Integrity Operational ലോഗുകളും മായ്ച്ചുകളയുക.</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>സിസ്റ്റത്തിൽ നിന്ന് എല്ലാ Code Integrity Operational ലോഗുകളും മായ്ച്ചുകളയുക.</value>
+  </data>
+  <data name="ClearOSAppLockerLogsMenuFlyoutItem.Text" xml:space="preserve">
+    <value>App Locker ലോഗുകൾ മായ്ച്ചുകളയുക</value>
+  </data>
+  <data name="ClearOSAppLockerLogsMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>സിസ്റ്റത്തിൽ നിന്ന് എല്ലാ App Locker ലോഗുകളും മായ്ച്ചുകളയുക.</value>
+  </data>
+  <data name="ClearOSAppLockerLogsMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>സിസ്റ്റത്തിൽ നിന്ന് എല്ലാ App Locker ലോഗുകളും മായ്ച്ചുകളയുക.</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsSuccessMsg" xml:space="preserve">
+    <value>സിസ്റ്റത്തിൽ നിന്ന് എല്ലാ Code Integrity Operational ലോഗുകളും വിജയകരമായി മായ്ച്ചുകളഞ്ഞു.</value>
+  </data>
+  <data name="ClearOSAppLockerLogsSuccessMsg" xml:space="preserve">
+    <value>സിസ്റ്റത്തിൽ നിന്ന് എല്ലാ App Locker ലോഗുകളും വിജയകരമായി മായ്ച്ചുകളഞ്ഞു.</value>
+  </data>
+  <data name="OSLogsDeletionContentDialogMsg" xml:space="preserve">
+    <value>നിങ്ങൾ തെരഞ്ഞെടുത്ത ലോഗുകൾ മായ്ച്ചുകളയാൻ നിങ്ങൾക്ക് ഉറപ്പാണോ? ഈ പ്രവർത്തി മാറ്റിനിര്‍ത്താനാവില്ല.</value>
+  </data>
+  <data name="OSCodeIntegrityLogsDeletionContentDialogTitle" xml:space="preserve">
+    <value>Code Integrity ലോഗുകൾ ഇല്ലാതാക്കുന്നു</value>
+  </data>
+  <data name="OSAppLockerLogsDeletionContentDialogTitle" xml:space="preserve">
+    <value>App Locker ലോഗുകൾ ഇല്ലാതാക്കുന്നു</value>
+  </data>
 </root>

--- a/AppControl Manager/Strings/pl-PL/Resources.resw
+++ b/AppControl Manager/Strings/pl-PL/Resources.resw
@@ -6146,4 +6146,46 @@ UWAGA: Ta opcja jest zawsze wymuszana, jeśli jakakolwiek zasada UMCI Kontroli A
   <data name="UseV2CIManagementSettingsCard.AutomationProperties.HelpText" xml:space="preserve">
     <value>Włącz tę funkcję, aby udostępnić alternatywne metody wdrażania i usuwania zasad App Control. Metody te nie zależą od pliku wykonywalnego CiTool i można ich użyć, jeśli CiTool jest zablokowany lub niedostępny.</value>
   </data>
+    <data name="ClearOperationSystemLogsMenuFlyoutItem.Text" xml:space="preserve">
+    <value>Wyczyść dzienniki systemowe</value>
+  </data>
+  <data name="ClearOperationSystemLogsMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Wyczyść różne dzienniki w systemie operacyjnym. Tej operacji nie można cofnąć.</value>
+  </data>
+  <data name="ClearOperationSystemLogsMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Wyczyść różne dzienniki w systemie operacyjnym. Tej operacji nie można cofnąć.</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsMenuFlyoutItem.Text" xml:space="preserve">
+    <value>Wyczyść dzienniki Code Integrity</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Wyczyść wszystkie dzienniki operacyjne Code Integrity z systemu.</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Wyczyść wszystkie dzienniki operacyjne Code Integrity z systemu.</value>
+  </data>
+  <data name="ClearOSAppLockerLogsMenuFlyoutItem.Text" xml:space="preserve">
+    <value>Wyczyść dzienniki App Locker</value>
+  </data>
+  <data name="ClearOSAppLockerLogsMenuFlyoutItem.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Wyczyść wszystkie dzienniki App Locker z systemu.</value>
+  </data>
+  <data name="ClearOSAppLockerLogsMenuFlyoutItem.AutomationProperties.HelpText" xml:space="preserve">
+    <value>Wyczyść wszystkie dzienniki App Locker z systemu.</value>
+  </data>
+  <data name="ClearOSCodeIntegrityLogsSuccessMsg" xml:space="preserve">
+    <value>Pomyślnie wyczyszczono wszystkie dzienniki operacyjne Code Integrity z systemu.</value>
+  </data>
+  <data name="ClearOSAppLockerLogsSuccessMsg" xml:space="preserve">
+    <value>Pomyślnie wyczyszczono wszystkie dzienniki App Locker z systemu.</value>
+  </data>
+  <data name="OSLogsDeletionContentDialogMsg" xml:space="preserve">
+    <value>Czy na pewno chcesz wyczyścić wybrane dzienniki? Tej operacji nie można cofnąć.</value>
+  </data>
+  <data name="OSCodeIntegrityLogsDeletionContentDialogTitle" xml:space="preserve">
+    <value>Usuwanie dzienników Code Integrity</value>
+  </data>
+  <data name="OSAppLockerLogsDeletionContentDialogTitle" xml:space="preserve">
+    <value>Usuwanie dzienników App Locker</value>
+  </data>
 </root>

--- a/AppControl Manager/ViewModels/AllowNewAppsVM.cs
+++ b/AppControl Manager/ViewModels/AllowNewAppsVM.cs
@@ -20,6 +20,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Numerics;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using AppControlManager.CustomUIElements;
 using AppControlManager.IntelGathering;
@@ -972,7 +973,7 @@ internal sealed partial class AllowNewAppsVM : ViewModelBase
 		List<FileIdentity> itemsToDelete = [.. lv.SelectedItems.Cast<FileIdentity>()];
 
 		// Remove each selected item from the FileIdentities collection
-		foreach (FileIdentity item in itemsToDelete)
+		foreach (FileIdentity item in CollectionsMarshal.AsSpan(itemsToDelete))
 		{
 			_ = LocalFilesFileIdentities.Remove(item);
 			_ = LocalFilesAllFileIdentities.Remove(item);
@@ -1067,7 +1068,7 @@ internal sealed partial class AllowNewAppsVM : ViewModelBase
 		List<FileIdentity> itemsToDelete = [.. lv.SelectedItems.Cast<FileIdentity>()];
 
 		// Remove each selected item from the FileIdentities collection
-		foreach (FileIdentity item in itemsToDelete)
+		foreach (FileIdentity item in CollectionsMarshal.AsSpan(itemsToDelete))
 		{
 			_ = EventLogsFileIdentities.Remove(item);
 			_ = EventLogsAllFileIdentities.Remove(item);

--- a/AppControl Manager/ViewModels/CreateSupplementalPolicyVM.cs
+++ b/AppControl Manager/ViewModels/CreateSupplementalPolicyVM.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using AppControlManager.IncrementalCollection;
@@ -1711,7 +1712,7 @@ internal sealed partial class CreateSupplementalPolicyVM : ViewModelBase, IDispo
 		List<FileIdentity> itemsToDelete = [.. lv.SelectedItems.Cast<FileIdentity>()];
 
 		// Remove each selected item from the FileIdentities collection
-		foreach (FileIdentity item in itemsToDelete)
+		foreach (FileIdentity item in CollectionsMarshal.AsSpan(itemsToDelete))
 		{
 			_ = StrictKernelModeScanResults.Remove(item);
 			_ = StrictKernelModeScanResultsList.Remove(item);

--- a/AppControl Manager/ViewModels/ViewCurrentPoliciesVM.cs
+++ b/AppControl Manager/ViewModels/ViewCurrentPoliciesVM.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using AppControlManager.CustomUIElements;
 using AppControlManager.Main;
@@ -227,7 +228,7 @@ internal sealed partial class ViewCurrentPoliciesVM : ViewModelBase
 			AllPoliciesOutput.AddRange(policies);
 
 			// Store all of the policies in the ObservableCollection
-			foreach (CiPolicyInfo policy in policies)
+			foreach (CiPolicyInfo policy in CollectionsMarshal.AsSpan(policies))
 			{
 				// Add the retrieved policies to the ObservableCollection
 				AllPolicies.Add(policy);
@@ -514,12 +515,9 @@ internal sealed partial class ViewCurrentPoliciesVM : ViewModelBase
 						// Find any automatic AppControlManagerSupplementalPolicy that is associated with it and still on the system
 						List<CiPolicyInfo> extraPoliciesToRemove = [.. currentlyDeployedAppControlManagerSupplementalPolicies.Where(p => string.Equals(p.BasePolicyID, ListViewSelectedPolicy.PolicyID, StringComparison.OrdinalIgnoreCase) && p.IsOnDisk)];
 
-						if (extraPoliciesToRemove.Count > 0)
+						foreach (CiPolicyInfo item in CollectionsMarshal.AsSpan(extraPoliciesToRemove))
 						{
-							foreach (CiPolicyInfo item in extraPoliciesToRemove)
-							{
-								policiesToRemove.Add(item);
-							}
+							policiesToRemove.Add(item);
 						}
 					}
 				}

--- a/AppControl Manager/eXclude/CommonCore/MicrosoftGraph/ThreadSafeObservableCollection.cs
+++ b/AppControl Manager/eXclude/CommonCore/MicrosoftGraph/ThreadSafeObservableCollection.cs
@@ -86,7 +86,7 @@ internal sealed class ThreadSafeObservableCollection<T> : ObservableCollection<T
 			// Create a snapshot of the items to iterate over.
 			var items = new T[Items.Count];
 			Items.CopyTo(items, 0);
-			foreach (var item in items)
+			foreach (T? item in items)
 			{
 				yield return item;
 			}


### PR DESCRIPTION
* Updated dependencies to the latest version.

* Added new options under the "Actions" button in Event Logs policy creation page that offers the ability to clear the entire system logs for Code Integrity and App Locker categories. There will be a confirmation dialog that you have to accept before the logs are cleared. Completes part of this feature request: https://github.com/HotCakeX/Harden-Windows-Security/issues/783

* Made various performance improvements across the board.

* Added a delete option to the selected files/folders previews across the app so that in addition to "clear all" button, you can remove the files or folders you've selected individually and easily.
