### PR TITLE
Added support for HotPatching data in App Control policies

### DIFF
--- a/AppControl Manager/Pages/PolicyEditor.xaml
+++ b/AppControl Manager/Pages/PolicyEditor.xaml
@@ -271,6 +271,9 @@
                                             <ColumnDefinition Width="{x:Bind ViewModel.FileBasedColumnWidth12, Mode=TwoWay}" MinWidth="50" />
                                             <ColumnDefinition Width="{x:Bind ViewModel.FileBasedColumnWidth13, Mode=TwoWay}" MinWidth="50" />
                                             <ColumnDefinition Width="{x:Bind ViewModel.FileBasedColumnWidth14, Mode=TwoWay}" MinWidth="50" />
+                                            <ColumnDefinition Width="{x:Bind ViewModel.FileBasedColumnWidth15, Mode=TwoWay}" MinWidth="50" />
+                                            <ColumnDefinition Width="{x:Bind ViewModel.FileBasedColumnWidth16, Mode=TwoWay}" MinWidth="50" />
+                                            <ColumnDefinition Width="{x:Bind ViewModel.FileBasedColumnWidth17, Mode=TwoWay}" MinWidth="50" />
                                         </Grid.ColumnDefinitions>
 
                                         <!-- Header TextBlocks -->
@@ -288,6 +291,9 @@
                                         <TextBlock x:Uid="PackageVersionHeader" FontFamily="{x:Bind ViewModel.AppSettings.ListViewFontFamily, Mode=OneWay}" Foreground="LightGray" HorizontalAlignment="Stretch" Grid.Column="11" FontWeight="Bold" Margin="10,0,2,0" Padding="5"/>
                                         <TextBlock Text="App IDs" FontFamily="{x:Bind ViewModel.AppSettings.ListViewFontFamily, Mode=OneWay}" Foreground="LightGray" HorizontalAlignment="Stretch" Grid.Column="12" FontWeight="Bold" Margin="10,0,2,0" Padding="5"/>
                                         <TextBlock Text="Type" FontFamily="{x:Bind ViewModel.AppSettings.ListViewFontFamily, Mode=OneWay}" Foreground="LightGray" HorizontalAlignment="Stretch" Grid.Column="13" FontWeight="Bold" Margin="10,0,2,0" Padding="5"/>
+                                        <TextBlock x:Uid="RequireHotpatchIDHeader" FontFamily="{x:Bind ViewModel.AppSettings.ListViewFontFamily, Mode=OneWay}" Foreground="LightGray" HorizontalAlignment="Stretch" Grid.Column="14" FontWeight="Bold" Margin="10,0,2,0" Padding="5"/>
+                                        <TextBlock x:Uid="MinimumHotpatchSequenceHeader" FontFamily="{x:Bind ViewModel.AppSettings.ListViewFontFamily, Mode=OneWay}" Foreground="LightGray" HorizontalAlignment="Stretch" Grid.Column="15" FontWeight="Bold" Margin="10,0,2,0" Padding="5"/>
+                                        <TextBlock x:Uid="MaximumHotpatchSequenceHeader" FontFamily="{x:Bind ViewModel.AppSettings.ListViewFontFamily, Mode=OneWay}" Foreground="LightGray" HorizontalAlignment="Stretch" Grid.Column="16" FontWeight="Bold" Margin="10,0,2,0" Padding="5"/>
 
                                         <!-- GridSplitters between columns -->
                                         <controls:GridSplitter Grid.Column="1" />
@@ -303,6 +309,9 @@
                                         <controls:GridSplitter Grid.Column="11" />
                                         <controls:GridSplitter Grid.Column="12" />
                                         <controls:GridSplitter Grid.Column="13" />
+                                        <controls:GridSplitter Grid.Column="14" />
+                                        <controls:GridSplitter Grid.Column="15" />
+                                        <controls:GridSplitter Grid.Column="16" />
                                     </Grid>
                                 </Border>
                             </customUI:ListViewV2.Header>
