### PR TITLE
Harden System Security v1.0.38.0

### DIFF
--- a/Harden System Security/Harden System Security.csproj
+++ b/Harden System Security/Harden System Security.csproj
@@ -64,7 +64,7 @@
 		<AssemblyName>HardenSystemSecurity</AssemblyName>
 		<!-- https://learn.microsoft.com/dotnet/core/deploying/native-aot/optimizing -->
 
-		<FileVersion>1.0.37.0</FileVersion>
+		<FileVersion>1.0.38.0</FileVersion>
 		<AssemblyVersion>$(FileVersion)</AssemblyVersion>
 		<StartupObject>HardenSystemSecurity.Program</StartupObject>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/Harden System Security/Package.appxmanifest
+++ b/Harden System Security/Package.appxmanifest
@@ -36,7 +36,7 @@
   <Identity
     Name="VioletHansen.HardenSystemSecurity"
     Publisher="CN=C62E63B6-6EF1-4F86-B80F-41A725BD0189"
-    Version="1.0.37.0" />
+    Version="1.0.38.0" />
 
   <mp:PhoneIdentity PhoneProductId="74d36aa3-e613-41ec-808e-c5d051224316" PhonePublisherId="387464d6-cb95-4e5f-9c8f-f153a4855fb2"/>
 

--- a/Harden System Security/ReleaseNotes.txt
+++ b/Harden System Security/ReleaseNotes.txt
@@ -1,3 +1,1 @@
-* Updated dependencies to the latest version.
-
-* In the app close confirmation dialog, the default selected button is now set to "No" instead of "Yes" to follow best practices.
+* Updated the Microsoft 365 Apps Security Baseline from 24H2 to 25H2.

--- a/Harden System Security/ViewModels/Microsoft365AppsSecurityBaselineVM.cs
+++ b/Harden System Security/ViewModels/Microsoft365AppsSecurityBaselineVM.cs
@@ -534,12 +534,12 @@ internal sealed partial class Microsoft365AppsSecurityBaselineVM : ViewModelBase
 	/// </summary>
 	private static readonly FrozenDictionary<string, string> DownloadURLs = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
 	{
-		{"Microsoft 365 Apps for Enterprise 2412", @"https://download.microsoft.com/download/8/5/c/85c25433-a1b0-4ffa-9429-7e023e7da8d8/Microsoft%20365%20Apps%20for%20Enterprise%202412.zip"}
+		{"Microsoft 365 Apps for Enterprise 2512", @"https://download.microsoft.com/download/e99be2d2-e077-4986-a06b-6078051999dd/Microsoft%20365%20Apps%20for%20Enterprise%202512.zip"}
 	}.ToFrozenDictionary<string, string>();
 
 	internal List<string> SecurityBaselinesComboBoxItemsSource => DownloadURLs.Keys.ToList();
 
-	internal string SecurityBaselinesComboBoxSelectedItem { get; set => SP(ref field, value); } = "Microsoft 365 Apps for Enterprise 2412";
+	internal string SecurityBaselinesComboBoxSelectedItem { get; set => SP(ref field, value); } = "Microsoft 365 Apps for Enterprise 2512";
 
 	/// <summary>
 	/// The path to the custom baseline file, if any.

--- a/Harden System Security/app.manifest
+++ b/Harden System Security/app.manifest
@@ -2,7 +2,7 @@
 <!-- INFO: https://learn.microsoft.com/windows/win32/sbscs/application-manifests -->
 <!-- INFO (for legacy UWP but its info can be used for better understanding): https://learn.microsoft.com/uwp/schemas/appxpackage/uapmanifestschema/root-elements -->
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-    <assemblyIdentity version="1.0.37.0" name="HardenSystemSecurity.app"/>
+    <assemblyIdentity version="1.0.38.0" name="HardenSystemSecurity.app"/>
 
     <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
         <application>


### PR DESCRIPTION
# What's New

Updated the Microsoft 365 Apps Security Baseline from 24H2 to 25H2. Fixes this issue: https://github.com/HotCakeX/Harden-Windows-Security/issues/1000
