### PR TITLE
AppControl Manager v2.0.54.0

### DIFF
--- a/AppControl Manager/AppControl Manager.csproj
+++ b/AppControl Manager/AppControl Manager.csproj
@@ -61,7 +61,7 @@
 		<AssemblyName>AppControlManager</AssemblyName>
 		<!-- https://learn.microsoft.com/dotnet/core/deploying/native-aot/optimizing -->
 
-		<FileVersion>2.0.53.0</FileVersion>
+		<FileVersion>2.0.54.0</FileVersion>
 		<AssemblyVersion>$(FileVersion)</AssemblyVersion>
 
 		<StartupObject>AppControlManager.Program</StartupObject>

--- a/AppControl Manager/CustomUIElements/SigningDetailsDialog.xaml
+++ b/AppControl Manager/CustomUIElements/SigningDetailsDialog.xaml
@@ -8,6 +8,7 @@
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     x:Uid="SigningDetailsDialog"
+    PrimaryButtonClick="{x:Bind OnPrimaryButtonClick}"
     IsPrimaryButtonEnabled="False"
     DefaultButton="Primary"
     Style="{ThemeResource DefaultContentDialogStyle}"

--- a/AppControl Manager/CustomUIElements/SigningDetailsDialog.xaml.cs
+++ b/AppControl Manager/CustomUIElements/SigningDetailsDialog.xaml.cs
@@ -193,7 +193,7 @@ internal sealed partial class SigningDetailsDialog : ContentDialogV2
 	/// </summary>
 	/// <param name="sender"></param>
 	/// <param name="args"></param>
-	private void OnPrimaryButtonClick(ContentDialogV2 sender, ContentDialogButtonClickEventArgs args)
+	private void OnPrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
 	{
 		// Fill in the text boxes based on the current user configs
 		CertificatePath = CertFilePathTextBox.Text;

--- a/AppControl Manager/CustomUIElements/SigningDetailsDialogForRemoval.xaml
+++ b/AppControl Manager/CustomUIElements/SigningDetailsDialogForRemoval.xaml
@@ -6,6 +6,7 @@
     xmlns:customUI="using:AppControlManager.CustomUIElements"
     xmlns:ui="using:CommunityToolkit.WinUI"
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
+    PrimaryButtonClick="{x:Bind OnPrimaryButtonClick}"
     xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     x:Uid="SigningDetailsDialog"
     IsPrimaryButtonEnabled="False"

--- a/AppControl Manager/Others/AllCertificatesGrabber.cs
+++ b/AppControl Manager/Others/AllCertificatesGrabber.cs
@@ -173,7 +173,7 @@ internal static class AllCertificatesGrabber
 	}
 
 	// This is the main method used to retrieve all signers for a given file
-	internal static unsafe List<AllFileSigners> GetAllFileSigners(string FilePath)
+	internal static unsafe List<AllFileSigners> GetAllFileSigners(string FilePath, bool includeInvalidCerts = false)
 	{
 		const int EncodedMessageParameter = 29;
 
@@ -235,14 +235,14 @@ internal static class AllCertificatesGrabber
 					}
 				}
 
-				// If the certificate is expired, continue to the next iteration
-				if (verifyTrustResult == WinVerifyTrustResult.CertExpired)
+				// If the certificate is expired and we don't want to include invalid certs, continue to the next iteration
+				if (verifyTrustResult == WinVerifyTrustResult.CertExpired && !includeInvalidCerts)
 				{
 					continue;
 				}
 