@@ -340,6 +349,9 @@
                                             <ColumnDefinition Width="{x:Bind VMs:ViewModelProvider.PolicyEditorVM.FileBasedColumnWidth12, Mode=OneWay}" />
                                             <ColumnDefinition Width="{x:Bind VMs:ViewModelProvider.PolicyEditorVM.FileBasedColumnWidth13, Mode=OneWay}" />
                                             <ColumnDefinition Width="{x:Bind VMs:ViewModelProvider.PolicyEditorVM.FileBasedColumnWidth14, Mode=OneWay}" />
+                                            <ColumnDefinition Width="{x:Bind VMs:ViewModelProvider.PolicyEditorVM.FileBasedColumnWidth15, Mode=OneWay}" />
+                                            <ColumnDefinition Width="{x:Bind VMs:ViewModelProvider.PolicyEditorVM.FileBasedColumnWidth16, Mode=OneWay}" />
+                                            <ColumnDefinition Width="{x:Bind VMs:ViewModelProvider.PolicyEditorVM.FileBasedColumnWidth17, Mode=OneWay}" />
                                         </Grid.ColumnDefinitions>
                                         <TextBlock IsTextSelectionEnabled="{x:Bind VMs:ViewModelProvider.PolicyEditorVM.TextsAreSelectableToggleState, Mode=OneWay}" FontFamily="{x:Bind VMs:ViewModelProvider.PolicyEditorVM.AppSettings.ListViewFontFamily, Mode=OneWay}" Text="{x:Bind Id}" Style="{StaticResource ListViewCellTextBlock}" Grid.Column="0"/>
                                         <TextBlock IsTextSelectionEnabled="{x:Bind VMs:ViewModelProvider.PolicyEditorVM.TextsAreSelectableToggleState, Mode=OneWay}" FontFamily="{x:Bind VMs:ViewModelProvider.PolicyEditorVM.AppSettings.ListViewFontFamily, Mode=OneWay}" Text="{x:Bind FriendlyName}" Style="{StaticResource ListViewCellTextBlock}" Grid.Column="1"/>
@@ -355,6 +367,9 @@
                                         <TextBlock IsTextSelectionEnabled="{x:Bind VMs:ViewModelProvider.PolicyEditorVM.TextsAreSelectableToggleState, Mode=OneWay}" FontFamily="{x:Bind VMs:ViewModelProvider.PolicyEditorVM.AppSettings.ListViewFontFamily, Mode=OneWay}" Text="{x:Bind PackageVersion}" Style="{StaticResource ListViewCellTextBlock}" Grid.Column="11"/>
                                         <TextBlock IsTextSelectionEnabled="{x:Bind VMs:ViewModelProvider.PolicyEditorVM.TextsAreSelectableToggleState, Mode=OneWay}" FontFamily="{x:Bind VMs:ViewModelProvider.PolicyEditorVM.AppSettings.ListViewFontFamily, Mode=OneWay}" Text="{x:Bind AppIDs}" Style="{StaticResource ListViewCellTextBlock}" Grid.Column="12"/>
                                         <TextBlock IsTextSelectionEnabled="{x:Bind VMs:ViewModelProvider.PolicyEditorVM.TextsAreSelectableToggleState, Mode=OneWay}" FontFamily="{x:Bind VMs:ViewModelProvider.PolicyEditorVM.AppSettings.ListViewFontFamily, Mode=OneWay}" Text="{x:Bind Type}" Style="{StaticResource ListViewCellTextBlock}" Grid.Column="13"/>
+                                        <TextBlock IsTextSelectionEnabled="{x:Bind VMs:ViewModelProvider.PolicyEditorVM.TextsAreSelectableToggleState, Mode=OneWay}" FontFamily="{x:Bind VMs:ViewModelProvider.PolicyEditorVM.AppSettings.ListViewFontFamily, Mode=OneWay}" Text="{x:Bind RequireHotpatchID}" Style="{StaticResource ListViewCellTextBlock}" Grid.Column="14"/>
+                                        <TextBlock IsTextSelectionEnabled="{x:Bind VMs:ViewModelProvider.PolicyEditorVM.TextsAreSelectableToggleState, Mode=OneWay}" FontFamily="{x:Bind VMs:ViewModelProvider.PolicyEditorVM.AppSettings.ListViewFontFamily, Mode=OneWay}" Text="{x:Bind MinimumHotpatchSequence}" Style="{StaticResource ListViewCellTextBlock}" Grid.Column="15"/>
+                                        <TextBlock IsTextSelectionEnabled="{x:Bind VMs:ViewModelProvider.PolicyEditorVM.TextsAreSelectableToggleState, Mode=OneWay}" FontFamily="{x:Bind VMs:ViewModelProvider.PolicyEditorVM.AppSettings.ListViewFontFamily, Mode=OneWay}" Text="{x:Bind MaximumHotpatchSequence}" Style="{StaticResource ListViewCellTextBlock}" Grid.Column="16"/>
                                     </Grid>
                                 </DataTemplate>
                             </customUI:ListViewV2.ItemTemplate>

--- a/AppControl Manager/PolicyEditor/FileBasedRulesForListView.cs
+++ b/AppControl Manager/PolicyEditor/FileBasedRulesForListView.cs
@@ -36,6 +36,9 @@ namespace AppControlManager.PolicyEditor;
 /// <param name="type"></param>
 /// <param name="sourceType"></param>
 /// <param name="source"></param>