-				// if there is a hash mismatch in the file, throw an exception
-				if (verifyTrustResult == WinVerifyTrustResult.HashMismatch)
+				// if there is a hash mismatch in the file, throw an exception unless we want to include invalid certs
+				if (verifyTrustResult == WinVerifyTrustResult.HashMismatch && !includeInvalidCerts)
 				{
 					// Throw a custom exception
 					throw new HashMismatchInCertificateException(

--- a/AppControl Manager/Package.appxmanifest
+++ b/AppControl Manager/Package.appxmanifest
@@ -35,7 +35,7 @@
   <Identity
     Name="VioletHansen.AppControlManager"
     Publisher="CN=C62E63B6-6EF1-4F86-B80F-41A725BD0189"
-    Version="2.0.53.0" />
+    Version="2.0.54.0" />
 
   <mp:PhoneIdentity PhoneProductId="4157a676-f4c2-4a8c-a511-b7fb2255c6f5" PhonePublisherId="387464d6-cb95-4e5f-9c8f-f153a4855fb2"/>
 

--- a/AppControl Manager/ReleaseNotes.txt
+++ b/AppControl Manager/ReleaseNotes.txt
@@ -1,19 +1,3 @@
-* Added real-time CPU temperature to the Home page.
+* Fixed an issue where you'd have to click/tap the Deploy button twice in the Deployment page to deploy a signed policy: https://github.com/HotCakeX/Harden-Windows-Security/issues/948
 
-* Added advanced CPU details to the home page.
-
-* Added Computer name to the home page.
-
-* Added OS edition, version and build information to the home page.
-
-* Added RAM speed and generation details to the home page.
-
-* Added real-time total amount of Internet uploaded data and downloaded data to the home page.
-
-* Features in the home page that display real-time data such as CPU temperature, network speed and so on, are highly optimized, fast and only active when the user is on the home page. If you navigate away to another page, they will stop gathering data and will not run in the background so they do not consume unnecessary resources.
-
-* The time it takes from clicking on the app icon on taskbar or start menu to launch it to the home page load is less than 1 second and will stay that way.
-
-* Localized the home page information for all of the supported languages.
-
-* Significantly improved the speed and performance of the Event Log Policy Creation. Now the scans of Code Integrity and App Locker event logs from local system or custom EVTX files *take half of the time* compared to the previous version. This performance boost is achieved by implementing new algorithms and optimizations in the scanning engine, rather than simply using more CPU cores and parallelism. The system resource usage actually remains the same as before or even lower in some cases, while the speed is greatly improved.
+* The View File Certificates page now shows the certificates of files with revoked, expired or Hash mismatch certificates: https://github.com/HotCakeX/Harden-Windows-Security/issues/947

--- a/AppControl Manager/ViewModels/ViewFileCertificatesVM.cs
+++ b/AppControl Manager/ViewModels/ViewFileCertificatesVM.cs
@@ -595,7 +595,7 @@ internal sealed partial class ViewFileCertificatesVM : ViewModelBase
 					try
 					{
 						// Get all of the file's certificates
-						signerDetails = AllCertificatesGrabber.GetAllFileSigners(selectedFile);
+						signerDetails = AllCertificatesGrabber.GetAllFileSigners(selectedFile, true);
 
 						// If the file has no signers and the user wants to include security catalogs
 						if (signerDetails.Count is 0 && IncludeSecurityCatalogsToggleSwitch)
@@ -610,7 +610,7 @@ internal sealed partial class ViewFileCertificatesVM : ViewModelBase
 							{
 								try
 								{
-									signerDetails = AllCertificatesGrabber.GetAllFileSigners(CurrentFilePathHashSHA1CatResult);
+									signerDetails = AllCertificatesGrabber.GetAllFileSigners(CurrentFilePathHashSHA1CatResult, true);
 								}
 								catch (HashMismatchInCertificateException)
 								{
@@ -626,7 +626,7 @@ internal sealed partial class ViewFileCertificatesVM : ViewModelBase
 							{
 								try
 								{
-									signerDetails = AllCertificatesGrabber.GetAllFileSigners(CurrentFilePathHashSHA256CatResult);
+									signerDetails = AllCertificatesGrabber.GetAllFileSigners(CurrentFilePathHashSHA256CatResult, true);
 								}
 								catch (HashMismatchInCertificateException)
 								{

--- a/AppControl Manager/app.manifest
+++ b/AppControl Manager/app.manifest
@@ -2,7 +2,7 @@
 <!-- INFO: https://learn.microsoft.com/windows/win32/sbscs/application-manifests -->
 <!-- INFO (for legacy UWP but its info can be used for better understanding): https://learn.microsoft.com/uwp/schemas/appxpackage/uapmanifestschema/root-elements -->
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-	<assemblyIdentity version="2.0.53.0" name="AppControlManager"/>
+	<assemblyIdentity version="2.0.54.0" name="AppControlManager"/>
 
 	<compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
 		<application>


### PR DESCRIPTION
* Fixed an issue where you'd have to click/tap the Deploy button twice in the Deployment page to deploy a signed policy: https://github.com/HotCakeX/Harden-Windows-Security/issues/948

* The [View File Certificates page](https://github.com/HotCakeX/Harden-Windows-Security/wiki/View-File-Certificates) now shows the certificates of files with revoked, expired or Hash mismatch certificates: https://github.com/HotCakeX/Harden-Windows-Security/issues/947