+/// <param name="requireHotpatchID">Only used for <see cref="SiPolicy.Allow"/> type</parm>
+/// <param name="minimumHotpatchSequence">Only used for <see cref="SiPolicy.Allow"/> type</param>
+/// <param name="maximumHotpatchSequence">Only used for <see cref="SiPolicy.Allow"/> type</param>
 internal sealed class FileBasedRulesForListView(
 	string? id,
 	string? friendlyName,
@@ -52,7 +55,10 @@ internal sealed class FileBasedRulesForListView(
 	string? filePath,
 	string? type,
 	FileBasedRuleType sourceType,
-	object source
+	object source,
+	string? requireHotpatchID,
+	uint? minimumHotpatchSequence,
+	uint? maximumHotpatchSequence
 	)
 {
 	internal string? Id => id;
@@ -71,4 +77,7 @@ internal sealed class FileBasedRulesForListView(
 	internal string? Type => type;
 	internal FileBasedRuleType SourceType => sourceType;
 	internal object Source => source;
+	internal string? RequireHotpatchID => requireHotpatchID;
+	internal uint? MinimumHotpatchSequence => minimumHotpatchSequence;
+	internal uint? MaximumHotpatchSequence => maximumHotpatchSequence;
 }

--- a/AppControl Manager/ReleaseNotes.txt
+++ b/AppControl Manager/ReleaseNotes.txt
@@ -7,3 +7,5 @@
 * Updated dependencies to the latest versions.
 
 * Improved overall performance.
+
+* Added support for the new App Control policy version 9. AppControl Manager now displays Hot🔥 Patching data available in the policies which are mainly used by the operating system at the moment.

--- a/AppControl Manager/SiPolicy/BinaryOpsReverse.cs
+++ b/AppControl Manager/SiPolicy/BinaryOpsReverse.cs
@@ -381,6 +381,28 @@ internal static class BinaryOpsReverse
 			policy.AppSettings = ParseAppSettings(reader);
 		}
 
+		if (version >= 9)
+		{
+			uint tag9 = reader.ReadUInt32();
+			if (tag9 != 9) throw new InvalidOperationException(string.Format("Expected V8 block tag '8', got '{0}'", tag9));
+
+			uint hpCount = reader.ReadUInt32();
+			for (uint i = 0; i < hpCount; i++)
+			{
+				uint baseIdx = reader.ReadUInt32();
+				uint targetIdx = reader.ReadUInt32();
+				uint minSeq = reader.ReadUInt32();
+				uint maxSeq = reader.ReadUInt32();
+
+				if (fileRules[baseIdx] is Allow baseRule && fileRules[targetIdx] is Allow targetRule)
+				{
+					baseRule.RequireHotpatchID = targetRule.ID;
+					targetRule.MinimumHotpatchSequence = minSeq;
+					targetRule.MaximumHotpatchSequence = (maxSeq == uint.MaxValue) ? null : maxSeq;
+				}
+			}
+		}
+
 		// Determine if we've encountered a new policy version.
 		// We have to implement the additional parsing logic for it.
 		uint expectedEndTag = version + 1;

--- a/AppControl Manager/SiPolicy/CustomDeserialization.cs
+++ b/AppControl Manager/SiPolicy/CustomDeserialization.cs
@@ -510,6 +510,19 @@ internal static class CustomDeserialization
 		string filePathValue = elem.GetAttribute("FilePath");
 		allow.FilePath = string.IsNullOrWhiteSpace(filePathValue) ? null : filePathValue;
 
+		string requireHotpatchIDValue = elem.GetAttribute("RequireHotpatchID");
+		allow.RequireHotpatchID = string.IsNullOrWhiteSpace(requireHotpatchIDValue) ? null : requireHotpatchIDValue;
+
+		if (elem.HasAttribute("MinimumHotpatchSequence"))
+		{
+			allow.MinimumHotpatchSequence = uint.Parse(elem.GetAttribute("MinimumHotpatchSequence"), CultureInfo.InvariantCulture);
+		}
+
+		if (elem.HasAttribute("MaximumHotpatchSequence"))
+		{
+			allow.MaximumHotpatchSequence = uint.Parse(elem.GetAttribute("MaximumHotpatchSequence"), CultureInfo.InvariantCulture);
+		}
+
 		if (!IDsCollection.Add(allow.ID))
 		{
 			throw new InvalidOperationException($"{GlobalVars.GetStr("AllowRuleDupIDValidationError")}: {allow.ID}");

--- a/AppControl Manager/SiPolicy/CustomSerialization.cs
+++ b/AppControl Manager/SiPolicy/CustomSerialization.cs
@@ -492,6 +492,9 @@ internal static class CustomSerialization
 		if (!allow.Hash.IsEmpty) element.SetAttribute("Hash", ConvertByteArrayToHex(allow.Hash));
 		if (!string.IsNullOrEmpty(allow.AppIDs)) element.SetAttribute("AppIDs", allow.AppIDs);
 		if (!string.IsNullOrEmpty(allow.FilePath)) element.SetAttribute("FilePath", allow.FilePath);
+		if (!string.IsNullOrEmpty(allow.RequireHotpatchID)) element.SetAttribute("RequireHotpatchID", allow.RequireHotpatchID);
+		if (allow.MinimumHotpatchSequence is not null) element.SetAttribute("MinimumHotpatchSequence", allow.MinimumHotpatchSequence.ToString());
+		if (allow.MaximumHotpatchSequence is not null) element.SetAttribute("MaximumHotpatchSequence", allow.MaximumHotpatchSequence.ToString());
 		_ = parent.AppendChild(element);
 	}
 

--- a/AppControl Manager/SiPolicy/SiPolicy.cs
+++ b/AppControl Manager/SiPolicy/SiPolicy.cs
@@ -271,6 +271,12 @@ internal sealed class Allow(string id)
 	internal string? AppIDs { get; set; }
 
 	internal string? FilePath { get; set; }
+
+	internal string? RequireHotpatchID { get; set; }
+
+	internal uint? MinimumHotpatchSequence { get; set; }
+
+	internal uint? MaximumHotpatchSequence { get; set; }
 }
 
 internal sealed class Deny(string id)

--- a/AppControl Manager/Strings/AR/Resources.resw
+++ b/AppControl Manager/Strings/AR/Resources.resw
@@ -6566,4 +6566,13 @@
   <data name="OpenPoliciesLibraryCacheLocationMenuFlyoutSubItem.AutomationProperties.HelpText" xml:space="preserve">
     <value>انتقل إلى الدليل الذي توجد به ذاكرة التخزين المؤقت لمكتبة السياسات. يرجى ملاحظة أنه يتم مسح هذا الموقع عند إلغاء تثبيت التطبيق.</value>
   </data>
+    <data name="RequireHotpatchIDHeader.Text" xml:space="preserve">
+    <value>مطلوب معرف Hotpatch</value>
+  </data>
+    <data name="MinimumHotpatchSequenceHeader.Text" xml:space="preserve">
+    <value>الحد الأدنى لتسلسل Hotpatch</value>
+  </data>
+    <data name="MaximumHotpatchSequenceHeader.Text" xml:space="preserve">
+    <value>الحد الأقصى لتسلسل Hotpatch</value>
+  </data>
 </root>

--- a/AppControl Manager/Strings/ES/Resources.resw
+++ b/AppControl Manager/Strings/ES/Resources.resw
@@ -6566,4 +6566,13 @@ NOTA: Esta opción siempre se aplica si alguna directiva UMCI de App Control la 
   <data name="OpenPoliciesLibraryCacheLocationMenuFlyoutSubItem.AutomationProperties.HelpText" xml:space="preserve">
     <value>Navegue al directorio donde se encuentra la caché de la Biblioteca de directivas. Tenga en cuenta que esta ubicación se elimina al desinstalar la aplicación.</value>
   </data>
+    <data name="RequireHotpatchIDHeader.Text" xml:space="preserve">
+    <value>Requerir identificador de Hotpatch</value>
+  </data>
+    <data name="MinimumHotpatchSequenceHeader.Text" xml:space="preserve">
+    <value>Secuencia mínima de Hotpatch</value>
+  </data>
+    <data name="MaximumHotpatchSequenceHeader.Text" xml:space="preserve">
+    <value>Secuencia máxima de Hotpatch</value>
+  </data>
 </root>

--- a/AppControl Manager/Strings/de-DE/Resources.resw
+++ b/AppControl Manager/Strings/de-DE/Resources.resw
@@ -6566,4 +6566,13 @@ HINWEIS: Diese Option wird immer erzwungen, wenn eine beliebige App Control-UMCI
   <data name="OpenPoliciesLibraryCacheLocationMenuFlyoutSubItem.AutomationProperties.HelpText" xml:space="preserve">
     <value>Navigieren Sie zu dem Verzeichnis, in dem sich der Cache der Richtlinienbibliothek befindet. Bitte beachten Sie, dass dieser Speicherort bei der Deinstallation der App gelöscht wird.</value>
   </data>
+    <data name="RequireHotpatchIDHeader.Text" xml:space="preserve">
+    <value>Hotpatch-ID erforderlich</value>
+  </data>
+    <data name="MinimumHotpatchSequenceHeader.Text" xml:space="preserve">
+    <value>Minimale Hotpatch-Sequenz</value>
+  </data>
+    <data name="MaximumHotpatchSequenceHeader.Text" xml:space="preserve">
+    <value>Maximale Hotpatch-Sequenz</value>
+  </data>
 </root>

--- a/AppControl Manager/Strings/el-GR/Resources.resw
+++ b/AppControl Manager/Strings/el-GR/Resources.resw
@@ -6566,4 +6566,13 @@
   <data name="OpenPoliciesLibraryCacheLocationMenuFlyoutSubItem.AutomationProperties.HelpText" xml:space="preserve">
     <value>Μεταβείτε στον κατάλογο όπου βρίσκεται η κρυφή μνήμη της Βιβλιοθήκης Πολιτικών. Λάβετε υπόψη ότι αυτή η τοποθεσία διαγράφεται κατά την απεγκατάσταση της εφαρμογής.</value>
   </data>
+    <data name="RequireHotpatchIDHeader.Text" xml:space="preserve">
+    <value>Απαιτείται αναγνωριστικό Hotpatch</value>
+  </data>
+    <data name="MinimumHotpatchSequenceHeader.Text" xml:space="preserve">
+    <value>Ελάχιστη ακολουθία Hotpatch</value>
+  </data>
+    <data name="MaximumHotpatchSequenceHeader.Text" xml:space="preserve">
+    <value>Μέγιστη ακολουθία Hotpatch</value>
+  </data>
 </root>

--- a/AppControl Manager/Strings/en-US/Resources.resw
+++ b/AppControl Manager/Strings/en-US/Resources.resw
@@ -6566,4 +6566,13 @@ NOTE: This option is always enforced if any App Control UMCI policy enables it. 
   <data name="OpenPoliciesLibraryCacheLocationMenuFlyoutSubItem.AutomationProperties.HelpText" xml:space="preserve">
     <value>Navigate to the directory where the Policies Library cache is located. Please keep in mind that this location is cleared when the app is uninstalled.</value>
   </data>
+  <data name="RequireHotpatchIDHeader.Text" xml:space="preserve">
+    <value>Require Hotpatch ID</value>
+  </data>
+    <data name="MinimumHotpatchSequenceHeader.Text" xml:space="preserve">
+    <value>Minimum Hotpatch Sequence</value>
+  </data>
+    <data name="MaximumHotpatchSequenceHeader.Text" xml:space="preserve">
+    <value>Maximum Hotpatch Sequence</value>
+  </data>
 </root>

--- a/AppControl Manager/Strings/fr-FR/Resources.resw
+++ b/AppControl Manager/Strings/fr-FR/Resources.resw
@@ -6566,4 +6566,13 @@
   <data name="OpenPoliciesLibraryCacheLocationMenuFlyoutSubItem.AutomationProperties.HelpText" xml:space="preserve">
     <value>Accédez au répertoire où se trouve le cache de la Bibliothèque de stratégies. Veuillez noter que cet emplacement est effacé lors de la désinstallation de l'application.</value>
   </data>
+    <data name="RequireHotpatchIDHeader.Text" xml:space="preserve">
+    <value>Exiger un ID de Hotpatch</value>
+  </data>
+    <data name="MinimumHotpatchSequenceHeader.Text" xml:space="preserve">
+    <value>Séquence Hotpatch minimale</value>
+  </data>
+    <data name="MaximumHotpatchSequenceHeader.Text" xml:space="preserve">
+    <value>Séquence Hotpatch maximale</value>
+  </data>
 </root>

--- a/AppControl Manager/Strings/he-IL/Resources.resw
+++ b/AppControl Manager/Strings/he-IL/Resources.resw
@@ -6566,4 +6566,13 @@
   <data name="OpenPoliciesLibraryCacheLocationMenuFlyoutSubItem.AutomationProperties.HelpText" xml:space="preserve">
     <value>נווט לתיקייה שבה נמצא המטמון של ספריית המדיניות. שים לב שמיקום זה נמחק בעת הסרת התקנת האפליקציה.</value>
   </data>
+    <data name="RequireHotpatchIDHeader.Text" xml:space="preserve">
+    <value>דרוש מזהה Hotpatch</value>
+  </data>
+    <data name="MinimumHotpatchSequenceHeader.Text" xml:space="preserve">
+    <value>רצף Hotpatch מינימלי</value>
+  </data>
+    <data name="MaximumHotpatchSequenceHeader.Text" xml:space="preserve">
+    <value>רצף Hotpatch מקסימלי</value>
+  </data>
 </root>

--- a/AppControl Manager/Strings/hi-IN/Resources.resw
+++ b/AppControl Manager/Strings/hi-IN/Resources.resw
@@ -6566,4 +6566,13 @@ NOTE: यदि कोई भी App Control UMCI नीति इसे सक�
   <data name="OpenPoliciesLibraryCacheLocationMenuFlyoutSubItem.AutomationProperties.HelpText" xml:space="preserve">
     <value>उस निर्देशिका पर जाएं जहां नीतियां लाइब्रेरी कैश स्थित है। कृपया ध्यान रखें कि ऐप अनइंस्टॉल होने पर यह स्थान साफ़ कर दिया जाता है।</value>
   </data>
+    <data name="RequireHotpatchIDHeader.Text" xml:space="preserve">
+    <value>Hotpatch ID आवश्यक</value>
+  </data>
+    <data name="MinimumHotpatchSequenceHeader.Text" xml:space="preserve">
+    <value>न्यूनतम Hotpatch अनुक्रम</value>
+  </data>
+    <data name="MaximumHotpatchSequenceHeader.Text" xml:space="preserve">
+    <value>अधिकतम Hotpatch अनुक्रम</value>
+  </data>
 </root>

--- a/AppControl Manager/Strings/ml-IN/Resources.resw
+++ b/AppControl Manager/Strings/ml-IN/Resources.resw
@@ -6566,4 +6566,13 @@
   <data name="OpenPoliciesLibraryCacheLocationMenuFlyoutSubItem.AutomationProperties.HelpText" xml:space="preserve">
     <value>പോളിസി ലൈബ്രറി കാഷെ സ്ഥിതിചെയ്യുന്ന ഡയറക്ടറിയിലേക്ക് പോകുക. ആപ്പ് അൺഇൻസ്റ്റാൾ ചെയ്യുമ്പോൾ ഈ ലൊക്കേഷൻ മായ്ച്ചുകളയുമെന്ന് ദയവായി ഓർക്കുക.</value>
   </data>
+    <data name="RequireHotpatchIDHeader.Text" xml:space="preserve">
+    <value>Hotpatch ID ആവശ്യമാണ്</value>
+  </data>
+    <data name="MinimumHotpatchSequenceHeader.Text" xml:space="preserve">
+    <value>കുറഞ്ഞ Hotpatch സീക്വൻസ്</value>
+  </data>
+    <data name="MaximumHotpatchSequenceHeader.Text" xml:space="preserve">
+    <value>കൂടിയ Hotpatch സീക്വൻസ്</value>
+  </data>
 </root>

--- a/AppControl Manager/Strings/pl-PL/Resources.resw
+++ b/AppControl Manager/Strings/pl-PL/Resources.resw
@@ -6566,4 +6566,13 @@ UWAGA: Ta opcja jest zawsze wymuszana, jeśli jakakolwiek zasada UMCI Kontroli A
   <data name="OpenPoliciesLibraryCacheLocationMenuFlyoutSubItem.AutomationProperties.HelpText" xml:space="preserve">
     <value>Przejdź do katalogu, w którym znajduje się pamięć podręczna Biblioteki Zasad. Pamiętaj, że ta lokalizacja jest czyszczona po odinstalowaniu aplikacji.</value>
   </data>
+    <data name="RequireHotpatchIDHeader.Text" xml:space="preserve">
+    <value>Wymagaj identyfikatora Hotpatch</value>
+  </data>
+    <data name="MinimumHotpatchSequenceHeader.Text" xml:space="preserve">
+    <value>Minimalna sekwencja Hotpatch</value>
+  </data>
+    <data name="MaximumHotpatchSequenceHeader.Text" xml:space="preserve">
+    <value>Maksymalna sekwencja Hotpatch</value>
+  </data>
 </root>

--- a/AppControl Manager/ViewModels/PolicyEditorVM.cs
+++ b/AppControl Manager/ViewModels/PolicyEditorVM.cs
@@ -54,6 +54,9 @@ internal sealed partial class PolicyEditorVM : ViewModelBase
 	internal GridLength FileBasedColumnWidth12 { get; set => SP(ref field, value); }
 	internal GridLength FileBasedColumnWidth13 { get; set => SP(ref field, value); }
 	internal GridLength FileBasedColumnWidth14 { get; set => SP(ref field, value); }
+	internal GridLength FileBasedColumnWidth15 { get; set => SP(ref field, value); }
+	internal GridLength FileBasedColumnWidth16 { get; set => SP(ref field, value); }
+	internal GridLength FileBasedColumnWidth17 { get; set => SP(ref field, value); }
 
 	// ------------ Signature Based ------------
 
@@ -293,6 +296,9 @@ internal sealed partial class PolicyEditorVM : ViewModelBase
 		double maxWidth12 = ListViewHelper.MeasureText(GlobalVars.GetStr("PackageVersionHeader/Text"));
 		double maxWidth13 = ListViewHelper.MeasureText("App IDs");
 		double maxWidth14 = ListViewHelper.MeasureText("Type");
+		double maxWidth15 = ListViewHelper.MeasureText(GlobalVars.GetStr("RequireHotpatchIDHeader/Text"));
+		double maxWidth16 = ListViewHelper.MeasureText(GlobalVars.GetStr("MinimumHotpatchSequenceHeader/Text"));
+		double maxWidth17 = ListViewHelper.MeasureText(GlobalVars.GetStr("MaximumHotpatchSequenceHeader/Text"));
 
 		// Iterate over all items to determine the widest string for each column.
 		foreach (PolicyEditor.FileBasedRulesForListView item in FileRulesCollection)
@@ -311,6 +317,9 @@ internal sealed partial class PolicyEditorVM : ViewModelBase
 			maxWidth12 = ListViewHelper.MeasureText(item.PackageVersion, maxWidth12);
 			maxWidth13 = ListViewHelper.MeasureText(item.AppIDs, maxWidth13);
 			maxWidth14 = ListViewHelper.MeasureText(item.Type, maxWidth14);
+			maxWidth15 = ListViewHelper.MeasureText(item.RequireHotpatchID, maxWidth15);
+			maxWidth16 = ListViewHelper.MeasureText(item.MinimumHotpatchSequence.ToString(), maxWidth16);
+			maxWidth17 = ListViewHelper.MeasureText(item.MaximumHotpatchSequence.ToString(), maxWidth17);
 		}
 
 		// Set the column width properties.
@@ -328,6 +337,9 @@ internal sealed partial class PolicyEditorVM : ViewModelBase
 		FileBasedColumnWidth12 = new(maxWidth12);
 		FileBasedColumnWidth13 = new(maxWidth13);
 		FileBasedColumnWidth14 = new(maxWidth14);
+		FileBasedColumnWidth15 = new(maxWidth15);
+		FileBasedColumnWidth16 = new(maxWidth16);
+		FileBasedColumnWidth17 = new(maxWidth17);
 	}
 
 	/// <summary>
@@ -516,7 +528,10 @@ internal sealed partial class PolicyEditorVM : ViewModelBase
 						filePath: allowRule.AllowElement.FilePath,
 						type: null,
 						sourceType: PolicyEditor.FileBasedRuleType.Allow,
-						source: allowRule
+						source: allowRule,
+						requireHotpatchID: allowRule.AllowElement.RequireHotpatchID,
+						minimumHotpatchSequence: allowRule.AllowElement.MinimumHotpatchSequence,
+						maximumHotpatchSequence: allowRule.AllowElement.MaximumHotpatchSequence
 					);
 
 					FileRulesCollection.Add(temp1);
@@ -547,7 +562,10 @@ internal sealed partial class PolicyEditorVM : ViewModelBase
 						filePath: denyRule.DenyElement.FilePath,
 						type: null,
 						sourceType: PolicyEditor.FileBasedRuleType.Deny,
-						source: denyRule
+						source: denyRule,
+						requireHotpatchID: null,
+						minimumHotpatchSequence: null,
+						maximumHotpatchSequence: null
 					);
 
 					FileRulesCollection.Add(temp2);
@@ -578,7 +596,10 @@ internal sealed partial class PolicyEditorVM : ViewModelBase
 						filePath: fileRule.FileRuleElement.FilePath,
 						type: fileRule.FileRuleElement.Type.ToString(),
 						sourceType: PolicyEditor.FileBasedRuleType.FileRule,
-						source: fileRule
+						source: fileRule,
+						requireHotpatchID: null,
+						minimumHotpatchSequence: null,
+						maximumHotpatchSequence: null
 					);
 
 					FileRulesCollection.Add(temp3);
@@ -614,7 +635,10 @@ internal sealed partial class PolicyEditorVM : ViewModelBase
 						filePath: item.FilePath,
 						type: null,
 						sourceType: PolicyEditor.FileBasedRuleType.CompoundPublisher,
-						source: item
+						source: item,
+						requireHotpatchID: null,
+						minimumHotpatchSequence: null,
+						maximumHotpatchSequence: null
 					);
 
 					FileRulesCollection.Add(temp4);


### PR DESCRIPTION
Added support for new App Control policy version. AppControl Manager now displays Hot🔥 Patching data available in the policies which are mainly used by the operating system at the moment.

Completes the following feature requests:

* https://github.com/HotCakeX/Harden-Windows-Security/issues/790
* https://github.com/HotCakeX/Harden-Windows-Security/discussions/1023
